### PR TITLE
feat(backup): scaffold Hosted Backup auth client + version check

### DIFF
--- a/docs/contracts/cli-json-contract.md
+++ b/docs/contracts/cli-json-contract.md
@@ -96,6 +96,21 @@ When `success` is `false`, the `error` field contains:
 | `INTERNAL_ERROR` | Unexpected internal error |
 | `SCHEMA_INCOMPATIBLE` | Schema version mismatch |
 
+#### Hosted Backup error codes
+
+These codes are produced exclusively by `endstate backup *` and `endstate account *` commands. Their precise HTTP-status mapping is locked in `hosted-backup-contract.md` §7, §11.
+
+| Code | Description |
+|------|-------------|
+| `AUTH_REQUIRED` | The hosted-backup session is missing or expired. Run `endstate backup login`. |
+| `SUBSCRIPTION_REQUIRED` | An active Endstate subscription is required for backup writes. Read paths remain available during `grace` and `cancelled` states. |
+| `NOT_FOUND` | The requested backup or version does not exist (or is owned by a different user — server returns 404, not 403, to avoid existence leaks). |
+| `RATE_LIMITED` | Backend rate limit hit. Honour the `Retry-After` hint where present. |
+| `BACKEND_ERROR` | Backend returned 5xx after the engine's bounded retries; transient infrastructure issue on Endstate's side. |
+| `BACKEND_UNREACHABLE` | Engine could not reach the configured `ENDSTATE_OIDC_ISSUER_URL` (DNS / TCP / TLS / timeout). |
+| `BACKEND_INCOMPATIBLE` | The configured backend does not advertise the required `endstate_extensions` discovery block (or advertises KDF parameters below the v1 floor). |
+| `STORAGE_QUOTA_EXCEEDED` | The user's hosted-backup storage quota would be exceeded by the operation. |
+
 ---
 
 ## Command: `capabilities`

--- a/docs/contracts/hosted-backup-contract.md
+++ b/docs/contracts/hosted-backup-contract.md
@@ -95,6 +95,8 @@ Each encrypted backup version is structured as a manifest plus chunks. Chunks ar
 
 The manifest itself is encrypted with the DEK before upload, using the same AES-256-GCM scheme as chunks. The server stores the encrypted manifest blob; chunk metadata (index, encryptedSize, sha256) is also tracked in the database for integrity checks but the manifest is the source of truth.
 
+The manifest's AAD when encrypted is the 4-byte big-endian unsigned value `0xFFFFFFFF` — a sentinel chosen because no real chunk index will ever take this value. This binds the encrypted manifest to the "manifest" role and prevents it being decrypted as if it were chunk index 0.
+
 ### Chunk format (AES-256-GCM, RFC 5116)
 
 | Field | Size | Contents |
@@ -303,6 +305,15 @@ All endpoints rate-limited at the substrate edge. Rate limits documented per-end
 ### Blob storage endpoints
 
 - `POST /api/backups/:backupId/versions/:versionId/download-urls` → request presigned download URLs for a set of chunk indices: `{ chunkIndices: [int] }` → `{ urls: [{ chunkIndex, presignedUrl, expiresAt }] }`
+
+### Manifest URL convention (transport flag)
+
+In the `uploadUrls` array returned by `POST /api/backups/:backupId/versions` and the `urls` array returned by `POST /api/backups/:backupId/versions/:versionId/download-urls`, the manifest blob is addressed by the sentinel `chunkIndex` value `-1`.
+
+- Servers minting upload URLs always include the manifest URL with `chunkIndex: -1` as the first entry. Clients must PUT the encrypted manifest to that URL.
+- Clients requesting download URLs MUST include `-1` in `chunkIndices` if they need the manifest. Servers return the manifest URL as `chunkIndex: -1` in the response.
+
+This `-1` is a transport-layer flag for "this URL targets the manifest." It is unrelated to the AAD sentinel `0xFFFFFFFF` used during manifest encryption (Section 3): one is a wire-protocol convention in API responses, the other is cryptographic binding inside the encrypted blob. Implementations must treat them as independent.
 
 ### OIDC discovery
 
@@ -574,3 +585,9 @@ A schema bump triggers the breaking-change protocol from Section 11.
 - **Bitwarden** — closest at-scale reference for split-output Argon2 auth
 - **Filen.io** — closest architectural reference (Windows-first hosted backup with self-host option)
 - **Standard Notes** — chunked envelope format reference
+
+---
+
+## Changelog
+
+- **2026-05-02** — Initial locked release. Addendum: Section 7 documents the manifest URL convention (`chunkIndex = -1` as transport flag); Section 3 clarifies the AAD sentinel `0xFFFFFFFF` for manifest encryption is independent of the transport flag.

--- a/go-engine/cmd/endstate/main.go
+++ b/go-engine/cmd/endstate/main.go
@@ -36,6 +36,8 @@ Commands:
   report          Retrieve run history
   doctor          Run diagnostics
   bootstrap       Bootstrap Endstate installation
+  backup          Hosted Backup commands (login, logout, status, ...)
+  account         Hosted account management (delete)
 
 Global flags:
   --json               Output result as a single-line JSON envelope to stdout
@@ -67,6 +69,10 @@ Subcommands:
   profile list         List discovered profiles
   profile path <name>  Resolve profile path
   profile validate <p> Validate a profile manifest
+  backup login         Sign in to Hosted Backup (passphrase via stdin)
+  backup logout        Clear cached Hosted Backup session
+  backup status        Report Hosted Backup session state
+  account delete       Delete the Hosted Backup account (requires --confirm)
 
 Run 'endstate <command> --help' for command-specific help.
 `
@@ -102,7 +108,14 @@ type parsedArgs struct {
 	last   int
 	runID  string
 
-	// Positional args after command (used by profile subcommands)
+	// Backup / account flags
+	email     string
+	backupID  string
+	versionID string
+	to        string
+	confirm   bool
+
+	// Positional args after command (used by profile / backup / account subcommands)
 	positionalArgs []string
 }
 
@@ -148,6 +161,8 @@ func parseArgs(args []string) parsedArgs {
 			p.minimize = true
 		case "--latest":
 			p.latest = true
+		case "--confirm":
+			p.confirm = true
 		case "--WithConfig":
 			// GUI sends --WithConfig for capture; the Go engine includes
 			// config modules by default, so this is a no-op. Accept it
@@ -198,6 +213,26 @@ func parseArgs(args []string) parsedArgs {
 		case "--restore-filter":
 			if i+1 < len(args) {
 				p.restoreFilter = args[i+1]
+				i++
+			}
+		case "--email":
+			if i+1 < len(args) {
+				p.email = args[i+1]
+				i++
+			}
+		case "--backup-id":
+			if i+1 < len(args) {
+				p.backupID = args[i+1]
+				i++
+			}
+		case "--version-id":
+			if i+1 < len(args) {
+				p.versionID = args[i+1]
+				i++
+			}
+		case "--to":
+			if i+1 < len(args) {
+				p.to = args[i+1]
 				i++
 			}
 		default:
@@ -251,6 +286,10 @@ func commandUsage(cmd string) string {
 		return "Usage: endstate doctor [--json]\n\nRun system diagnostics.\n"
 	case "profile":
 		return "Usage: endstate profile <subcommand> [args] [--json]\n\nSubcommands:\n  list              List discovered profiles\n  path <name>       Resolve profile path from name\n  validate <path>   Validate a profile manifest\n"
+	case "backup":
+		return "Usage: endstate backup <subcommand> [flags] [--json] [--events jsonl]\n\nSubcommands:\n  login --email <addr>     Sign in (passphrase via stdin)\n  logout                   Clear local session\n  status                   Report current session state\n\nEnv vars:\n  ENDSTATE_OIDC_ISSUER_URL  Backend issuer URL (default: https://substratesystems.io)\n  ENDSTATE_OIDC_AUDIENCE    JWT audience (default: endstate-backup)\n"
+	case "account":
+		return "Usage: endstate account <subcommand> [flags] [--json]\n\nSubcommands:\n  delete --confirm  Delete the Hosted Backup account permanently\n"
 	case "bootstrap":
 		return "Usage: endstate bootstrap\n\nBootstrap Endstate installation.\n"
 	default:
@@ -429,6 +468,40 @@ func dispatch(p parsedArgs) (interface{}, *envelope.Error) {
 	case "bootstrap":
 		return commands.RunBootstrap(commands.BootstrapFlags{
 			Events: p.events,
+		})
+
+	case "backup":
+		subcommand := ""
+		var subArgs []string
+		if len(p.positionalArgs) > 0 {
+			subcommand = p.positionalArgs[0]
+			subArgs = p.positionalArgs[1:]
+		}
+		return commands.RunBackup(commands.BackupFlags{
+			Subcommand: subcommand,
+			Args:       subArgs,
+			Email:      p.email,
+			BackupID:   p.backupID,
+			VersionID:  p.versionID,
+			Profile:    p.profile,
+			Name:       p.name,
+			To:         p.to,
+			Confirm:    p.confirm,
+			Events:     p.events,
+		})
+
+	case "account":
+		subcommand := ""
+		var subArgs []string
+		if len(p.positionalArgs) > 0 {
+			subcommand = p.positionalArgs[0]
+			subArgs = p.positionalArgs[1:]
+		}
+		return commands.RunAccount(commands.AccountFlags{
+			Subcommand: subcommand,
+			Args:       subArgs,
+			Confirm:    p.confirm,
+			Events:     p.events,
 		})
 
 	default:

--- a/go-engine/go.mod
+++ b/go-engine/go.mod
@@ -3,3 +3,8 @@ module github.com/Artexis10/endstate/go-engine
 go 1.22
 
 require golang.org/x/sys v0.28.0
+
+require (
+	github.com/danieljoos/wincred v1.2.3 // indirect
+	github.com/golang-jwt/jwt/v5 v5.3.1 // indirect
+)

--- a/go-engine/go.sum
+++ b/go-engine/go.sum
@@ -1,2 +1,6 @@
+github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMFLdQ=
+github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
+github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
+github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 golang.org/x/sys v0.28.0 h1:Fksou7UEQUWlKvIdsqzJmUmCX3cZuD2+P3XyyzwMhlA=
 golang.org/x/sys v0.28.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/go-engine/internal/backup/auth/authenticator.go
+++ b/go-engine/internal/backup/auth/authenticator.go
@@ -1,0 +1,255 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"context"
+	stdBase64Pkg "encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/Artexis10/endstate/go-engine/internal/backup/client"
+	"github.com/Artexis10/endstate/go-engine/internal/backup/crypto"
+	"github.com/Artexis10/endstate/go-engine/internal/backup/oidc"
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+var stdBase64 = stdBase64Pkg.StdEncoding
+
+// Authenticator owns the substrate auth API surface (contract §5–§6) for
+// one issuer + audience pair. It coordinates between the OIDC discovery
+// client (for endpoint URLs and JWKS), the HTTP client (for transport),
+// the SessionStore (for in-memory + keychain persistence), and the
+// crypto package (for KDF / DEK wrap, currently STUBS).
+type Authenticator struct {
+	issuer  Issuer
+	oidc    *oidc.Client
+	httpc   *client.Client
+	session *SessionStore
+}
+
+// NewAuthenticator constructs an Authenticator. The supplied client.Client
+// MUST be configured with a TokenProvider that defers to session — see
+// auth.MakeTokenProvider helper.
+func NewAuthenticator(issuer Issuer, o *oidc.Client, c *client.Client, s *SessionStore) *Authenticator {
+	a := &Authenticator{issuer: issuer, oidc: o, httpc: c, session: s}
+	// Wire the refresh callback so the HTTP client's 401-refresh hook
+	// reaches into our /api/auth/refresh handler instead of looping.
+	s.WithRefreshFn(a.refreshAccessToken)
+	return a
+}
+
+// Issuer returns the configured issuer.
+func (a *Authenticator) Issuer() Issuer { return a.issuer }
+
+// Session returns the underlying SessionStore.
+func (a *Authenticator) Session() *SessionStore { return a.session }
+
+// MakeTokenProvider returns a client.TokenProvider that draws access and
+// refresh from the supplied SessionStore. Provided here so the wiring in
+// command handlers reads in one place.
+func MakeTokenProvider(s *SessionStore) client.TokenProvider { return s }
+
+// preHandshakeRequest matches the contract §5 step-1 body shape.
+type preHandshakeRequest struct {
+	Email string `json:"email"`
+}
+
+// preHandshakeResponse matches the contract §5 step-1 response shape.
+type preHandshakeResponse struct {
+	Salt      string          `json:"salt"`
+	KDFParams crypto.KDFParams `json:"kdfParams"`
+}
+
+// PreHandshake performs login step 1: fetches the user salt + kdfParams
+// so the client can derive the same serverPassword and masterKey that
+// were derived at signup.
+//
+// Errors map to envelope codes the command handler can return verbatim:
+//   - 404 → ErrNotFound (no such user)
+//   - other → BACKEND_* / SCHEMA_INCOMPATIBLE etc.
+func (a *Authenticator) PreHandshake(ctx context.Context, email string) (*preHandshakeResponse, *envelope.Error) {
+	doc, err := a.oidc.Discovery(ctx)
+	if err != nil {
+		return nil, mapDiscoveryError(err)
+	}
+	var resp preHandshakeResponse
+	if cerr := a.httpc.Do(ctx, client.Request{
+		Method:   "POST",
+		URL:      doc.EndstateExtensions.AuthLoginEndpoint,
+		Body:     preHandshakeRequest{Email: strings.ToLower(email)},
+		ReadOnly: false,
+	}, &resp); cerr != nil {
+		return nil, cerr
+	}
+	if !resp.KDFParams.MeetsFloor() {
+		return nil, envelope.NewError(envelope.ErrBackendIncompatible,
+			fmt.Sprintf("Server-advertised KDF parameters are below the v1 floor (memory=%d iterations=%d parallelism=%d).",
+				resp.KDFParams.Memory, resp.KDFParams.Iterations, resp.KDFParams.Parallelism)).
+			WithRemediation("This account was created with parameters this engine refuses on principle. Update the engine or contact support.")
+	}
+	return &resp, nil
+}
+
+// completeLoginRequest matches the contract §5 step-2 body shape.
+type completeLoginRequest struct {
+	Email          string `json:"email"`
+	ServerPassword string `json:"serverPassword"`
+}
+
+// CompleteLoginResponse matches the contract §5 step-2 response shape.
+type CompleteLoginResponse struct {
+	UserID             string `json:"userId"`
+	AccessToken        string `json:"accessToken"`
+	RefreshToken       string `json:"refreshToken"`
+	WrappedDEK         string `json:"wrappedDEK"`
+	SubscriptionStatus string `json:"subscriptionStatus,omitempty"`
+}
+
+// CompleteLogin performs login step 2: authenticates with the
+// pre-derived serverPassword and stores the resulting tokens.
+//
+// On success the session is updated and the refresh token is persisted
+// to the keychain. The caller is responsible for unwrapping the DEK with
+// the masterKey it derived in step 1.
+func (a *Authenticator) CompleteLogin(ctx context.Context, email string, serverPassword []byte) (*CompleteLoginResponse, *envelope.Error) {
+	doc, err := a.oidc.Discovery(ctx)
+	if err != nil {
+		return nil, mapDiscoveryError(err)
+	}
+	var resp CompleteLoginResponse
+	if cerr := a.httpc.Do(ctx, client.Request{
+		Method:   "POST",
+		URL:      doc.EndstateExtensions.AuthLoginEndpoint,
+		Body:     completeLoginRequest{Email: strings.ToLower(email), ServerPassword: base64Encode(serverPassword)},
+		ReadOnly: false,
+	}, &resp); cerr != nil {
+		return nil, cerr
+	}
+	a.session.SetTokens(resp.UserID, strings.ToLower(email), resp.AccessToken, resp.RefreshToken, resp.SubscriptionStatus, time.Time{})
+	if perr := a.session.Persist(); perr != nil {
+		// Persisting to the keychain failed — the session is still good
+		// in-process but won't survive a restart. Surface as INTERNAL_ERROR
+		// because we shouldn't pretend everything is fine.
+		return &resp, envelope.NewError(envelope.ErrInternalError,
+			"login succeeded but refresh token could not be saved to the OS keychain: "+perr.Error()).
+			WithRemediation("Re-run `endstate backup login` after addressing the keychain access issue.")
+	}
+	return &resp, nil
+}
+
+// refreshAccessToken implements the client.TokenProvider refresh hook.
+// Returns the new access token on success.
+func (a *Authenticator) refreshAccessToken(ctx context.Context) (string, error) {
+	doc, err := a.oidc.Discovery(ctx)
+	if err != nil {
+		return "", err
+	}
+	snap := a.session.Snapshot()
+	if snap.RefreshToken == "" {
+		return "", errors.New("auth: no refresh token in session")
+	}
+	type refreshReq struct {
+		RefreshToken string `json:"refreshToken"`
+	}
+	type refreshResp struct {
+		AccessToken  string `json:"accessToken"`
+		RefreshToken string `json:"refreshToken"`
+	}
+	var resp refreshResp
+	if cerr := a.httpc.Do(ctx, client.Request{
+		Method:          "POST",
+		URL:             doc.EndstateExtensions.AuthRefreshEndpoint,
+		Body:            refreshReq{RefreshToken: snap.RefreshToken},
+		ReadOnly:        false,
+		SkipAuthRefresh: true, // never let a 401 here recurse into a fresh refresh attempt
+	}, &resp); cerr != nil {
+		return "", fmt.Errorf("auth: refresh: %s: %s", cerr.Code, cerr.Message)
+	}
+	a.session.SetTokens(snap.UserID, snap.Email, resp.AccessToken, resp.RefreshToken, snap.SubscriptionStatus, time.Time{})
+	if perr := a.session.Persist(); perr != nil {
+		return "", fmt.Errorf("auth: refresh: persist refresh token: %w", perr)
+	}
+	return resp.AccessToken, nil
+}
+
+// Logout invalidates the refresh token server-side (best-effort) and
+// clears all local state.
+func (a *Authenticator) Logout(ctx context.Context) *envelope.Error {
+	snap := a.session.Snapshot()
+	if snap.RefreshToken != "" {
+		doc, err := a.oidc.Discovery(ctx)
+		if err == nil {
+			type logoutReq struct {
+				RefreshToken string `json:"refreshToken"`
+			}
+			// Best-effort: ignore errors. The local state is what matters.
+			_ = a.httpc.Do(ctx, client.Request{
+				Method: "POST",
+				URL:    doc.EndstateExtensions.AuthLogoutEndpoint,
+				Body:   logoutReq{RefreshToken: snap.RefreshToken},
+			}, nil)
+		}
+	}
+	if err := a.session.Forget(); err != nil {
+		return envelope.NewError(envelope.ErrInternalError,
+			"logout: clear local session: "+err.Error())
+	}
+	return nil
+}
+
+// MeResponse matches the GET /api/account/me payload (contract §7).
+type MeResponse struct {
+	UserID             string `json:"userId"`
+	Email              string `json:"email"`
+	SubscriptionStatus string `json:"subscriptionStatus"`
+	CreatedAt          string `json:"createdAt"`
+}
+
+// Me fetches the current user's profile from the backend. Used by the
+// `backup status` command to report subscription state.
+func (a *Authenticator) Me(ctx context.Context) (*MeResponse, *envelope.Error) {
+	doc, err := a.oidc.Discovery(ctx)
+	if err != nil {
+		return nil, mapDiscoveryError(err)
+	}
+	// /api/account/me lives off the same base as auth endpoints; substrate
+	// places it at <issuer>/api/account/me. We compute the URL from the
+	// issuer rather than the backup_api_base so a self-hoster can place
+	// account endpoints anywhere they like via the discovery document.
+	url := strings.TrimRight(a.issuer.URL, "/") + "/api/account/me"
+	var resp MeResponse
+	if cerr := a.httpc.Do(ctx, client.Request{
+		Method:   "GET",
+		URL:      url,
+		ReadOnly: true,
+	}, &resp); cerr != nil {
+		return nil, cerr
+	}
+	// Update the cached subscription hint.
+	snap := a.session.Snapshot()
+	a.session.SetTokens(snap.UserID, resp.Email, snap.AccessToken, snap.RefreshToken, resp.SubscriptionStatus, snap.AccessExpiry)
+	_ = doc // referenced for symmetry with future endpoints; retained to keep callers in lockstep with Discovery.
+	return &resp, nil
+}
+
+// mapDiscoveryError converts an oidc package error to the envelope code
+// the command handler should return.
+func mapDiscoveryError(err error) *envelope.Error {
+	if errors.Is(err, oidc.ErrIncompatibleIssuer) {
+		return envelope.NewError(envelope.ErrBackendIncompatible,
+			"The configured backend does not advertise the required `endstate_extensions` block.").
+			WithRemediation("Verify ENDSTATE_OIDC_ISSUER_URL points at a substrate-compatible backend.")
+	}
+	return envelope.NewError(envelope.ErrBackendUnreachable,
+		"Could not fetch OIDC discovery: "+err.Error()).
+		WithRemediation("Check your network connection or override ENDSTATE_OIDC_ISSUER_URL.")
+}
+
+// base64Encode is a tiny helper that keeps the call sites readable.
+func base64Encode(b []byte) string {
+	return stdBase64.EncodeToString(b)
+}

--- a/go-engine/internal/backup/auth/authenticator_test.go
+++ b/go-engine/internal/backup/auth/authenticator_test.go
@@ -1,0 +1,279 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package auth_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Artexis10/endstate/go-engine/internal/backup/auth"
+	"github.com/Artexis10/endstate/go-engine/internal/backup/client"
+	"github.com/Artexis10/endstate/go-engine/internal/backup/keychain"
+	"github.com/Artexis10/endstate/go-engine/internal/backup/oidc"
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// fakeBackend serves discovery + auth + account endpoints for the
+// Authenticator integration tests. Each handler can be overridden per
+// test.
+type fakeBackend struct {
+	srv               *httptest.Server
+	loginPreFn        http.HandlerFunc
+	loginCompleteFn   http.HandlerFunc
+	refreshFn         http.HandlerFunc
+	logoutFn          http.HandlerFunc
+	meFn              http.HandlerFunc
+	loginPreHits      int32
+	loginCompleteHits int32
+	refreshHits       int32
+	logoutHits        int32
+	meHits            int32
+}
+
+func newFakeBackend(t *testing.T) *fakeBackend {
+	t.Helper()
+	fb := &fakeBackend{}
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	fb.srv = srv
+	t.Cleanup(srv.Close)
+
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(oidc.Document{
+			Issuer:                            srv.URL,
+			JWKSURI:                           srv.URL + "/api/.well-known/jwks.json",
+			IDTokenSigningAlgValuesSupported:  []string{"EdDSA"},
+			EndstateExtensions: oidc.EndstateExtensions{
+				AuthSignupEndpoint:        srv.URL + "/api/auth/signup",
+				AuthLoginEndpoint:         srv.URL + "/api/auth/login",
+				AuthRefreshEndpoint:       srv.URL + "/api/auth/refresh",
+				AuthLogoutEndpoint:        srv.URL + "/api/auth/logout",
+				AuthRecoverEndpoint:       srv.URL + "/api/auth/recover",
+				BackupAPIBase:             srv.URL + "/api/backups",
+				SupportedKDFAlgorithms:    []string{"argon2id"},
+				SupportedEnvelopeVersions: []int{1},
+				MinKDFParams:              oidc.MinKDFParams{Memory: 65536, Iterations: 3, Parallelism: 4},
+			},
+		})
+	})
+	mux.HandleFunc("/api/.well-known/jwks.json", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(oidc.JWKS{Keys: []oidc.JWK{}})
+	})
+	mux.HandleFunc("/api/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "1.0")
+		// Substrate distinguishes pre-handshake from complete via body shape.
+		var raw map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&raw)
+		if _, hasPwd := raw["serverPassword"]; hasPwd {
+			atomic.AddInt32(&fb.loginCompleteHits, 1)
+			if fb.loginCompleteFn != nil {
+				fb.loginCompleteFn(w, r)
+				return
+			}
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"userId":             "user-1",
+				"accessToken":        "access-1",
+				"refreshToken":       "refresh-1",
+				"wrappedDEK":         "AAAA",
+				"subscriptionStatus": "active",
+			})
+			return
+		}
+		atomic.AddInt32(&fb.loginPreHits, 1)
+		if fb.loginPreFn != nil {
+			fb.loginPreFn(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"salt": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"kdfParams": map[string]interface{}{
+				"algorithm":   "argon2id",
+				"memory":      65536,
+				"iterations":  3,
+				"parallelism": 4,
+			},
+		})
+	})
+	mux.HandleFunc("/api/auth/refresh", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "1.0")
+		atomic.AddInt32(&fb.refreshHits, 1)
+		if fb.refreshFn != nil {
+			fb.refreshFn(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"accessToken":  "access-2",
+			"refreshToken": "refresh-2",
+		})
+	})
+	mux.HandleFunc("/api/auth/logout", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "1.0")
+		atomic.AddInt32(&fb.logoutHits, 1)
+		if fb.logoutFn != nil {
+			fb.logoutFn(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+	})
+	mux.HandleFunc("/api/account/me", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "1.0")
+		atomic.AddInt32(&fb.meHits, 1)
+		if fb.meFn != nil {
+			fb.meFn(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"userId":             "user-1",
+			"email":              "user@example.com",
+			"subscriptionStatus": "active",
+			"createdAt":          "2026-05-02T00:00:00Z",
+		})
+	})
+	return fb
+}
+
+func (fb *fakeBackend) URL() string { return fb.srv.URL }
+
+// newAuthForTest wires a fresh Authenticator + memory keychain bound to
+// the supplied fakeBackend. Returns the authenticator and the underlying
+// keychain so the caller can assert keychain state.
+func newAuthForTest(t *testing.T, fb *fakeBackend) (*auth.Authenticator, keychain.Keychain) {
+	t.Helper()
+	kc := keychain.NewMemory()
+	store := auth.NewSessionStore(kc)
+	oc := oidc.NewClient(fb.URL(), fb.srv.Client())
+	rp := client.RetryPolicy{MaxRetries: 1, InitialWait: time.Millisecond, Multiplier: 1, MaxWait: 5 * time.Millisecond}
+	hc := client.New(client.Options{
+		Tokens: store,
+		Retry:  &rp,
+	})
+	a := auth.NewAuthenticator(auth.IssuerFromOIDC(oc, "endstate-backup"), oc, hc, store)
+	return a, kc
+}
+
+func TestAuthenticator_PreHandshake_HappyPath(t *testing.T) {
+	fb := newFakeBackend(t)
+	a, _ := newAuthForTest(t, fb)
+	resp, err := a.PreHandshake(context.Background(), "user@example.com")
+	if err != nil {
+		t.Fatalf("PreHandshake: %+v", err)
+	}
+	if resp.KDFParams.Memory != 65536 {
+		t.Errorf("Memory = %d, want 65536", resp.KDFParams.Memory)
+	}
+}
+
+func TestAuthenticator_PreHandshake_UnreachableMappedToBackendUnreachable(t *testing.T) {
+	kc := keychain.NewMemory()
+	store := auth.NewSessionStore(kc)
+	oc := oidc.NewClient("http://127.0.0.1:1", &http.Client{Timeout: 100 * time.Millisecond})
+	rp := client.RetryPolicy{MaxRetries: 0, InitialWait: time.Millisecond, MaxWait: time.Millisecond}
+	hc := client.New(client.Options{Tokens: store, Retry: &rp})
+	a := auth.NewAuthenticator(auth.Issuer{URL: "http://127.0.0.1:1"}, oc, hc, store)
+	_, err := a.PreHandshake(context.Background(), "x@y.com")
+	if err == nil || err.Code != envelope.ErrBackendUnreachable {
+		t.Errorf("got %+v, want BACKEND_UNREACHABLE", err)
+	}
+}
+
+func TestAuthenticator_CompleteLogin_PersistsRefreshToken(t *testing.T) {
+	fb := newFakeBackend(t)
+	a, kc := newAuthForTest(t, fb)
+	resp, err := a.CompleteLogin(context.Background(), "user@example.com", []byte("server-pw"))
+	if err != nil {
+		t.Fatalf("CompleteLogin: %+v", err)
+	}
+	if resp.RefreshToken != "refresh-1" {
+		t.Errorf("RefreshToken = %q, want refresh-1", resp.RefreshToken)
+	}
+	stored, kerr := kc.Load(keychain.AccountForUser("user-1"))
+	if kerr != nil {
+		t.Fatalf("keychain.Load: %v", kerr)
+	}
+	if string(stored) != "refresh-1" {
+		t.Errorf("keychain entry = %q, want refresh-1", stored)
+	}
+}
+
+func TestAuthenticator_RefreshRotatesRefreshToken(t *testing.T) {
+	fb := newFakeBackend(t)
+	a, kc := newAuthForTest(t, fb)
+	if _, err := a.CompleteLogin(context.Background(), "user@example.com", []byte("pw")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate the client's 401-refresh hook: ask the session for a
+	// refreshed access token. The new refresh token should also be persisted.
+	newAccess, err := a.Session().RefreshAccessToken(context.Background())
+	if err != nil {
+		t.Fatalf("RefreshAccessToken: %v", err)
+	}
+	if newAccess != "access-2" {
+		t.Errorf("new access = %q, want access-2", newAccess)
+	}
+	stored, _ := kc.Load(keychain.AccountForUser("user-1"))
+	if string(stored) != "refresh-2" {
+		t.Errorf("keychain entry = %q, want refresh-2 (rotated)", stored)
+	}
+}
+
+func TestAuthenticator_LogoutClearsKeychainEvenIfBackendDown(t *testing.T) {
+	fb := newFakeBackend(t)
+	a, kc := newAuthForTest(t, fb)
+	if _, err := a.CompleteLogin(context.Background(), "user@example.com", []byte("pw")); err != nil {
+		t.Fatal(err)
+	}
+
+	// Backend returns 500: logout should still wipe local state.
+	fb.logoutFn = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "1.0")
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+	if err := a.Logout(context.Background()); err != nil {
+		t.Fatalf("Logout: %+v", err)
+	}
+	if _, err := kc.Load(keychain.AccountForUser("user-1")); !errors.Is(err, keychain.ErrNotFound) {
+		t.Errorf("keychain entry remained after logout: %v", err)
+	}
+	if a.Session().SignedIn() {
+		t.Error("session still signed in after logout")
+	}
+}
+
+func TestAuthenticator_Me_ReturnsAccountInfo(t *testing.T) {
+	fb := newFakeBackend(t)
+	a, _ := newAuthForTest(t, fb)
+	if _, err := a.CompleteLogin(context.Background(), "user@example.com", []byte("pw")); err != nil {
+		t.Fatal(err)
+	}
+	me, err := a.Me(context.Background())
+	if err != nil {
+		t.Fatalf("Me: %+v", err)
+	}
+	if me.Email != "user@example.com" {
+		t.Errorf("email = %q", me.Email)
+	}
+	if me.SubscriptionStatus != "active" {
+		t.Errorf("subscription = %q", me.SubscriptionStatus)
+	}
+}
+
+func TestAuthenticator_PreHandshake_404MapsToNotFound(t *testing.T) {
+	fb := newFakeBackend(t)
+	fb.loginPreFn = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "1.0")
+		w.WriteHeader(http.StatusNotFound)
+	}
+	a, _ := newAuthForTest(t, fb)
+	_, err := a.PreHandshake(context.Background(), "missing@example.com")
+	if err == nil || err.Code != envelope.ErrNotFound {
+		t.Errorf("got %+v, want NOT_FOUND", err)
+	}
+}

--- a/go-engine/internal/backup/auth/jwt.go
+++ b/go-engine/internal/backup/auth/jwt.go
@@ -1,0 +1,128 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package auth
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/Artexis10/endstate/go-engine/internal/backup/oidc"
+)
+
+// Claims is the EdDSA-signed access-token payload shape from contract §4.
+type Claims struct {
+	jwt.RegisteredClaims
+	SubscriptionStatus string `json:"subscription_status,omitempty"`
+}
+
+// VerifyOptions captures the per-call expectations the engine enforces on
+// every access token: the audience the client requires, the issuer the
+// engine is talking to, and the JWKS to verify the signature against.
+type VerifyOptions struct {
+	ExpectedIssuer   string
+	ExpectedAudience string
+	JWKS             *oidc.JWKS
+	Now              time.Time
+}
+
+// JWKSResolver fetches the JWK set the verifier uses. Implemented by
+// oidc.Client (real) or a stub in tests.
+type JWKSResolver interface {
+	JWKS(ctx context.Context) (*oidc.JWKS, error)
+	InvalidateJWKS()
+}
+
+// Verify parses and validates the supplied access token. The token must
+// be signed with EdDSA, contain the expected `iss` and `aud`, be within
+// its `nbf` and `exp` window (±60s clock skew), and carry a `kid` that
+// resolves to a key in the JWKS.
+//
+// On signature failure the JWKS cache is invalidated so the next call
+// refreshes from the backend (handles key rotation).
+func Verify(ctx context.Context, tokenStr string, resolver JWKSResolver, opts VerifyOptions) (*Claims, error) {
+	parser := jwt.NewParser(
+		jwt.WithValidMethods([]string{"EdDSA"}),
+		jwt.WithIssuer(opts.ExpectedIssuer),
+		jwt.WithAudience(opts.ExpectedAudience),
+		jwt.WithLeeway(60*time.Second),
+	)
+
+	keyFunc := func(token *jwt.Token) (interface{}, error) {
+		return lookupKey(opts.JWKS, token)
+	}
+
+	tok, err := parser.ParseWithClaims(tokenStr, &Claims{}, keyFunc)
+	if err != nil {
+		// Signature failures are most often a rotated key; invalidate the
+		// JWKS cache so the next request fetches fresh keys.
+		if errors.Is(err, jwt.ErrTokenSignatureInvalid) || errors.Is(err, jwt.ErrTokenUnverifiable) {
+			resolver.InvalidateJWKS()
+		}
+		return nil, err
+	}
+	if !tok.Valid {
+		return nil, errors.New("auth: token marked invalid by parser")
+	}
+	claims, ok := tok.Claims.(*Claims)
+	if !ok {
+		return nil, errors.New("auth: claims type assertion failed")
+	}
+
+	// jwt/v5 already validates iss/aud/exp/nbf via the parser options. We
+	// double-check exp and nbf against the supplied time so tests can
+	// exercise the boundary deterministically.
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now()
+	}
+	if claims.ExpiresAt != nil && now.After(claims.ExpiresAt.Time.Add(60*time.Second)) {
+		return nil, jwt.ErrTokenExpired
+	}
+	if claims.NotBefore != nil && now.Add(60*time.Second).Before(claims.NotBefore.Time) {
+		return nil, jwt.ErrTokenNotValidYet
+	}
+	return claims, nil
+}
+
+// lookupKey finds the JWK matching the token's `kid` and returns its
+// ed25519.PublicKey. Returns an error if no key is found or the key is
+// not a usable Ed25519 OKP key.
+func lookupKey(set *oidc.JWKS, token *jwt.Token) (interface{}, error) {
+	if set == nil {
+		return nil, errors.New("auth: empty JWKS")
+	}
+	kid, _ := token.Header["kid"].(string)
+	for _, k := range set.Keys {
+		if kid != "" && k.Kid != kid {
+			continue
+		}
+		if !strings.EqualFold(k.Kty, "OKP") || !strings.EqualFold(k.Crv, "Ed25519") {
+			continue
+		}
+		raw, err := base64URLDecode(k.X)
+		if err != nil {
+			return nil, fmt.Errorf("auth: decode JWK x: %w", err)
+		}
+		if len(raw) != ed25519.PublicKeySize {
+			return nil, fmt.Errorf("auth: JWK x has wrong length %d (want %d)", len(raw), ed25519.PublicKeySize)
+		}
+		return ed25519.PublicKey(raw), nil
+	}
+	return nil, fmt.Errorf("auth: no Ed25519 key matching kid %q", kid)
+}
+
+func base64URLDecode(s string) ([]byte, error) {
+	// Try unpadded URL-safe first; some JWKS implementations include
+	// padding, which the standard URL encoding accepts when explicitly
+	// padded. RawURLEncoding with auto-padding handled.
+	s = strings.TrimRight(s, "=")
+	return base64.RawURLEncoding.DecodeString(s)
+}

--- a/go-engine/internal/backup/auth/jwt_test.go
+++ b/go-engine/internal/backup/auth/jwt_test.go
@@ -1,0 +1,214 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package auth_test
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/golang-jwt/jwt/v5"
+
+	"github.com/Artexis10/endstate/go-engine/internal/backup/auth"
+	"github.com/Artexis10/endstate/go-engine/internal/backup/oidc"
+)
+
+const (
+	testIssuer   = "https://substratesystems.io"
+	testAudience = "endstate-backup"
+)
+
+// stubResolver is a JWKSResolver that returns a fixed JWKS and counts
+// invalidations.
+type stubResolver struct {
+	keys           *oidc.JWKS
+	invalidations  int
+}
+
+func (s *stubResolver) JWKS(context.Context) (*oidc.JWKS, error) { return s.keys, nil }
+func (s *stubResolver) InvalidateJWKS()                          { s.invalidations++ }
+
+// signTestToken mints an Ed25519-signed access token with the supplied
+// claim overrides.
+func signTestToken(t *testing.T, kid string, priv ed25519.PrivateKey, override func(c *auth.Claims)) string {
+	t.Helper()
+	now := time.Now()
+	claims := &auth.Claims{
+		RegisteredClaims: jwt.RegisteredClaims{
+			Issuer:    testIssuer,
+			Subject:   "user-1",
+			Audience:  jwt.ClaimStrings{testAudience},
+			IssuedAt:  jwt.NewNumericDate(now),
+			NotBefore: jwt.NewNumericDate(now),
+			ExpiresAt: jwt.NewNumericDate(now.Add(15 * time.Minute)),
+			ID:        "jti-1",
+		},
+		SubscriptionStatus: "active",
+	}
+	if override != nil {
+		override(claims)
+	}
+	tok := jwt.NewWithClaims(jwt.SigningMethodEdDSA, claims)
+	tok.Header["kid"] = kid
+	signed, err := tok.SignedString(priv)
+	if err != nil {
+		t.Fatalf("SignedString: %v", err)
+	}
+	return signed
+}
+
+// testJWKS builds a JWK set containing a single Ed25519 public key with
+// the given kid.
+func testJWKS(t *testing.T, kid string, pub ed25519.PublicKey) *oidc.JWKS {
+	t.Helper()
+	return &oidc.JWKS{
+		Keys: []oidc.JWK{{
+			Kty: "OKP",
+			Crv: "Ed25519",
+			Kid: kid,
+			Alg: "EdDSA",
+			Use: "sig",
+			X:   base64.RawURLEncoding.EncodeToString(pub),
+		}},
+	}
+}
+
+func newKeyPair(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	return pub, priv
+}
+
+func TestVerify_ValidToken(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	keys := testJWKS(t, "k1", pub)
+	resolver := &stubResolver{keys: keys}
+	tokenStr := signTestToken(t, "k1", priv, nil)
+
+	claims, err := auth.Verify(context.Background(), tokenStr, resolver, auth.VerifyOptions{
+		ExpectedIssuer:   testIssuer,
+		ExpectedAudience: testAudience,
+		JWKS:             keys,
+		Now:              time.Now(),
+	})
+	if err != nil {
+		t.Fatalf("Verify: %v", err)
+	}
+	if claims.Subject != "user-1" {
+		t.Errorf("sub = %q, want user-1", claims.Subject)
+	}
+	if claims.SubscriptionStatus != "active" {
+		t.Errorf("subscription_status = %q, want active", claims.SubscriptionStatus)
+	}
+	if resolver.invalidations != 0 {
+		t.Errorf("invalidations = %d, want 0 on success", resolver.invalidations)
+	}
+}
+
+func TestVerify_ExpiredToken(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	keys := testJWKS(t, "k1", pub)
+	resolver := &stubResolver{keys: keys}
+	tokenStr := signTestToken(t, "k1", priv, func(c *auth.Claims) {
+		past := time.Now().Add(-2 * time.Hour)
+		c.IssuedAt = jwt.NewNumericDate(past)
+		c.NotBefore = jwt.NewNumericDate(past)
+		c.ExpiresAt = jwt.NewNumericDate(past.Add(15 * time.Minute))
+	})
+	_, err := auth.Verify(context.Background(), tokenStr, resolver, auth.VerifyOptions{
+		ExpectedIssuer:   testIssuer,
+		ExpectedAudience: testAudience,
+		JWKS:             keys,
+		Now:              time.Now(),
+	})
+	if err == nil || !errors.Is(err, jwt.ErrTokenExpired) {
+		t.Errorf("expected ErrTokenExpired, got %v", err)
+	}
+}
+
+func TestVerify_WrongAudience(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	keys := testJWKS(t, "k1", pub)
+	resolver := &stubResolver{keys: keys}
+	tokenStr := signTestToken(t, "k1", priv, func(c *auth.Claims) {
+		c.Audience = jwt.ClaimStrings{"some-other-aud"}
+	})
+	_, err := auth.Verify(context.Background(), tokenStr, resolver, auth.VerifyOptions{
+		ExpectedIssuer:   testIssuer,
+		ExpectedAudience: testAudience,
+		JWKS:             keys,
+		Now:              time.Now(),
+	})
+	if err == nil || !errors.Is(err, jwt.ErrTokenInvalidAudience) {
+		t.Errorf("expected ErrTokenInvalidAudience, got %v", err)
+	}
+}
+
+func TestVerify_WrongIssuer(t *testing.T) {
+	pub, priv := newKeyPair(t)
+	keys := testJWKS(t, "k1", pub)
+	resolver := &stubResolver{keys: keys}
+	tokenStr := signTestToken(t, "k1", priv, func(c *auth.Claims) {
+		c.Issuer = "https://attacker.example.com"
+	})
+	_, err := auth.Verify(context.Background(), tokenStr, resolver, auth.VerifyOptions{
+		ExpectedIssuer:   testIssuer,
+		ExpectedAudience: testAudience,
+		JWKS:             keys,
+		Now:              time.Now(),
+	})
+	if err == nil || !errors.Is(err, jwt.ErrTokenInvalidIssuer) {
+		t.Errorf("expected ErrTokenInvalidIssuer, got %v", err)
+	}
+}
+
+func TestVerify_BadSignature_InvalidatesJWKS(t *testing.T) {
+	// Sign with one key; verify against a JWKS containing a different key.
+	_, priv := newKeyPair(t)
+	otherPub, _ := newKeyPair(t)
+	keys := testJWKS(t, "k1", otherPub)
+	resolver := &stubResolver{keys: keys}
+
+	tokenStr := signTestToken(t, "k1", priv, nil)
+
+	_, err := auth.Verify(context.Background(), tokenStr, resolver, auth.VerifyOptions{
+		ExpectedIssuer:   testIssuer,
+		ExpectedAudience: testAudience,
+		JWKS:             keys,
+		Now:              time.Now(),
+	})
+	if err == nil {
+		t.Fatal("expected error on bad signature")
+	}
+	if resolver.invalidations != 1 {
+		t.Errorf("invalidations = %d, want 1 (signature failure should invalidate JWKS)", resolver.invalidations)
+	}
+}
+
+func TestVerify_RotatedKid(t *testing.T) {
+	// JWKS contains key kid="k2" only; token signed with key kid="k1".
+	// The verifier must fail to find a matching kid.
+	_, priv := newKeyPair(t)
+	otherPub, _ := newKeyPair(t)
+	keys := testJWKS(t, "k2", otherPub)
+	resolver := &stubResolver{keys: keys}
+
+	tokenStr := signTestToken(t, "k1", priv, nil)
+	_, err := auth.Verify(context.Background(), tokenStr, resolver, auth.VerifyOptions{
+		ExpectedIssuer:   testIssuer,
+		ExpectedAudience: testAudience,
+		JWKS:             keys,
+		Now:              time.Now(),
+	})
+	if err == nil {
+		t.Fatal("expected error when no matching kid")
+	}
+}

--- a/go-engine/internal/backup/auth/session.go
+++ b/go-engine/internal/backup/auth/session.go
@@ -1,0 +1,204 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+// Package auth orchestrates the Hosted Backup login/logout/refresh/recover
+// flows defined in docs/contracts/hosted-backup-contract.md §5–§6.
+//
+// The crypto operations (Argon2id KDF, DEK wrap/unwrap) live in
+// internal/backup/crypto and are STUBS until PROMPT 3 lands. Until then,
+// any flow that requires deriving keys (login, signup, recover, push,
+// pull) returns a "crypto: not implemented" error and surfaces
+// INTERNAL_ERROR to the user. The orchestration code is real; the
+// cryptographic primitives are not.
+package auth
+
+import (
+	"context"
+	"sync"
+	"time"
+
+	"github.com/Artexis10/endstate/go-engine/internal/backup/keychain"
+	"github.com/Artexis10/endstate/go-engine/internal/backup/oidc"
+)
+
+// SessionStore caches the access + refresh tokens for the current process
+// invocation. The refresh token is also persisted to the OS keychain so
+// it survives process restarts.
+type SessionStore struct {
+	mu             sync.Mutex
+	userID         string
+	email          string
+	accessToken    string
+	accessExpiry   time.Time
+	refreshToken   string
+	subscription   string
+	keychainClient keychain.Keychain
+	refreshFn      refreshFunc
+}
+
+// NewSessionStore constructs a SessionStore backed by the supplied
+// keychain. Pass keychain.NewSystem() in production paths.
+func NewSessionStore(kc keychain.Keychain) *SessionStore {
+	return &SessionStore{keychainClient: kc}
+}
+
+// Hydrate loads the persisted refresh token for userID from the keychain
+// into the in-memory session. Called by command handlers on startup so
+// subsequent calls have a session to act on. Returns keychain.ErrNotFound
+// if no refresh token is persisted (i.e. the user is signed out).
+func (s *SessionStore) Hydrate(userID string) error {
+	rt, err := s.keychainClient.Load(keychain.AccountForUser(userID))
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	s.userID = userID
+	s.refreshToken = string(rt)
+	s.mu.Unlock()
+	return nil
+}
+
+// Persist writes the refresh token to the keychain under the canonical
+// account name for the current userID. Called after a successful login
+// or refresh. Idempotent.
+func (s *SessionStore) Persist() error {
+	s.mu.Lock()
+	uid := s.userID
+	rt := s.refreshToken
+	s.mu.Unlock()
+	if uid == "" || rt == "" {
+		return nil
+	}
+	return s.keychainClient.Store(keychain.AccountForUser(uid), []byte(rt))
+}
+
+// Forget clears the in-memory session and removes the refresh token from
+// the keychain. Idempotent: returns nil even if no entry was present.
+func (s *SessionStore) Forget() error {
+	s.mu.Lock()
+	uid := s.userID
+	s.userID = ""
+	s.email = ""
+	s.accessToken = ""
+	s.accessExpiry = time.Time{}
+	s.refreshToken = ""
+	s.subscription = ""
+	s.mu.Unlock()
+	if uid == "" {
+		return nil
+	}
+	if err := s.keychainClient.Delete(keychain.AccountForUser(uid)); err != nil {
+		if err == keychain.ErrNotFound {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
+
+// SetTokens updates the cached access + refresh tokens and the subscription
+// hint. Called after every successful login/refresh response.
+func (s *SessionStore) SetTokens(userID, email, access, refresh, subscription string, accessExpiry time.Time) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.userID = userID
+	s.email = email
+	s.accessToken = access
+	s.accessExpiry = accessExpiry
+	s.refreshToken = refresh
+	s.subscription = subscription
+}
+
+// Snapshot returns a read-only view of the session state.
+type Snapshot struct {
+	UserID             string
+	Email              string
+	AccessToken        string
+	AccessExpiry       time.Time
+	RefreshToken       string
+	SubscriptionStatus string
+}
+
+// Snapshot returns a copy of the current session state. Nil-safe for the
+// "not signed in" case; the returned Snapshot has empty fields.
+func (s *SessionStore) Snapshot() Snapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return Snapshot{
+		UserID:             s.userID,
+		Email:              s.email,
+		AccessToken:        s.accessToken,
+		AccessExpiry:       s.accessExpiry,
+		RefreshToken:       s.refreshToken,
+		SubscriptionStatus: s.subscription,
+	}
+}
+
+// SignedIn reports whether the store currently has a refresh token. A
+// stale or expired access token still counts as signed in — the next
+// request will refresh.
+func (s *SessionStore) SignedIn() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.refreshToken != ""
+}
+
+// AccessToken implements client.TokenProvider.
+//
+// If the cached access token is expired (or expires within 30s), the
+// caller is expected to invoke a refresh before this returns. For the
+// integration scaffold we return whatever we have; the client package's
+// 401-refresh hook handles the rotation when needed.
+func (s *SessionStore) AccessToken(_ context.Context) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.accessToken, nil
+}
+
+// RefreshAccessToken implements client.TokenProvider. Invoked by the
+// client wrapper after a 401 to refresh the access token using the cached
+// refresh token. The actual HTTP call lives on the high-level Authenticator
+// (added in subsequent commits) — this default returns the cached value
+// to keep the wiring compilable; an Authenticator implementation provided
+// to a SessionStore via WithRefreshFn replaces it.
+func (s *SessionStore) RefreshAccessToken(ctx context.Context) (string, error) {
+	s.mu.Lock()
+	fn := s.refreshFn
+	s.mu.Unlock()
+	if fn == nil {
+		return s.AccessToken(ctx)
+	}
+	return fn(ctx)
+}
+
+// refreshFn is set by SessionStore.WithRefreshFn so the high-level
+// Authenticator can wire its substrate /api/auth/refresh call.
+type refreshFunc func(ctx context.Context) (string, error)
+
+// WithRefreshFn installs the refresh callback. Returns the receiver for
+// chaining.
+func (s *SessionStore) WithRefreshFn(fn refreshFunc) *SessionStore {
+	s.mu.Lock()
+	s.refreshFn = fn
+	s.mu.Unlock()
+	return s
+}
+
+func (s *SessionStore) refreshFnSlot() refreshFunc {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.refreshFn
+}
+
+// Issuer is the canonical name of the configured backend, surfaced in
+// status output. Stored next to the session so command handlers don't
+// need to plumb it separately.
+type Issuer struct {
+	URL      string
+	Audience string
+}
+
+// IssuerFromOIDC builds an Issuer from an oidc.Client.
+func IssuerFromOIDC(c *oidc.Client, audience string) Issuer {
+	return Issuer{URL: c.IssuerURL(), Audience: audience}
+}

--- a/go-engine/internal/backup/backup.go
+++ b/go-engine/internal/backup/backup.go
@@ -1,0 +1,108 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+// Package backup wires the hosted-backup component stack from environment
+// configuration. Command handlers call NewAuthenticator() to obtain a
+// fully configured authenticator without re-doing the env-var plumbing.
+//
+// Two env vars are read here, both per docs/contracts/hosted-backup-contract.md
+// §9:
+//
+//   - ENDSTATE_OIDC_ISSUER_URL — defaults to https://substratesystems.io
+//   - ENDSTATE_OIDC_AUDIENCE  — defaults to "endstate-backup"
+//
+// A third implementation-detail var is also honoured here:
+//
+//   - ENDSTATE_BACKUP_CONCURRENCY — worker pool size for upload/download,
+//     clamped to [1,16], default 4. Read by the upload/download
+//     subpackages via Concurrency().
+package backup
+
+import (
+	"os"
+	"strconv"
+
+	"github.com/Artexis10/endstate/go-engine/internal/backup/auth"
+	"github.com/Artexis10/endstate/go-engine/internal/backup/client"
+	"github.com/Artexis10/endstate/go-engine/internal/backup/keychain"
+	"github.com/Artexis10/endstate/go-engine/internal/backup/oidc"
+)
+
+// IssuerURL returns the configured OIDC issuer URL with no trailing slash.
+func IssuerURL() string { return envOrDefault("ENDSTATE_OIDC_ISSUER_URL", oidc.DefaultIssuerURL) }
+
+// Audience returns the configured JWT audience claim.
+func Audience() string { return envOrDefault("ENDSTATE_OIDC_AUDIENCE", oidc.DefaultAudience) }
+
+// Concurrency returns the upload/download worker count, clamped to [1,16].
+func Concurrency() int {
+	v := os.Getenv("ENDSTATE_BACKUP_CONCURRENCY")
+	if v == "" {
+		return 4
+	}
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 1 {
+		return 4
+	}
+	if n > 16 {
+		return 16
+	}
+	return n
+}
+
+// Stack groups every component a hosted-backup command handler needs.
+// Components share the same SessionStore + OIDC + HTTP client so a
+// refresh that happens during one call is visible to the next.
+//
+// The storage client is added by `add-backup-storage-client`.
+type Stack struct {
+	Auth    *auth.Authenticator
+	Issuer  string
+	OIDC    *oidc.Client
+	HTTP    *client.Client
+	Session *auth.SessionStore
+}
+
+// NewStack builds the full hosted-backup component stack using the
+// platform-native keychain. Each invocation returns a fresh stack with
+// an empty in-memory session; callers Hydrate from the keychain when
+// they know the userID they are acting as.
+func NewStack() *Stack {
+	return newStack(keychain.NewSystem())
+}
+
+// NewStackForTest is a test seam: substitutes the keychain (typically
+// keychain.NewMemory()).
+func NewStackForTest(kc keychain.Keychain) *Stack {
+	return newStack(kc)
+}
+
+func newStack(kc keychain.Keychain) *Stack {
+	issuer := IssuerURL()
+	audience := Audience()
+	store := auth.NewSessionStore(kc)
+	oc := oidc.NewClient(issuer, nil)
+	hc := client.New(client.Options{Tokens: store})
+	a := auth.NewAuthenticator(auth.Issuer{URL: issuer, Audience: audience}, oc, hc, store)
+	return &Stack{
+		Auth:    a,
+		Issuer:  issuer,
+		OIDC:    oc,
+		HTTP:    hc,
+		Session: store,
+	}
+}
+
+// NewAuthenticator is retained as the convenience constructor existing
+// code uses; equivalent to `NewStack().Auth`.
+func NewAuthenticator() *auth.Authenticator {
+	return NewStack().Auth
+}
+
+func envOrDefault(key, def string) string {
+	v := os.Getenv(key)
+	if v == "" {
+		return def
+	}
+	return v
+}

--- a/go-engine/internal/backup/client/client.go
+++ b/go-engine/internal/backup/client/client.go
@@ -1,0 +1,337 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+// Package client provides a thin HTTP wrapper around the substrate Hosted
+// Backup API. Responsibilities:
+//
+//   - bearer-token injection via a TokenProvider
+//   - JSON request/response marshaling
+//   - X-Endstate-API-Version checking on every response
+//   - status → envelope.ErrorCode mapping
+//   - retry with exponential backoff and jitter on 5xx + transport errors
+//   - one-shot 401 → refresh-then-retry hook
+//
+// Contract: docs/contracts/hosted-backup-contract.md §7, §11.
+//
+// The JWT itself is parsed and verified by the auth package. This package
+// only carries the bearer string; it does not interpret it.
+package client
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"math/rand"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// TokenProvider supplies access tokens to the client and refreshes them
+// when the backend rejects the current one with 401. Implemented by the
+// auth package.
+type TokenProvider interface {
+	// AccessToken returns a current bearer token. May call refresh
+	// internally if the cached token is known-expired.
+	AccessToken(ctx context.Context) (string, error)
+	// RefreshAccessToken forces a refresh and returns the new token. The
+	// client invokes this after a single 401 before giving up.
+	RefreshAccessToken(ctx context.Context) (string, error)
+}
+
+// Anonymous is a TokenProvider that supplies no token. Used for the auth
+// endpoints (signup / login pre-handshake) that are unauthenticated.
+type Anonymous struct{}
+
+// AccessToken returns an empty string with no error.
+func (Anonymous) AccessToken(context.Context) (string, error)        { return "", nil }
+// RefreshAccessToken returns an empty string with no error.
+func (Anonymous) RefreshAccessToken(context.Context) (string, error) { return "", nil }
+
+// Client is safe for concurrent use.
+type Client struct {
+	http   *http.Client
+	tokens TokenProvider
+	retry  RetryPolicy
+	rng    *rand.Rand
+	logger *slog.Logger
+	sleep  func(time.Duration) // overridable for tests
+}
+
+// Options configures a new Client.
+type Options struct {
+	HTTPClient *http.Client    // optional; default 60s timeout
+	Tokens     TokenProvider   // required; use Anonymous{} for unauth flows
+	Retry      *RetryPolicy    // optional; defaults to DefaultRetryPolicy
+	Logger     *slog.Logger    // optional; defaults to slog.Default
+	Now        func() time.Time
+}
+
+// New constructs a Client.
+func New(opts Options) *Client {
+	hc := opts.HTTPClient
+	if hc == nil {
+		hc = &http.Client{Timeout: 60 * time.Second}
+	}
+	rp := DefaultRetryPolicy()
+	if opts.Retry != nil {
+		rp = *opts.Retry
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &Client{
+		http:   hc,
+		tokens: opts.Tokens,
+		retry:  rp,
+		rng:    rand.New(rand.NewSource(time.Now().UnixNano())),
+		logger: logger,
+		sleep:  time.Sleep,
+	}
+}
+
+// Request carries the per-call options for Do.
+type Request struct {
+	Method   string      // GET, POST, DELETE, PUT
+	URL      string      // absolute URL
+	Body     interface{} // optional JSON-marshaled body
+	ReadOnly bool        // version-mismatch tolerance for minor bumps
+	Headers  http.Header // additional headers (caller-supplied)
+
+	// SkipAuthRefresh disables the one-shot 401 → refresh-then-retry hop
+	// for this call. Required for the refresh endpoint itself: substrate
+	// authenticates `/api/auth/refresh` via the body refresh token, not
+	// the bearer header. If a self-host implementation rejected the
+	// stale bearer with 401, the default refresh hook would recurse back
+	// into RefreshAccessToken indefinitely.
+	SkipAuthRefresh bool
+}
+
+// Do executes the request with retry + version check + auth refresh.
+// On 2xx the response body is decoded into out (when non-nil) as JSON
+// and nil is returned. On any other outcome an envelope.Error is
+// returned with the appropriate ErrorCode set; command handlers can
+// return it verbatim.
+func (c *Client) Do(ctx context.Context, req Request, out interface{}) *envelope.Error {
+	var lastAPIErr *APIError
+	var lastTransportErr error
+	refreshed := false
+
+	for attempt := 0; attempt <= c.retry.MaxRetries; attempt++ {
+		body, err := encodeBody(req.Body)
+		if err != nil {
+			return envelope.NewError(envelope.ErrInternalError, err.Error())
+		}
+		httpReq, err := http.NewRequestWithContext(ctx, req.Method, req.URL, body)
+		if err != nil {
+			return envelope.NewError(envelope.ErrInternalError, "client: build request: "+err.Error())
+		}
+		if req.Body != nil {
+			httpReq.Header.Set("Content-Type", "application/json")
+		}
+		httpReq.Header.Set("Accept", "application/json")
+		for k, vs := range req.Headers {
+			for _, v := range vs {
+				httpReq.Header.Add(k, v)
+			}
+		}
+
+		token, err := c.tokens.AccessToken(ctx)
+		if err != nil {
+			return envelope.NewError(envelope.ErrAuthRequired, "client: get access token: "+err.Error()).
+				WithRemediation(defaultRemediation(envelope.ErrAuthRequired))
+		}
+		if token != "" {
+			httpReq.Header.Set("Authorization", "Bearer "+token)
+		}
+
+		resp, err := c.http.Do(httpReq)
+		if err != nil {
+			lastTransportErr = err
+			if attempt < c.retry.MaxRetries {
+				wait := c.retry.nextWait(attempt, "", c.rng)
+				c.logger.Warn("backup: transport error, retrying",
+					"err", err.Error(), "attempt", attempt+1, "wait", wait)
+				if !c.waitOrCancel(ctx, wait) {
+					return envelope.NewError(envelope.ErrInternalError, "client: context cancelled")
+				}
+				continue
+			}
+			return mapTransportError(err)
+		}
+
+		apiErr := c.processResponse(resp, req.ReadOnly, out)
+		if apiErr == nil {
+			return nil
+		}
+		lastAPIErr = apiErr
+
+		// 401 → one-shot refresh, then retry without consuming a regular retry slot.
+		// Suppressed via SkipAuthRefresh on the refresh endpoint itself so we
+		// don't recurse back into RefreshAccessToken if the backend rejects
+		// the stale bearer.
+		if apiErr.Code == envelope.ErrAuthRequired && !refreshed && !req.SkipAuthRefresh {
+			if _, rerr := c.tokens.RefreshAccessToken(ctx); rerr == nil {
+				refreshed = true
+				attempt-- // don't burn a retry on the refresh-then-retry hop
+				continue
+			}
+			return apiErr.AsEnvelopeError()
+		}
+
+		if !IsRetryable(apiErr) || attempt >= c.retry.MaxRetries {
+			return apiErr.AsEnvelopeError()
+		}
+
+		wait := c.retry.nextWait(attempt, apiErr.RetryAfter, c.rng)
+		c.logger.Warn("backup: retryable response, retrying",
+			"status", apiErr.HTTPStatus, "code", string(apiErr.Code),
+			"attempt", attempt+1, "wait", wait)
+		if !c.waitOrCancel(ctx, wait) {
+			return envelope.NewError(envelope.ErrInternalError, "client: context cancelled")
+		}
+	}
+
+	if lastAPIErr != nil {
+		return lastAPIErr.AsEnvelopeError()
+	}
+	if lastTransportErr != nil {
+		return mapTransportError(lastTransportErr)
+	}
+	return envelope.NewError(envelope.ErrInternalError, "client: retries exhausted")
+}
+
+// processResponse handles version + status mapping for a single response.
+// The returned *APIError is nil on full success.
+func (c *Client) processResponse(resp *http.Response, readOnly bool, out interface{}) *APIError {
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(io.LimitReader(resp.Body, 5<<20))
+
+	if v := resp.Header.Get(versionHeader); v != "" {
+		if pv, err := parseVersionHeader(v); err == nil {
+			if mismatch, warn := versionMismatch(pv, readOnly); mismatch != nil {
+				mismatch.HTTPStatus = resp.StatusCode
+				return mismatch
+			} else if warn {
+				c.logger.Warn("backup: backend minor version newer than engine",
+					"backendVersion", v, "engineMajor", EngineSchemaMajor,
+					"engineMinor", EngineSchemaMinor)
+			}
+		} else {
+			c.logger.Warn("backup: invalid X-Endstate-API-Version header", "value", v, "err", err.Error())
+		}
+	}
+
+	if resp.StatusCode/100 == 2 {
+		if out != nil && len(body) > 0 {
+			if err := json.Unmarshal(body, out); err != nil {
+				return &APIError{
+					Code:           envelope.ErrInternalError,
+					HTTPStatus:     resp.StatusCode,
+					BackendMessage: fmt.Sprintf("decode response body: %v", err),
+				}
+			}
+		}
+		return nil
+	}
+
+	return parseAPIError(resp, body)
+}
+
+// parseAPIError maps a non-2xx response to an APIError. It tries to
+// decode the standard error envelope in the body to surface backend
+// remediation/docsKey verbatim; on parse failure it falls back to a
+// status-only error.
+func parseAPIError(resp *http.Response, body []byte) *APIError {
+	ae := &APIError{
+		HTTPStatus: resp.StatusCode,
+		RetryAfter: resp.Header.Get("Retry-After"),
+	}
+
+	// Map the status code first; backend body can refine the code (e.g.
+	// 409 → STORAGE_QUOTA_EXCEEDED) by setting a known code value.
+	switch {
+	case resp.StatusCode == http.StatusUnauthorized:
+		ae.Code = envelope.ErrAuthRequired
+	case resp.StatusCode == http.StatusPaymentRequired:
+		ae.Code = envelope.ErrSubscriptionRequired
+	case resp.StatusCode == http.StatusNotFound:
+		ae.Code = envelope.ErrNotFound
+	case resp.StatusCode == http.StatusTooManyRequests:
+		ae.Code = envelope.ErrRateLimited
+	case resp.StatusCode == http.StatusConflict:
+		ae.Code = envelope.ErrBackendError
+	case resp.StatusCode/100 == 5:
+		ae.Code = envelope.ErrBackendError
+	case resp.StatusCode/100 == 4:
+		ae.Code = envelope.ErrBackendError
+	default:
+		ae.Code = envelope.ErrBackendError
+	}
+
+	if len(body) > 0 {
+		var env struct {
+			Success bool `json:"success"`
+			Error   *struct {
+				Code        string      `json:"code"`
+				Message     string      `json:"message"`
+				Detail      interface{} `json:"detail"`
+				Remediation string      `json:"remediation"`
+				DocsKey     string      `json:"docsKey"`
+			} `json:"error"`
+		}
+		if err := json.Unmarshal(body, &env); err == nil && env.Error != nil {
+			ae.BackendCode = env.Error.Code
+			ae.BackendMessage = env.Error.Message
+			ae.Detail = env.Error.Detail
+			ae.Remediation = env.Error.Remediation
+			ae.DocsKey = env.Error.DocsKey
+			// Substrate may surface STORAGE_QUOTA_EXCEEDED on a 409 (or 403).
+			// Honour their code when it's one we recognise.
+			if up := strings.ToUpper(env.Error.Code); up == "STORAGE_QUOTA_EXCEEDED" {
+				ae.Code = envelope.ErrStorageQuotaExceeded
+			}
+		}
+	}
+	return ae
+}
+
+func encodeBody(b interface{}) (io.Reader, error) {
+	if b == nil {
+		return nil, nil
+	}
+	if r, ok := b.(io.Reader); ok {
+		return r, nil
+	}
+	buf, err := json.Marshal(b)
+	if err != nil {
+		return nil, fmt.Errorf("client: encode body: %w", err)
+	}
+	return bytes.NewReader(buf), nil
+}
+
+func (c *Client) waitOrCancel(ctx context.Context, d time.Duration) bool {
+	if d <= 0 {
+		return true
+	}
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-t.C:
+		return true
+	case <-ctx.Done():
+		return false
+	}
+}
+
+func mapTransportError(err error) *envelope.Error {
+	return envelope.NewError(envelope.ErrBackendUnreachable,
+		"Could not reach the Endstate backup service: "+err.Error()).
+		WithRemediation(defaultRemediation(envelope.ErrBackendUnreachable))
+}

--- a/go-engine/internal/backup/client/client_test.go
+++ b/go-engine/internal/backup/client/client_test.go
@@ -1,0 +1,392 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package client_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Artexis10/endstate/go-engine/internal/backup/client"
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// fastRetry returns a retry policy with near-zero waits so tests don't
+// burn real wall time exercising 5xx/429 paths.
+func fastRetry() client.RetryPolicy {
+	return client.RetryPolicy{
+		MaxRetries:  3,
+		InitialWait: time.Millisecond,
+		Multiplier:  1,
+		JitterFrac:  0,
+		MaxWait:     5 * time.Millisecond,
+	}
+}
+
+// versionV1 is the header value all test responses include unless a test
+// is specifically exercising the version-mismatch path.
+func versionV1(h http.Header) {
+	h.Set("X-Endstate-API-Version", "1.0")
+}
+
+// staticTokens is a TokenProvider that returns whatever the test sets.
+type staticTokens struct {
+	mu          sync.Mutex
+	access      string
+	refresh     string
+	refreshErr  error
+	refreshHits int32
+}
+
+func (s *staticTokens) AccessToken(context.Context) (string, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.access, nil
+}
+
+func (s *staticTokens) RefreshAccessToken(context.Context) (string, error) {
+	atomic.AddInt32(&s.refreshHits, 1)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.refreshErr != nil {
+		return "", s.refreshErr
+	}
+	s.access = s.refresh
+	return s.access, nil
+}
+
+func newClient(t *testing.T, tokens client.TokenProvider) *client.Client {
+	t.Helper()
+	rp := fastRetry()
+	return client.New(client.Options{
+		Tokens: tokens,
+		Retry:  &rp,
+	})
+}
+
+func TestDo_Success_DecodesBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		versionV1(w.Header())
+		_ = json.NewEncoder(w).Encode(map[string]string{"hello": "world"})
+	}))
+	defer srv.Close()
+
+	c := newClient(t, client.Anonymous{})
+	var out struct {
+		Hello string `json:"hello"`
+	}
+	if err := c.Do(context.Background(), client.Request{Method: "GET", URL: srv.URL}, &out); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if out.Hello != "world" {
+		t.Errorf("decoded body: hello = %q, want %q", out.Hello, "world")
+	}
+}
+
+func TestDo_BearerTokenInjected(t *testing.T) {
+	var seenAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenAuth = r.Header.Get("Authorization")
+		versionV1(w.Header())
+		w.WriteHeader(204)
+	}))
+	defer srv.Close()
+
+	c := newClient(t, &staticTokens{access: "tok-abc"})
+	if err := c.Do(context.Background(), client.Request{Method: "GET", URL: srv.URL}, nil); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if seenAuth != "Bearer tok-abc" {
+		t.Errorf("Authorization header = %q, want %q", seenAuth, "Bearer tok-abc")
+	}
+}
+
+func TestDo_401_RefreshThenRetrySucceeds(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		versionV1(w.Header())
+		if n == 1 {
+			w.WriteHeader(http.StatusUnauthorized)
+			return
+		}
+		// Second request must carry the refreshed token.
+		if r.Header.Get("Authorization") != "Bearer fresh-token" {
+			t.Errorf("second request authz = %q, want Bearer fresh-token", r.Header.Get("Authorization"))
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{"ok": "yes"})
+	}))
+	defer srv.Close()
+
+	tokens := &staticTokens{access: "stale-token", refresh: "fresh-token"}
+	c := newClient(t, tokens)
+	var out struct {
+		Ok string `json:"ok"`
+	}
+	if err := c.Do(context.Background(), client.Request{Method: "GET", URL: srv.URL}, &out); err != nil {
+		t.Fatalf("Do after refresh: %v", err)
+	}
+	if atomic.LoadInt32(&tokens.refreshHits) != 1 {
+		t.Errorf("RefreshAccessToken hits = %d, want 1", tokens.refreshHits)
+	}
+}
+
+func TestDo_401_TwiceReturnsAuthRequired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		versionV1(w.Header())
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	tokens := &staticTokens{access: "stale", refresh: "still-stale"}
+	c := newClient(t, tokens)
+	err := c.Do(context.Background(), client.Request{Method: "GET", URL: srv.URL}, nil)
+	if err == nil || err.Code != envelope.ErrAuthRequired {
+		t.Fatalf("expected ErrAuthRequired, got %+v", err)
+	}
+}
+
+func TestDo_402_SubscriptionRequired(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		versionV1(w.Header())
+		w.WriteHeader(http.StatusPaymentRequired)
+	}))
+	defer srv.Close()
+	c := newClient(t, client.Anonymous{})
+	err := c.Do(context.Background(), client.Request{Method: "POST", URL: srv.URL}, nil)
+	if err == nil || err.Code != envelope.ErrSubscriptionRequired {
+		t.Errorf("got %+v, want ErrSubscriptionRequired", err)
+	}
+}
+
+func TestDo_404_NotFound(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		versionV1(w.Header())
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	c := newClient(t, client.Anonymous{})
+	err := c.Do(context.Background(), client.Request{Method: "GET", URL: srv.URL}, nil)
+	if err == nil || err.Code != envelope.ErrNotFound {
+		t.Errorf("got %+v, want ErrNotFound", err)
+	}
+}
+
+func TestDo_429_RetriesUntilLimit(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		versionV1(w.Header())
+		w.Header().Set("Retry-After", "0") // immediate retry permitted
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer srv.Close()
+	c := newClient(t, client.Anonymous{})
+	err := c.Do(context.Background(), client.Request{Method: "GET", URL: srv.URL}, nil)
+	if err == nil || err.Code != envelope.ErrRateLimited {
+		t.Errorf("got %+v, want ErrRateLimited", err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 4 { // initial + 3 retries
+		t.Errorf("hits = %d, want 4 (initial + 3 retries)", got)
+	}
+}
+
+func TestDo_5xxThenSuccessSucceeds(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&hits, 1)
+		versionV1(w.Header())
+		if n < 3 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+	c := newClient(t, client.Anonymous{})
+	var out struct {
+		OK bool `json:"ok"`
+	}
+	if err := c.Do(context.Background(), client.Request{Method: "GET", URL: srv.URL}, &out); err != nil {
+		t.Fatalf("Do: %v", err)
+	}
+	if !out.OK {
+		t.Errorf("decoded body: ok = %v, want true", out.OK)
+	}
+}
+
+func TestDo_5xxRetriesExhausted(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		versionV1(w.Header())
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer srv.Close()
+	c := newClient(t, client.Anonymous{})
+	err := c.Do(context.Background(), client.Request{Method: "GET", URL: srv.URL}, nil)
+	if err == nil || err.Code != envelope.ErrBackendError {
+		t.Errorf("got %+v, want ErrBackendError", err)
+	}
+	if got := atomic.LoadInt32(&hits); got != 4 {
+		t.Errorf("hits = %d, want 4", got)
+	}
+}
+
+func TestDo_4xxNotRetried(t *testing.T) {
+	var hits int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&hits, 1)
+		versionV1(w.Header())
+		w.WriteHeader(http.StatusBadRequest)
+	}))
+	defer srv.Close()
+	c := newClient(t, client.Anonymous{})
+	_ = c.Do(context.Background(), client.Request{Method: "POST", URL: srv.URL}, nil)
+	if got := atomic.LoadInt32(&hits); got != 1 {
+		t.Errorf("4xx retried %d times; should never retry (got hits=%d)", got-1, got)
+	}
+}
+
+func TestDo_VersionMajorMismatch_AlwaysSchemaIncompatible(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "2.0")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+	c := newClient(t, client.Anonymous{})
+
+	// On a read-only request:
+	err := c.Do(context.Background(), client.Request{Method: "GET", URL: srv.URL, ReadOnly: true}, nil)
+	if err == nil || err.Code != envelope.ErrSchemaIncompatible {
+		t.Errorf("read-only major mismatch: got %+v, want SCHEMA_INCOMPATIBLE", err)
+	}
+	// And on a write:
+	err = c.Do(context.Background(), client.Request{Method: "POST", URL: srv.URL}, nil)
+	if err == nil || err.Code != envelope.ErrSchemaIncompatible {
+		t.Errorf("write major mismatch: got %+v, want SCHEMA_INCOMPATIBLE", err)
+	}
+}
+
+func TestDo_VersionMinorMismatch_ReadOnlyProceeds(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "1.5")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer srv.Close()
+	c := newClient(t, client.Anonymous{})
+	if err := c.Do(context.Background(), client.Request{Method: "GET", URL: srv.URL, ReadOnly: true}, nil); err != nil {
+		t.Errorf("read-only minor mismatch: expected nil error, got %+v", err)
+	}
+}
+
+func TestDo_VersionMinorMismatch_WriteRejected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "1.5")
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer srv.Close()
+	c := newClient(t, client.Anonymous{})
+	err := c.Do(context.Background(), client.Request{Method: "POST", URL: srv.URL}, nil)
+	if err == nil || err.Code != envelope.ErrSchemaIncompatible {
+		t.Errorf("write minor mismatch: got %+v, want SCHEMA_INCOMPATIBLE", err)
+	}
+}
+
+func TestDo_StorageQuotaExceededFromBody(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		versionV1(w.Header())
+		w.WriteHeader(http.StatusConflict)
+		_, _ = w.Write([]byte(`{"success":false,"error":{"code":"STORAGE_QUOTA_EXCEEDED","message":"Quota reached"}}`))
+	}))
+	defer srv.Close()
+	c := newClient(t, client.Anonymous{})
+	err := c.Do(context.Background(), client.Request{Method: "POST", URL: srv.URL}, nil)
+	if err == nil || err.Code != envelope.ErrStorageQuotaExceeded {
+		t.Errorf("got %+v, want STORAGE_QUOTA_EXCEEDED", err)
+	}
+}
+
+func TestDo_TransportErrorMappedToBackendUnreachable(t *testing.T) {
+	c := client.New(client.Options{
+		Tokens:     client.Anonymous{},
+		HTTPClient: &http.Client{Timeout: 100 * time.Millisecond},
+		Retry:      ptrRetry(fastRetry()),
+	})
+	// Loopback port 1 is reserved & should be closed; immediate connect refusal.
+	err := c.Do(context.Background(), client.Request{Method: "GET", URL: "http://127.0.0.1:1"}, nil)
+	if err == nil || err.Code != envelope.ErrBackendUnreachable {
+		t.Errorf("got %+v, want BACKEND_UNREACHABLE", err)
+	}
+}
+
+func TestDo_BackendErrorEnvelopePassesRemediation(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		versionV1(w.Header())
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte(`{"success":false,"error":{"code":"FORBIDDEN","message":"nope","remediation":"Run a thing","docsKey":"errors/forbidden"}}`))
+	}))
+	defer srv.Close()
+	c := newClient(t, client.Anonymous{})
+	err := c.Do(context.Background(), client.Request{Method: "GET", URL: srv.URL}, nil)
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if err.Remediation != "Run a thing" {
+		t.Errorf("remediation = %q, want %q", err.Remediation, "Run a thing")
+	}
+	if err.DocsKey != "errors/forbidden" {
+		t.Errorf("docsKey = %q, want %q", err.DocsKey, "errors/forbidden")
+	}
+}
+
+func ptrRetry(p client.RetryPolicy) *client.RetryPolicy { return &p }
+
+// TestRetryAfterHonoured verifies the 429 Retry-After header is parsed and
+// (loosely) honoured. We can't easily measure the wall time without
+// flaking, so just ensure parsing doesn't panic and the header value is
+// surfaced.
+func TestRetryAfterHonoured(t *testing.T) {
+	t.Run("seconds form", func(t *testing.T) {
+		// Smoke-test parseRetryAfter via a 429 response with Retry-After=1 — should still
+		// retry (we configure fastRetry; the cap means actual wait is &lt;=5ms).
+		var hits int32
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			n := atomic.AddInt32(&hits, 1)
+			versionV1(w.Header())
+			if n < 2 {
+				w.Header().Set("Retry-After", strconv.Itoa(1))
+				w.WriteHeader(http.StatusTooManyRequests)
+				return
+			}
+			_, _ = w.Write([]byte(`{}`))
+		}))
+		defer srv.Close()
+
+		// Use a retry policy with MaxWait < 1s so Retry-After=1s doesn't burn real time.
+		rp := client.RetryPolicy{
+			MaxRetries:  3,
+			InitialWait: time.Millisecond,
+			Multiplier:  1,
+			JitterFrac:  0,
+			MaxWait:     5 * time.Millisecond,
+		}
+		c := client.New(client.Options{
+			Tokens: client.Anonymous{},
+			Retry:  &rp,
+		})
+		if err := c.Do(context.Background(), client.Request{Method: "GET", URL: srv.URL}, nil); err != nil {
+			t.Fatalf("Do: %+v", err)
+		}
+		if atomic.LoadInt32(&hits) < 2 {
+			t.Errorf("expected at least 2 hits (one retry), got %d", hits)
+		}
+	})
+}

--- a/go-engine/internal/backup/client/errors.go
+++ b/go-engine/internal/backup/client/errors.go
@@ -1,0 +1,137 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// APIError is returned by the client when the backend responds with a
+// non-2xx status. Code is the mapped envelope error code; HTTPStatus is
+// the original HTTP status; Backend* fields are the parsed substrate
+// error envelope (when present).
+type APIError struct {
+	Code           envelope.ErrorCode
+	HTTPStatus     int
+	BackendCode    string
+	BackendMessage string
+	Detail         interface{}
+	Remediation    string
+	DocsKey        string
+	RetryAfter     string
+}
+
+func (e *APIError) Error() string {
+	if e.BackendCode != "" {
+		return fmt.Sprintf("backend %d %s: %s", e.HTTPStatus, e.BackendCode, e.BackendMessage)
+	}
+	return fmt.Sprintf("backend %d: %s", e.HTTPStatus, e.BackendMessage)
+}
+
+// AsEnvelopeError lifts the APIError into an envelope.Error suitable for
+// returning from a command handler. Remediation and docsKey are filled in
+// with sensible defaults when the backend did not supply them.
+func (e *APIError) AsEnvelopeError() *envelope.Error {
+	out := envelope.NewError(e.Code, fallbackMessage(e))
+	if e.Detail != nil {
+		out.WithDetail(e.Detail)
+	}
+	if e.Remediation != "" {
+		out.WithRemediation(e.Remediation)
+	} else if rem := defaultRemediation(e.Code); rem != "" {
+		out.WithRemediation(rem)
+	}
+	if e.DocsKey != "" {
+		out.WithDocsKey(e.DocsKey)
+	} else if dk := defaultDocsKey(e.Code); dk != "" {
+		out.WithDocsKey(dk)
+	}
+	return out
+}
+
+func fallbackMessage(e *APIError) string {
+	if e.BackendMessage != "" {
+		return e.BackendMessage
+	}
+	if e.BackendCode != "" {
+		return e.BackendCode
+	}
+	switch e.Code {
+	case envelope.ErrAuthRequired:
+		return "Authentication required."
+	case envelope.ErrSubscriptionRequired:
+		return "Active subscription required."
+	case envelope.ErrNotFound:
+		return "Resource not found."
+	case envelope.ErrRateLimited:
+		return "Too many requests. Try again shortly."
+	case envelope.ErrBackendError:
+		return fmt.Sprintf("Backend returned %d.", e.HTTPStatus)
+	case envelope.ErrBackendUnreachable:
+		return "Could not reach the Endstate backup service."
+	case envelope.ErrBackendIncompatible:
+		return "The backup backend is not compatible with this engine version."
+	case envelope.ErrSchemaIncompatible:
+		return "Backend schema version is incompatible with this engine."
+	case envelope.ErrStorageQuotaExceeded:
+		return "Backup storage quota exceeded."
+	}
+	return fmt.Sprintf("Request failed (status %d).", e.HTTPStatus)
+}
+
+func defaultRemediation(c envelope.ErrorCode) string {
+	switch c {
+	case envelope.ErrAuthRequired:
+		return "Run `endstate backup login` and retry."
+	case envelope.ErrSubscriptionRequired:
+		return "Subscribe to Endstate Hosted Backup to upload backups; restore remains available during grace and cancelled states."
+	case envelope.ErrRateLimited:
+		return "Wait a few seconds and retry."
+	case envelope.ErrBackendUnreachable:
+		return "Check your network connection or override ENDSTATE_OIDC_ISSUER_URL if pointing at a self-host backend."
+	case envelope.ErrBackendIncompatible:
+		return "Update the engine, or point at a backend that advertises the required `endstate_extensions` block."
+	case envelope.ErrSchemaIncompatible:
+		return "Update the engine to a version compatible with the backend's schema major."
+	case envelope.ErrStorageQuotaExceeded:
+		return "Delete old backup versions or remove unused backups, then retry."
+	}
+	return ""
+}
+
+func defaultDocsKey(c envelope.ErrorCode) string {
+	return "errors/" + strings.ToLower(strings.ReplaceAll(string(c), "_", "-"))
+}
+
+// IsAuthRequired reports whether err is an APIError mapped to AUTH_REQUIRED.
+// Helper used by the auth retry-after-refresh path.
+func IsAuthRequired(err error) bool {
+	var ae *APIError
+	if errors.As(err, &ae) {
+		return ae.Code == envelope.ErrAuthRequired
+	}
+	return false
+}
+
+// IsRetryable reports whether err is a transport error or a 5xx APIError
+// that the retry loop is allowed to attempt again. 4xx (except 429) are
+// never retried per the locked policy.
+func IsRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	var ae *APIError
+	if errors.As(err, &ae) {
+		if ae.Code == envelope.ErrRateLimited {
+			return true
+		}
+		return ae.HTTPStatus >= 500 && ae.HTTPStatus < 600
+	}
+	// Any non-API error (network, timeout, DNS) is retryable up to the cap.
+	return true
+}

--- a/go-engine/internal/backup/client/retry.go
+++ b/go-engine/internal/backup/client/retry.go
@@ -1,0 +1,74 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"math/rand"
+	"strconv"
+	"time"
+)
+
+// RetryPolicy controls the per-call retry behaviour. The defaults match
+// the plan: max 3 retries, initial 500 ms, ×2 backoff, ±25% jitter,
+// capped at 8 s. 5xx and transport errors retry; 4xx never retry; 429
+// honours Retry-After when present.
+type RetryPolicy struct {
+	MaxRetries  int
+	InitialWait time.Duration
+	Multiplier  float64
+	JitterFrac  float64
+	MaxWait     time.Duration
+}
+
+// DefaultRetryPolicy returns the locked plan defaults.
+func DefaultRetryPolicy() RetryPolicy {
+	return RetryPolicy{
+		MaxRetries:  3,
+		InitialWait: 500 * time.Millisecond,
+		Multiplier:  2,
+		JitterFrac:  0.25,
+		MaxWait:     8 * time.Second,
+	}
+}
+
+// nextWait returns the wait duration before retry attempt n (0-indexed —
+// attempt 0 is the first retry, not the initial call). honourRetryAfter
+// overrides the computed backoff when the server provided a Retry-After
+// header value.
+func (p RetryPolicy) nextWait(attempt int, honourRetryAfter string, rng *rand.Rand) time.Duration {
+	if d := parseRetryAfter(honourRetryAfter); d > 0 {
+		if d > p.MaxWait {
+			return p.MaxWait
+		}
+		return d
+	}
+	base := float64(p.InitialWait)
+	for i := 0; i < attempt; i++ {
+		base *= p.Multiplier
+	}
+	if base > float64(p.MaxWait) {
+		base = float64(p.MaxWait)
+	}
+	if p.JitterFrac > 0 && rng != nil {
+		j := (rng.Float64()*2 - 1) * p.JitterFrac // [-JitterFrac, +JitterFrac)
+		base *= 1 + j
+		if base < 0 {
+			base = 0
+		}
+	}
+	return time.Duration(base)
+}
+
+// parseRetryAfter parses an HTTP Retry-After header. Only the
+// delta-seconds form is supported; HTTP-date forms return 0.
+func parseRetryAfter(v string) time.Duration {
+	if v == "" {
+		return 0
+	}
+	secs, err := strconv.Atoi(v)
+	if err != nil || secs <= 0 {
+		return 0
+	}
+	return time.Duration(secs) * time.Second
+}

--- a/go-engine/internal/backup/client/version.go
+++ b/go-engine/internal/backup/client/version.go
@@ -1,0 +1,78 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package client
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// EngineSchemaMajor is the API schema major version this engine speaks
+// (contract §11). A backend advertising any other major triggers
+// SCHEMA_INCOMPATIBLE on every request.
+const EngineSchemaMajor = 1
+
+// EngineSchemaMinor is the maximum minor version this engine knows about.
+// A backend advertising a higher minor on a write request also triggers
+// SCHEMA_INCOMPATIBLE; on a read-only request it logs a warning and lets
+// the request proceed.
+const EngineSchemaMinor = 0
+
+// versionHeader is the response header substrate sets on every response
+// (contract §11).
+const versionHeader = "X-Endstate-API-Version"
+
+// parsedVersion holds the major/minor extracted from the version header.
+type parsedVersion struct {
+	major int
+	minor int
+}
+
+func parseVersionHeader(v string) (parsedVersion, error) {
+	parts := strings.SplitN(strings.TrimSpace(v), ".", 2)
+	if len(parts) != 2 {
+		return parsedVersion{}, fmt.Errorf("expected MAJOR.MINOR, got %q", v)
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil || major < 0 {
+		return parsedVersion{}, fmt.Errorf("invalid major component %q", parts[0])
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil || minor < 0 {
+		return parsedVersion{}, fmt.Errorf("invalid minor component %q", parts[1])
+	}
+	return parsedVersion{major: major, minor: minor}, nil
+}
+
+// versionMismatch returns nil if the backend version is acceptable. For a
+// major mismatch it always returns an APIError with SCHEMA_INCOMPATIBLE.
+// For a higher minor it returns an APIError on writes and a warning
+// (boolean second return) on reads.
+func versionMismatch(backend parsedVersion, readOnly bool) (*APIError, bool) {
+	if backend.major != EngineSchemaMajor {
+		return &APIError{
+			Code: envelope.ErrSchemaIncompatible,
+			BackendMessage: fmt.Sprintf(
+				"Backend schema major %d does not match engine major %d.",
+				backend.major, EngineSchemaMajor,
+			),
+		}, false
+	}
+	if backend.minor > EngineSchemaMinor {
+		if readOnly {
+			return nil, true // proceed but warn
+		}
+		return &APIError{
+			Code: envelope.ErrSchemaIncompatible,
+			BackendMessage: fmt.Sprintf(
+				"Backend schema minor %d is newer than engine minor %d (write blocked).",
+				backend.minor, EngineSchemaMinor,
+			),
+		}, false
+	}
+	return nil, false
+}

--- a/go-engine/internal/backup/crypto/crypto_test.go
+++ b/go-engine/internal/backup/crypto/crypto_test.go
@@ -1,0 +1,109 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package crypto_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/backup/crypto"
+)
+
+// TestDefaultKDFParamsLockedV1 confirms the locked v1 parameter set matches
+// docs/contracts/hosted-backup-contract.md §2 exactly.
+func TestDefaultKDFParamsLockedV1(t *testing.T) {
+	got := crypto.DefaultKDFParams()
+	if got.Algorithm != "argon2id" {
+		t.Errorf("Algorithm = %q, want %q", got.Algorithm, "argon2id")
+	}
+	if got.Memory != 65536 {
+		t.Errorf("Memory = %d, want 65536", got.Memory)
+	}
+	if got.Iterations != 3 {
+		t.Errorf("Iterations = %d, want 3", got.Iterations)
+	}
+	if got.Parallelism != 4 {
+		t.Errorf("Parallelism = %d, want 4", got.Parallelism)
+	}
+}
+
+// TestKDFParams_MeetsFloor exercises the floor check. The engine refuses
+// any parameters weaker than the locked v1 floor regardless of what the
+// server advertises (contract §2).
+func TestKDFParams_MeetsFloor(t *testing.T) {
+	cases := []struct {
+		name string
+		p    crypto.KDFParams
+		want bool
+	}{
+		{"v1 default", crypto.DefaultKDFParams(), true},
+		{"weaker memory", crypto.KDFParams{Algorithm: "argon2id", Memory: 32768, Iterations: 3, Parallelism: 4}, false},
+		{"weaker iterations", crypto.KDFParams{Algorithm: "argon2id", Memory: 65536, Iterations: 2, Parallelism: 4}, false},
+		{"weaker parallelism", crypto.KDFParams{Algorithm: "argon2id", Memory: 65536, Iterations: 3, Parallelism: 2}, false},
+		{"wrong algorithm", crypto.KDFParams{Algorithm: "argon2i", Memory: 65536, Iterations: 3, Parallelism: 4}, false},
+		{"stronger memory", crypto.KDFParams{Algorithm: "argon2id", Memory: 131072, Iterations: 3, Parallelism: 4}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.p.MeetsFloor(); got != tc.want {
+				t.Errorf("MeetsFloor() = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestStubsReturnNotImplemented ensures every operation surface returns
+// ErrNotImplemented until PROMPT 3 lands. Locking this in a test prevents
+// accidentally shipping a half-stubbed crypto module.
+func TestStubsReturnNotImplemented(t *testing.T) {
+	dek := make([]byte, crypto.DEKSize)
+	salt := make([]byte, crypto.SaltSize)
+	masterKey := [crypto.MasterKeySize]byte{}
+	rkBytes := [32]byte{}
+
+	if _, err := crypto.DeriveKeys("pw", salt, crypto.DefaultKDFParams()); !errors.Is(err, crypto.ErrNotImplemented) {
+		t.Errorf("DeriveKeys: expected ErrNotImplemented, got %v", err)
+	}
+	if _, err := crypto.GenerateDEK(); !errors.Is(err, crypto.ErrNotImplemented) {
+		t.Errorf("GenerateDEK: expected ErrNotImplemented, got %v", err)
+	}
+	if _, err := crypto.WrapDEK(dek, masterKey); !errors.Is(err, crypto.ErrNotImplemented) {
+		t.Errorf("WrapDEK: expected ErrNotImplemented, got %v", err)
+	}
+	if _, err := crypto.UnwrapDEK(nil, masterKey); !errors.Is(err, crypto.ErrNotImplemented) {
+		t.Errorf("UnwrapDEK: expected ErrNotImplemented, got %v", err)
+	}
+	if _, err := crypto.EncryptChunk(nil, 0, dek); !errors.Is(err, crypto.ErrNotImplemented) {
+		t.Errorf("EncryptChunk: expected ErrNotImplemented, got %v", err)
+	}
+	if _, err := crypto.DecryptChunk(nil, 0, dek); !errors.Is(err, crypto.ErrNotImplemented) {
+		t.Errorf("DecryptChunk: expected ErrNotImplemented, got %v", err)
+	}
+	if _, err := crypto.EncryptManifest(nil, dek); !errors.Is(err, crypto.ErrNotImplemented) {
+		t.Errorf("EncryptManifest: expected ErrNotImplemented, got %v", err)
+	}
+	if _, err := crypto.DecryptManifest(nil, dek); !errors.Is(err, crypto.ErrNotImplemented) {
+		t.Errorf("DecryptManifest: expected ErrNotImplemented, got %v", err)
+	}
+	if _, err := crypto.GenerateRecoveryKey(); !errors.Is(err, crypto.ErrNotImplemented) {
+		t.Errorf("GenerateRecoveryKey: expected ErrNotImplemented, got %v", err)
+	}
+	if _, err := crypto.ParseRecoveryPhrase(""); !errors.Is(err, crypto.ErrNotImplemented) {
+		t.Errorf("ParseRecoveryPhrase: expected ErrNotImplemented, got %v", err)
+	}
+	if _, err := crypto.DeriveRecoveryKey(rkBytes, salt, crypto.DefaultKDFParams()); !errors.Is(err, crypto.ErrNotImplemented) {
+		t.Errorf("DeriveRecoveryKey: expected ErrNotImplemented, got %v", err)
+	}
+	if _, err := crypto.RecoveryKeyVerifier(rkBytes, salt, crypto.DefaultKDFParams()); !errors.Is(err, crypto.ErrNotImplemented) {
+		t.Errorf("RecoveryKeyVerifier: expected ErrNotImplemented, got %v", err)
+	}
+}
+
+// TestManifestAAD_IsSentinel locks the contract value (§3). Changing this
+// value would break interoperability with all existing encrypted manifests.
+func TestManifestAAD_IsSentinel(t *testing.T) {
+	if crypto.ManifestAAD != 0xFFFFFFFF {
+		t.Errorf("ManifestAAD = %#x, want 0xFFFFFFFF", crypto.ManifestAAD)
+	}
+}

--- a/go-engine/internal/backup/crypto/dek.go
+++ b/go-engine/internal/backup/crypto/dek.go
@@ -1,0 +1,29 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package crypto
+
+// GenerateDEK produces a fresh DEKSize-byte data-encryption-key from a
+// CSPRNG. Contract §3 ("DEK wrapping").
+//
+// TODO(prompt-3): implement using crypto/rand.Read.
+func GenerateDEK() ([]byte, error) {
+	return nil, ErrNotImplemented
+}
+
+// WrapDEK encrypts dek with masterKey using AES-256-GCM, returning the
+// wire-format wrapped blob: nonce || ciphertext || tag. Contract §3.
+//
+// TODO(prompt-3): implement using crypto/aes + crypto/cipher.NewGCM.
+func WrapDEK(dek []byte, masterKey [MasterKeySize]byte) ([]byte, error) {
+	return nil, ErrNotImplemented
+}
+
+// UnwrapDEK reverses WrapDEK. Returns ErrNotImplemented in the stub.
+//
+// TODO(prompt-3): implement and return an error on AEAD authentication
+// failure (do NOT mask as nil — the caller must distinguish a bad key from
+// a corrupt blob).
+func UnwrapDEK(wrapped []byte, masterKey [MasterKeySize]byte) ([]byte, error) {
+	return nil, ErrNotImplemented
+}

--- a/go-engine/internal/backup/crypto/doc.go
+++ b/go-engine/internal/backup/crypto/doc.go
@@ -1,0 +1,21 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+// Package crypto defines the cryptographic primitives required by Endstate
+// Hosted Backup as locked in docs/contracts/hosted-backup-contract.md
+// (sections 2, 3 and 6).
+//
+// Scope boundary: this package's bodies are intentionally STUB
+// implementations. Every operation returns ErrNotImplemented and carries a
+// // TODO(prompt-3) comment. The cryptographic implementation is delivered
+// in PROMPT 3 (see .claude/scratch/hosted-backup-v2/PROMPT_3_engine_crypto.md).
+//
+// The interface defined here is the integration surface the rest of the
+// engine compiles against (auth, upload, download). PROMPT 3 fills in the
+// bodies without changing the surface.
+package crypto
+
+import "errors"
+
+// ErrNotImplemented is returned by every stub function until PROMPT 3 lands.
+var ErrNotImplemented = errors.New("crypto: not implemented; see PROMPT_3_engine_crypto")

--- a/go-engine/internal/backup/crypto/envelope.go
+++ b/go-engine/internal/backup/crypto/envelope.go
@@ -1,0 +1,43 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package crypto
+
+// EncryptChunk encrypts plaintext with AES-256-GCM using dek as the key,
+// a fresh random nonce, and chunkIndex (4-byte big-endian uint32) as AAD.
+// Returns the wire-format blob: nonce || ciphertext || tag. Contract §3.
+//
+// TODO(prompt-3): implement.
+func EncryptChunk(plaintext []byte, chunkIndex uint32, dek []byte) ([]byte, error) {
+	return nil, ErrNotImplemented
+}
+
+// DecryptChunk reverses EncryptChunk. Returns an error on AEAD
+// authentication failure or when blob is malformed.
+//
+// TODO(prompt-3): implement.
+func DecryptChunk(blob []byte, chunkIndex uint32, dek []byte) ([]byte, error) {
+	return nil, ErrNotImplemented
+}
+
+// EncryptManifest encrypts the marshalled manifest JSON. Identical wire
+// format to EncryptChunk but binds the manifest sentinel AAD (ManifestAAD,
+// 0xFFFFFFFF) so a manifest blob cannot be substituted for a chunk-index-0
+// ciphertext or vice versa (contract §3).
+//
+// Note: ManifestAAD is the cryptographic binding inside the encrypted blob
+// and is independent of the chunkIndex=-1 transport-layer flag used in API
+// presigned-URL responses (contract §7). Implementations of upload/download
+// must NOT conflate them.
+//
+// TODO(prompt-3): implement.
+func EncryptManifest(manifestJSON []byte, dek []byte) ([]byte, error) {
+	return nil, ErrNotImplemented
+}
+
+// DecryptManifest reverses EncryptManifest.
+//
+// TODO(prompt-3): implement.
+func DecryptManifest(blob []byte, dek []byte) ([]byte, error) {
+	return nil, ErrNotImplemented
+}

--- a/go-engine/internal/backup/crypto/kdf.go
+++ b/go-engine/internal/backup/crypto/kdf.go
@@ -1,0 +1,15 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package crypto
+
+// DeriveKeys runs Argon2id over the user's passphrase using the given salt
+// and parameters, producing 64 bytes split into ServerPassword (first 32) +
+// MasterKey (last 32). Contract §1, §2.
+//
+// The caller MUST verify params.MeetsFloor() returns true before calling.
+//
+// TODO(prompt-3): implement using golang.org/x/crypto/argon2.IDKey.
+func DeriveKeys(passphrase string, salt []byte, params KDFParams) (DerivedKeys, error) {
+	return DerivedKeys{}, ErrNotImplemented
+}

--- a/go-engine/internal/backup/crypto/recovery.go
+++ b/go-engine/internal/backup/crypto/recovery.go
@@ -1,0 +1,40 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package crypto
+
+// GenerateRecoveryKey produces a fresh 32-byte CSPRNG value encoded as a
+// 24-word BIP39 mnemonic. Contract §6.
+//
+// TODO(prompt-3): implement using a vetted BIP39 library; surface the
+// chosen library in the PROMPT 3 plan.
+func GenerateRecoveryKey() (RecoveryKey, error) {
+	return RecoveryKey{}, ErrNotImplemented
+}
+
+// ParseRecoveryPhrase decodes a BIP39 mnemonic of RecoveryMnemonicWords
+// words back to its 32-byte raw key. The phrase is normalised (whitespace
+// collapsed, case-folded per BIP39) and the checksum is validated.
+//
+// TODO(prompt-3): implement.
+func ParseRecoveryPhrase(phrase string) ([32]byte, error) {
+	return [32]byte{}, ErrNotImplemented
+}
+
+// DeriveRecoveryKey runs Argon2id over the recovery key bytes using the
+// supplied salt and parameters, producing the 32-byte recoveryKey used to
+// wrap the DEK on the second unlock path (contract §6).
+//
+// TODO(prompt-3): implement using golang.org/x/crypto/argon2.IDKey.
+func DeriveRecoveryKey(rk [32]byte, salt []byte, params KDFParams) ([32]byte, error) {
+	return [32]byte{}, ErrNotImplemented
+}
+
+// RecoveryKeyVerifier produces Argon2id(recoveryKey, salt) — the value the
+// server stores so it can confirm a recovery attempt without ever seeing
+// the recovery key itself (contract §6).
+//
+// TODO(prompt-3): implement.
+func RecoveryKeyVerifier(recoveryKey [32]byte, salt []byte, params KDFParams) ([]byte, error) {
+	return nil, ErrNotImplemented
+}

--- a/go-engine/internal/backup/crypto/types.go
+++ b/go-engine/internal/backup/crypto/types.go
@@ -1,0 +1,106 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package crypto
+
+// Locked sizes and constants from docs/contracts/hosted-backup-contract.md
+// sections 2 and 3. These values are part of the wire/protocol contract and
+// MUST NOT be changed without a schema bump.
+const (
+	// DEKSize is the length of a data-encryption-key in bytes (AES-256).
+	DEKSize = 32
+
+	// MasterKeySize is the length of the second half of the Argon2id output
+	// used to wrap the DEK.
+	MasterKeySize = 32
+
+	// ServerPasswordSize is the length of the first half of the Argon2id
+	// output sent to the server as the auth password.
+	ServerPasswordSize = 32
+
+	// SaltSize is the per-user KDF salt length in bytes (contract §2).
+	SaltSize = 16
+
+	// NonceSize is the AES-256-GCM nonce length in bytes (RFC 5116).
+	NonceSize = 12
+
+	// GCMTagSize is the AES-256-GCM authentication tag length in bytes
+	// (NIST SP 800-38D).
+	GCMTagSize = 16
+
+	// ChunkPlainSize is the plaintext chunk size in bytes — 4 MiB except
+	// the trailing chunk which may be shorter (contract §3).
+	ChunkPlainSize = 4 * 1024 * 1024
+
+	// EnvelopeVersion is the manifest envelope version (contract §3).
+	EnvelopeVersion = 1
+
+	// ManifestAAD is the 4-byte big-endian unsigned sentinel value used as
+	// AEAD AAD when encrypting/decrypting the manifest. Chosen because no
+	// real chunk index will ever take this value, binding the encrypted
+	// blob to the "manifest" role per contract §3. Distinct from — and
+	// independent of — the chunkIndex=-1 transport-layer flag used in API
+	// presigned-URL responses (contract §7).
+	ManifestAAD uint32 = 0xFFFFFFFF
+
+	// RecoveryMnemonicWords is the BIP39 word count required for recovery
+	// keys (contract §6).
+	RecoveryMnemonicWords = 24
+)
+
+// KDFParams matches the contract's Argon2id parameter object (§2).
+//
+// Memory is in KiB (so 65536 means 64 MiB). Iterations and Parallelism are
+// the t and p parameters from RFC 9106.
+type KDFParams struct {
+	Algorithm   string `json:"algorithm"`
+	Memory      uint32 `json:"memory"`
+	Iterations  uint32 `json:"iterations"`
+	Parallelism uint8  `json:"parallelism"`
+}
+
+// DefaultKDFParams returns the v1 locked parameter set.
+func DefaultKDFParams() KDFParams {
+	return KDFParams{
+		Algorithm:   "argon2id",
+		Memory:      65536,
+		Iterations:  3,
+		Parallelism: 4,
+	}
+}
+
+// MeetsFloor reports whether the supplied parameters meet or exceed the v1
+// locked floor. The engine refuses to derive keys with weaker parameters
+// regardless of what the server advertises (contract §2).
+func (p KDFParams) MeetsFloor() bool {
+	floor := DefaultKDFParams()
+	if p.Algorithm != floor.Algorithm {
+		return false
+	}
+	if p.Memory < floor.Memory {
+		return false
+	}
+	if p.Iterations < floor.Iterations {
+		return false
+	}
+	if p.Parallelism < floor.Parallelism {
+		return false
+	}
+	return true
+}
+
+// DerivedKeys is the 64-byte output of Argon2id(passphrase, salt) split into
+// the two roles defined in contract §1: ServerPassword (sent to the server)
+// and MasterKey (never leaves the device; wraps the DEK).
+type DerivedKeys struct {
+	ServerPassword [ServerPasswordSize]byte
+	MasterKey      [MasterKeySize]byte
+}
+
+// RecoveryKey holds a freshly minted recovery key and its BIP39 phrase.
+// The phrase is what the user is shown / saves; the bytes are what the
+// engine uses for KDF derivation downstream.
+type RecoveryKey struct {
+	Bytes  [32]byte
+	Phrase string
+}

--- a/go-engine/internal/backup/keychain/keychain.go
+++ b/go-engine/internal/backup/keychain/keychain.go
@@ -1,0 +1,40 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+// Package keychain provides a narrow Store/Load/Delete interface around the
+// platform-native secret store. Endstate Hosted Backup uses it to persist
+// the refresh token between CLI invocations (contract §5).
+//
+// The default implementation on Windows is the Credential Manager via
+// github.com/danieljoos/wincred. Callers that need to test the auth flow
+// without touching the real store can use NewMemory().
+package keychain
+
+import "errors"
+
+// ErrNotFound is returned by Load and Delete when no entry exists for the
+// requested account.
+var ErrNotFound = errors.New("keychain: account not found")
+
+// Keychain is the narrow surface every command handler interacts with.
+// Implementations MUST be safe for concurrent use by multiple goroutines.
+type Keychain interface {
+	// Store writes the secret bytes for the given account, overwriting any
+	// existing value. Implementations MUST NOT log the secret bytes.
+	Store(account string, secret []byte) error
+
+	// Load returns the secret bytes for the account or ErrNotFound if no
+	// entry exists.
+	Load(account string) ([]byte, error)
+
+	// Delete removes the entry for the account. Returns ErrNotFound if no
+	// entry exists. Idempotent at the caller level: callers may treat
+	// ErrNotFound as success when intent is "ensure absent".
+	Delete(account string) error
+}
+
+// AccountForUser returns the canonical account name for the refresh token
+// of a given userId. Centralised so command handlers don't drift.
+func AccountForUser(userID string) string {
+	return "endstate-refresh-" + userID
+}

--- a/go-engine/internal/backup/keychain/keychain_other.go
+++ b/go-engine/internal/backup/keychain/keychain_other.go
@@ -1,0 +1,29 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package keychain
+
+import "errors"
+
+// NewSystem on non-Windows platforms returns a Keychain that always errors.
+// Endstate is Windows-first; the engine refuses to store the refresh token
+// in plaintext fallback storage (contract §1, contract §5).
+func NewSystem() Keychain {
+	return &unsupportedKeychain{}
+}
+
+type unsupportedKeychain struct{}
+
+func (*unsupportedKeychain) Store(account string, secret []byte) error {
+	return errors.New("keychain: platform not supported (Windows only)")
+}
+
+func (*unsupportedKeychain) Load(account string) ([]byte, error) {
+	return nil, errors.New("keychain: platform not supported (Windows only)")
+}
+
+func (*unsupportedKeychain) Delete(account string) error {
+	return errors.New("keychain: platform not supported (Windows only)")
+}

--- a/go-engine/internal/backup/keychain/keychain_test.go
+++ b/go-engine/internal/backup/keychain/keychain_test.go
@@ -1,0 +1,100 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package keychain_test
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/backup/keychain"
+)
+
+func TestMemory_StoreLoadRoundTrip(t *testing.T) {
+	kc := keychain.NewMemory()
+	secret := []byte("rt-1234567890")
+	account := keychain.AccountForUser("user-1")
+
+	if err := kc.Store(account, secret); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+
+	got, err := kc.Load(account)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !bytes.Equal(got, secret) {
+		t.Errorf("Load = %q, want %q", got, secret)
+	}
+}
+
+func TestMemory_LoadMissing(t *testing.T) {
+	kc := keychain.NewMemory()
+	_, err := kc.Load("missing-account")
+	if !errors.Is(err, keychain.ErrNotFound) {
+		t.Errorf("Load missing: expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestMemory_StoreOverwrites(t *testing.T) {
+	kc := keychain.NewMemory()
+	account := keychain.AccountForUser("user-1")
+
+	_ = kc.Store(account, []byte("first"))
+	if err := kc.Store(account, []byte("second")); err != nil {
+		t.Fatalf("Store overwrite: %v", err)
+	}
+
+	got, err := kc.Load(account)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if string(got) != "second" {
+		t.Errorf("Load = %q, want %q", got, "second")
+	}
+}
+
+func TestMemory_DeleteRemoves(t *testing.T) {
+	kc := keychain.NewMemory()
+	account := keychain.AccountForUser("user-1")
+	_ = kc.Store(account, []byte("rt"))
+
+	if err := kc.Delete(account); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := kc.Load(account); !errors.Is(err, keychain.ErrNotFound) {
+		t.Errorf("Load after Delete: expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestMemory_DeleteMissingErrNotFound(t *testing.T) {
+	kc := keychain.NewMemory()
+	if err := kc.Delete("missing-account"); !errors.Is(err, keychain.ErrNotFound) {
+		t.Errorf("Delete missing: expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestMemory_StoreCopiesInput(t *testing.T) {
+	// Tampering with the caller's slice after Store must not leak into the
+	// stored value — defensive copy is part of the contract.
+	kc := keychain.NewMemory()
+	account := keychain.AccountForUser("user-1")
+	secret := []byte("rt-original")
+	_ = kc.Store(account, secret)
+
+	for i := range secret {
+		secret[i] = 0
+	}
+
+	got, _ := kc.Load(account)
+	if string(got) != "rt-original" {
+		t.Errorf("Load = %q, want %q (Store must defensively copy)", got, "rt-original")
+	}
+}
+
+func TestAccountForUser_Stable(t *testing.T) {
+	if got, want := keychain.AccountForUser("abc"), "endstate-refresh-abc"; got != want {
+		t.Errorf("AccountForUser(abc) = %q, want %q", got, want)
+	}
+}

--- a/go-engine/internal/backup/keychain/keychain_windows.go
+++ b/go-engine/internal/backup/keychain/keychain_windows.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package keychain
+
+import (
+	"errors"
+	"syscall"
+
+	"github.com/danieljoos/wincred"
+)
+
+// NewSystem returns the platform-native Keychain — Windows Credential
+// Manager via github.com/danieljoos/wincred.
+//
+// The contract requires no fallback to plaintext file storage: if the
+// Credential Manager is unavailable the caller surfaces the error rather
+// than silently degrading.
+func NewSystem() Keychain {
+	return &windowsKeychain{}
+}
+
+type windowsKeychain struct{}
+
+func (*windowsKeychain) Store(account string, secret []byte) error {
+	gc := wincred.NewGenericCredential(account)
+	gc.CredentialBlob = append([]byte(nil), secret...)
+	return gc.Write()
+}
+
+func (*windowsKeychain) Load(account string) ([]byte, error) {
+	gc, err := wincred.GetGenericCredential(account)
+	if err != nil {
+		if isNotFound(err) {
+			return nil, ErrNotFound
+		}
+		return nil, err
+	}
+	out := make([]byte, len(gc.CredentialBlob))
+	copy(out, gc.CredentialBlob)
+	return out, nil
+}
+
+func (*windowsKeychain) Delete(account string) error {
+	gc, err := wincred.GetGenericCredential(account)
+	if err != nil {
+		if isNotFound(err) {
+			return ErrNotFound
+		}
+		return err
+	}
+	if err := gc.Delete(); err != nil {
+		if isNotFound(err) {
+			return ErrNotFound
+		}
+		return err
+	}
+	return nil
+}
+
+// isNotFound reports whether err is the Win32 "element not found" sentinel
+// returned by Credential Manager when no entry exists for the target name.
+func isNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	// ERROR_NOT_FOUND = 1168 = 0x490
+	const errNotFound syscall.Errno = 1168
+	var en syscall.Errno
+	if errors.As(err, &en) {
+		return en == errNotFound
+	}
+	return false
+}

--- a/go-engine/internal/backup/keychain/memory.go
+++ b/go-engine/internal/backup/keychain/memory.go
@@ -1,0 +1,50 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package keychain
+
+import "sync"
+
+// memoryKeychain is a process-local in-memory Keychain used by tests and
+// the rare CLI flow that wants to opt out of platform persistence.
+type memoryKeychain struct {
+	mu      sync.Mutex
+	entries map[string][]byte
+}
+
+// NewMemory returns an in-memory Keychain. Useful in tests; never use in
+// production paths — secrets vanish when the process exits.
+func NewMemory() Keychain {
+	return &memoryKeychain{entries: map[string][]byte{}}
+}
+
+func (m *memoryKeychain) Store(account string, secret []byte) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	cp := make([]byte, len(secret))
+	copy(cp, secret)
+	m.entries[account] = cp
+	return nil
+}
+
+func (m *memoryKeychain) Load(account string) ([]byte, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	v, ok := m.entries[account]
+	if !ok {
+		return nil, ErrNotFound
+	}
+	cp := make([]byte, len(v))
+	copy(cp, v)
+	return cp, nil
+}
+
+func (m *memoryKeychain) Delete(account string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if _, ok := m.entries[account]; !ok {
+		return ErrNotFound
+	}
+	delete(m.entries, account)
+	return nil
+}

--- a/go-engine/internal/backup/oidc/oidc.go
+++ b/go-engine/internal/backup/oidc/oidc.go
@@ -1,0 +1,320 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+// Package oidc fetches and caches the OIDC discovery document advertised
+// by the substrate backend (or any self-host equivalent), validates the
+// `endstate_extensions` block, and exposes the discovered endpoints +
+// JWKS to the auth and client packages.
+//
+// Contract: docs/contracts/hosted-backup-contract.md §4 (JWKS), §9 (OIDC).
+package oidc
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+)
+
+// DefaultIssuerURL is the Endstate Cloud production issuer.
+const DefaultIssuerURL = "https://substratesystems.io"
+
+// DefaultAudience is the JWT `aud` claim Endstate Cloud signs.
+const DefaultAudience = "endstate-backup"
+
+// DiscoveryTTL is how long a successfully fetched discovery document is
+// reused before refetch (contract §9: cached for 1 hour).
+const DiscoveryTTL = time.Hour
+
+// JWKSTTL governs how long a fetched JWKS is reused. Kept distinct from
+// DiscoveryTTL so a key rotation triggered by the backend is picked up
+// faster than the discovery document.
+const JWKSTTL = 15 * time.Minute
+
+// Required minimums advertised by `endstate_extensions.min_kdf_params`.
+// Engine refuses to derive keys below these values regardless of what the
+// server says (contract §2 floor).
+const (
+	requiredKDFMemory      = 65536
+	requiredKDFIterations  = 3
+	requiredKDFParallelism = 4
+)
+
+// Document is the subset of the OIDC discovery response Endstate consumes.
+type Document struct {
+	Issuer                            string             `json:"issuer"`
+	JWKSURI                           string             `json:"jwks_uri"`
+	IDTokenSigningAlgValuesSupported  []string           `json:"id_token_signing_alg_values_supported"`
+	EndstateExtensions                EndstateExtensions `json:"endstate_extensions"`
+}
+
+// EndstateExtensions is the namespaced extension block required of any
+// backend Endstate talks to (contract §9). Missing or invalid → engine
+// refuses to use the backend.
+type EndstateExtensions struct {
+	AuthSignupEndpoint        string         `json:"auth_signup_endpoint"`
+	AuthLoginEndpoint         string         `json:"auth_login_endpoint"`
+	AuthRefreshEndpoint       string         `json:"auth_refresh_endpoint"`
+	AuthLogoutEndpoint        string         `json:"auth_logout_endpoint"`
+	AuthRecoverEndpoint       string         `json:"auth_recover_endpoint"`
+	BackupAPIBase             string         `json:"backup_api_base"`
+	SupportedKDFAlgorithms    []string       `json:"supported_kdf_algorithms"`
+	SupportedEnvelopeVersions []int          `json:"supported_envelope_versions"`
+	MinKDFParams              MinKDFParams   `json:"min_kdf_params"`
+}
+
+// MinKDFParams matches the contract §9 sub-block inside endstate_extensions.
+type MinKDFParams struct {
+	Memory      uint32 `json:"memory"`
+	Iterations  uint32 `json:"iterations"`
+	Parallelism uint8  `json:"parallelism"`
+}
+
+// JWKS is the JSON Web Key Set returned by the JWKS endpoint (contract §4).
+type JWKS struct {
+	Keys []JWK `json:"keys"`
+}
+
+// JWK is one EdDSA key in a JWKS. Endstate only supports EdDSA / Ed25519;
+// other kty/crv combinations are ignored on parse so a future migration
+// can add new keys to the set without breaking older clients.
+type JWK struct {
+	Kty string `json:"kty"`
+	Crv string `json:"crv"`
+	Kid string `json:"kid"`
+	Alg string `json:"alg"`
+	Use string `json:"use"`
+	X   string `json:"x"` // base64url-encoded Ed25519 public key
+}
+
+// HTTPDoer abstracts the http.Client surface oidc needs. Lets tests inject
+// httptest servers and explicit transports without depending on net/http
+// global state.
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// Client fetches and caches discovery + JWKS for one issuer. Safe for
+// concurrent use.
+type Client struct {
+	issuerURL string
+	http      HTTPDoer
+	now       func() time.Time
+
+	mu       sync.Mutex
+	doc      *Document
+	docExp   time.Time
+	jwks     *JWKS
+	jwksExp  time.Time
+	jwksURI  string // remembered separately so a stale jwks does not cross-pollute when the doc URL changes
+}
+
+// NewClient returns a discovery client for the given issuer URL.
+// Trailing slashes are tolerated.
+func NewClient(issuerURL string, httpDoer HTTPDoer) *Client {
+	if httpDoer == nil {
+		httpDoer = &http.Client{Timeout: 15 * time.Second}
+	}
+	return &Client{
+		issuerURL: strings.TrimRight(issuerURL, "/"),
+		http:      httpDoer,
+		now:       time.Now,
+	}
+}
+
+// IssuerURL returns the configured issuer URL with no trailing slash.
+func (c *Client) IssuerURL() string { return c.issuerURL }
+
+// Discovery returns the (possibly cached) discovery document.
+//
+// Errors:
+//   - any transport / parse / non-2xx response → wrapped error
+//   - empty or invalid endstate_extensions → ErrIncompatibleIssuer
+//
+// Callers map ErrIncompatibleIssuer → envelope.ErrBackendIncompatible and
+// other errors → envelope.ErrBackendUnreachable.
+func (c *Client) Discovery(ctx context.Context) (*Document, error) {
+	c.mu.Lock()
+	if c.doc != nil && c.now().Before(c.docExp) {
+		doc := c.doc
+		c.mu.Unlock()
+		return doc, nil
+	}
+	c.mu.Unlock()
+
+	doc, err := c.fetchDiscovery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateDocument(doc, c.issuerURL); err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	c.doc = doc
+	c.docExp = c.now().Add(DiscoveryTTL)
+	// If the JWKS URI changed, blow away any cached JWKS for the previous
+	// URI so we don't validate against stale keys.
+	if c.jwksURI != doc.JWKSURI {
+		c.jwks = nil
+		c.jwksExp = time.Time{}
+		c.jwksURI = doc.JWKSURI
+	}
+	c.mu.Unlock()
+	return doc, nil
+}
+
+// JWKS returns the (possibly cached) JWK set.
+func (c *Client) JWKS(ctx context.Context) (*JWKS, error) {
+	doc, err := c.Discovery(ctx)
+	if err != nil {
+		return nil, err
+	}
+	c.mu.Lock()
+	if c.jwks != nil && c.now().Before(c.jwksExp) {
+		ks := c.jwks
+		c.mu.Unlock()
+		return ks, nil
+	}
+	c.mu.Unlock()
+
+	keys, err := c.fetchJWKS(ctx, doc.JWKSURI)
+	if err != nil {
+		return nil, err
+	}
+
+	c.mu.Lock()
+	c.jwks = keys
+	c.jwksExp = c.now().Add(JWKSTTL)
+	c.mu.Unlock()
+	return keys, nil
+}
+
+// InvalidateJWKS forces the next JWKS call to refetch. Auth callers invoke
+// this after a signature verification failure so a freshly rotated key is
+// picked up without waiting out JWKSTTL.
+func (c *Client) InvalidateJWKS() {
+	c.mu.Lock()
+	c.jwks = nil
+	c.jwksExp = time.Time{}
+	c.mu.Unlock()
+}
+
+// SetClock overrides the time source. Used by tests.
+func (c *Client) SetClock(now func() time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = now
+}
+
+// ErrIncompatibleIssuer is returned by Discovery when the backend either
+// fails to advertise the `endstate_extensions` block or advertises values
+// the engine refuses (KDF floor, missing envelope version 1, missing
+// argon2id algorithm).
+var ErrIncompatibleIssuer = errors.New("oidc: backend does not advertise required endstate_extensions")
+
+func (c *Client) fetchDiscovery(ctx context.Context) (*Document, error) {
+	url := c.issuerURL + "/.well-known/openid-configuration"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("oidc: build discovery request: %w", err)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("oidc: fetch discovery: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("oidc: discovery returned status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("oidc: read discovery body: %w", err)
+	}
+	var doc Document
+	if err := json.Unmarshal(body, &doc); err != nil {
+		return nil, fmt.Errorf("oidc: decode discovery: %w", err)
+	}
+	return &doc, nil
+}
+
+func (c *Client) fetchJWKS(ctx context.Context, jwksURI string) (*JWKS, error) {
+	if jwksURI == "" {
+		return nil, errors.New("oidc: discovery document has empty jwks_uri")
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, jwksURI, nil)
+	if err != nil {
+		return nil, fmt.Errorf("oidc: build jwks request: %w", err)
+	}
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("oidc: fetch jwks: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		return nil, fmt.Errorf("oidc: jwks returned status %d", resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if err != nil {
+		return nil, fmt.Errorf("oidc: read jwks body: %w", err)
+	}
+	var keys JWKS
+	if err := json.Unmarshal(body, &keys); err != nil {
+		return nil, fmt.Errorf("oidc: decode jwks: %w", err)
+	}
+	return &keys, nil
+}
+
+func validateDocument(doc *Document, expectedIssuer string) error {
+	if doc.Issuer == "" || strings.TrimRight(doc.Issuer, "/") != expectedIssuer {
+		return fmt.Errorf("oidc: issuer mismatch (got %q, want %q)", doc.Issuer, expectedIssuer)
+	}
+	if doc.JWKSURI == "" {
+		return errors.New("oidc: discovery document missing jwks_uri")
+	}
+	if !contains(doc.IDTokenSigningAlgValuesSupported, "EdDSA") {
+		return errors.New("oidc: backend does not advertise EdDSA support")
+	}
+
+	ext := doc.EndstateExtensions
+	if ext.AuthSignupEndpoint == "" || ext.AuthLoginEndpoint == "" ||
+		ext.AuthRefreshEndpoint == "" || ext.AuthLogoutEndpoint == "" ||
+		ext.AuthRecoverEndpoint == "" || ext.BackupAPIBase == "" {
+		return ErrIncompatibleIssuer
+	}
+	if !contains(ext.SupportedKDFAlgorithms, "argon2id") {
+		return ErrIncompatibleIssuer
+	}
+	if !containsInt(ext.SupportedEnvelopeVersions, 1) {
+		return ErrIncompatibleIssuer
+	}
+	if ext.MinKDFParams.Memory < requiredKDFMemory ||
+		ext.MinKDFParams.Iterations < requiredKDFIterations ||
+		ext.MinKDFParams.Parallelism < requiredKDFParallelism {
+		return ErrIncompatibleIssuer
+	}
+	return nil
+}
+
+func contains(s []string, want string) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}
+
+func containsInt(s []int, want int) bool {
+	for _, v := range s {
+		if v == want {
+			return true
+		}
+	}
+	return false
+}

--- a/go-engine/internal/backup/oidc/oidc_test.go
+++ b/go-engine/internal/backup/oidc/oidc_test.go
@@ -1,0 +1,214 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package oidc_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/Artexis10/endstate/go-engine/internal/backup/oidc"
+)
+
+// validDiscovery returns a discovery document that satisfies all engine
+// requirements. Test cases mutate it to drive the negative paths.
+func validDiscovery(issuer string) oidc.Document {
+	return oidc.Document{
+		Issuer:                            issuer,
+		JWKSURI:                           issuer + "/api/.well-known/jwks.json",
+		IDTokenSigningAlgValuesSupported:  []string{"EdDSA"},
+		EndstateExtensions: oidc.EndstateExtensions{
+			AuthSignupEndpoint:        issuer + "/api/auth/signup",
+			AuthLoginEndpoint:         issuer + "/api/auth/login",
+			AuthRefreshEndpoint:       issuer + "/api/auth/refresh",
+			AuthLogoutEndpoint:        issuer + "/api/auth/logout",
+			AuthRecoverEndpoint:       issuer + "/api/auth/recover",
+			BackupAPIBase:             issuer + "/api/backups",
+			SupportedKDFAlgorithms:    []string{"argon2id"},
+			SupportedEnvelopeVersions: []int{1},
+			MinKDFParams:              oidc.MinKDFParams{Memory: 65536, Iterations: 3, Parallelism: 4},
+		},
+	}
+}
+
+// fakeBackend serves a discovery document the test mutates. The same
+// httptest server hosts the JWKS endpoint, so the issuer URL inside the
+// served body resolves back to the same listener address.
+func fakeBackend(t *testing.T, mutate func(d *oidc.Document)) (*httptest.Server, *int32, *int32) {
+	t.Helper()
+	var discoveryHits int32
+	var jwksHits int32
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&discoveryHits, 1)
+		doc := validDiscovery(srv.URL)
+		if mutate != nil {
+			mutate(&doc)
+		}
+		_ = json.NewEncoder(w).Encode(doc)
+	})
+	mux.HandleFunc("/api/.well-known/jwks.json", func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&jwksHits, 1)
+		_ = json.NewEncoder(w).Encode(oidc.JWKS{
+			Keys: []oidc.JWK{{Kty: "OKP", Crv: "Ed25519", Kid: "key-1", Alg: "EdDSA", Use: "sig", X: "AAAA"}},
+		})
+	})
+	t.Cleanup(srv.Close)
+	return srv, &discoveryHits, &jwksHits
+}
+
+func TestDiscovery_FetchAndCache(t *testing.T) {
+	srv, hits, _ := fakeBackend(t, nil)
+	c := oidc.NewClient(srv.URL, srv.Client())
+
+	doc, err := c.Discovery(context.Background())
+	if err != nil {
+		t.Fatalf("first fetch: %v", err)
+	}
+	if doc.Issuer != srv.URL {
+		t.Errorf("issuer = %q, want %q", doc.Issuer, srv.URL)
+	}
+
+	// Second call should hit the cache.
+	if _, err := c.Discovery(context.Background()); err != nil {
+		t.Fatalf("second fetch: %v", err)
+	}
+	if got := atomic.LoadInt32(hits); got != 1 {
+		t.Errorf("discovery hits = %d, want 1 (cache miss after first fetch)", got)
+	}
+}
+
+func TestDiscovery_TTLExpiry(t *testing.T) {
+	srv, hits, _ := fakeBackend(t, nil)
+	c := oidc.NewClient(srv.URL, srv.Client())
+
+	// Fixed clock the test advances explicitly.
+	now := time.Date(2026, 5, 2, 0, 0, 0, 0, time.UTC)
+	c.SetClock(func() time.Time { return now })
+
+	if _, err := c.Discovery(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(hits); got != 1 {
+		t.Errorf("hits = %d, want 1", got)
+	}
+
+	// Just before TTL expiry — still cached.
+	now = now.Add(oidc.DiscoveryTTL - time.Second)
+	if _, err := c.Discovery(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(hits); got != 1 {
+		t.Errorf("hits before TTL = %d, want 1", got)
+	}
+
+	// One second after TTL — refetched.
+	now = now.Add(2 * time.Second)
+	if _, err := c.Discovery(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(hits); got != 2 {
+		t.Errorf("hits after TTL = %d, want 2", got)
+	}
+}
+
+func TestDiscovery_RejectsMissingExtensions(t *testing.T) {
+	srv, _, _ := fakeBackend(t, func(d *oidc.Document) {
+		d.EndstateExtensions = oidc.EndstateExtensions{}
+	})
+	c := oidc.NewClient(srv.URL, srv.Client())
+	_, err := c.Discovery(context.Background())
+	if !errors.Is(err, oidc.ErrIncompatibleIssuer) {
+		t.Errorf("expected ErrIncompatibleIssuer, got %v", err)
+	}
+}
+
+func TestDiscovery_RejectsMissingArgon2id(t *testing.T) {
+	srv, _, _ := fakeBackend(t, func(d *oidc.Document) {
+		d.EndstateExtensions.SupportedKDFAlgorithms = []string{"argon2i"}
+	})
+	c := oidc.NewClient(srv.URL, srv.Client())
+	_, err := c.Discovery(context.Background())
+	if !errors.Is(err, oidc.ErrIncompatibleIssuer) {
+		t.Errorf("expected ErrIncompatibleIssuer, got %v", err)
+	}
+}
+
+func TestDiscovery_RejectsWeakerKDFFloor(t *testing.T) {
+	srv, _, _ := fakeBackend(t, func(d *oidc.Document) {
+		d.EndstateExtensions.MinKDFParams.Memory = 32768
+	})
+	c := oidc.NewClient(srv.URL, srv.Client())
+	_, err := c.Discovery(context.Background())
+	if !errors.Is(err, oidc.ErrIncompatibleIssuer) {
+		t.Errorf("expected ErrIncompatibleIssuer for weak memory floor, got %v", err)
+	}
+}
+
+func TestDiscovery_RejectsMissingEnvelopeV1(t *testing.T) {
+	srv, _, _ := fakeBackend(t, func(d *oidc.Document) {
+		d.EndstateExtensions.SupportedEnvelopeVersions = []int{2}
+	})
+	c := oidc.NewClient(srv.URL, srv.Client())
+	_, err := c.Discovery(context.Background())
+	if !errors.Is(err, oidc.ErrIncompatibleIssuer) {
+		t.Errorf("expected ErrIncompatibleIssuer when v1 envelope missing, got %v", err)
+	}
+}
+
+func TestDiscovery_RejectsIssuerMismatch(t *testing.T) {
+	srv, _, _ := fakeBackend(t, func(d *oidc.Document) {
+		d.Issuer = "https://attacker.example.com"
+	})
+	c := oidc.NewClient(srv.URL, srv.Client())
+	_, err := c.Discovery(context.Background())
+	if err == nil || errors.Is(err, oidc.ErrIncompatibleIssuer) {
+		t.Errorf("expected non-incompatible issuer mismatch error, got %v", err)
+	}
+}
+
+func TestDiscovery_NetworkErrorBubbles(t *testing.T) {
+	c := oidc.NewClient("http://127.0.0.1:1", &http.Client{Timeout: 100 * time.Millisecond})
+	_, err := c.Discovery(context.Background())
+	if err == nil {
+		t.Fatal("expected error on unreachable backend")
+	}
+}
+
+func TestJWKS_FetchAndCache(t *testing.T) {
+	srv, _, jHits := fakeBackend(t, nil)
+	c := oidc.NewClient(srv.URL, srv.Client())
+
+	if _, err := c.JWKS(context.Background()); err != nil {
+		t.Fatalf("first jwks fetch: %v", err)
+	}
+	if _, err := c.JWKS(context.Background()); err != nil {
+		t.Fatalf("second jwks fetch: %v", err)
+	}
+	if got := atomic.LoadInt32(jHits); got != 1 {
+		t.Errorf("jwks hits = %d, want 1 (second call should be cached)", got)
+	}
+}
+
+func TestJWKS_InvalidatePicksUpNewKey(t *testing.T) {
+	srv, _, jHits := fakeBackend(t, nil)
+	c := oidc.NewClient(srv.URL, srv.Client())
+
+	if _, err := c.JWKS(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	c.InvalidateJWKS()
+	if _, err := c.JWKS(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if got := atomic.LoadInt32(jHits); got != 2 {
+		t.Errorf("jwks hits after invalidation = %d, want 2", got)
+	}
+}

--- a/go-engine/internal/commands/account.go
+++ b/go-engine/internal/commands/account.go
@@ -1,0 +1,39 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// AccountFlags holds the parsed CLI flags for `endstate account`.
+//
+// All `account *` subcommands operate on the Hosted Backup account
+// represented by the cached refresh token (contract §12).
+type AccountFlags struct {
+	Subcommand string
+	Args       []string
+	Confirm    bool
+	Events     string
+}
+
+// RunAccount dispatches to the appropriate account subcommand handler.
+//
+// PR 1 (auth-client) wires the dispatcher only; the `delete` handler
+// ships with `add-backup-storage-client` so account purge can coordinate
+// with backup deletion in a single change.
+func RunAccount(flags AccountFlags) (interface{}, *envelope.Error) {
+	switch flags.Subcommand {
+	case "delete":
+		return nil, envelope.NewError(envelope.ErrInternalError,
+			"account delete is not yet implemented in this engine build").
+			WithRemediation("Update the engine; this subcommand ships with add-backup-storage-client.")
+	case "":
+		return nil, envelope.NewError(envelope.ErrInternalError,
+			"account requires a subcommand (delete)")
+	default:
+		return nil, envelope.NewError(envelope.ErrInternalError,
+			"unknown account subcommand: "+flags.Subcommand)
+	}
+}

--- a/go-engine/internal/commands/backup.go
+++ b/go-engine/internal/commands/backup.go
@@ -1,0 +1,87 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"github.com/Artexis10/endstate/go-engine/internal/backup"
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// newBackupStack is the factory each backup command handler calls to
+// build its component stack. Replaceable from tests via
+// ReplaceBackupStackFactoryForTest to inject a memory keychain and a
+// test-controlled issuer.
+var newBackupStack func() *backup.Stack = backup.NewStack
+
+// ReplaceBackupStackFactoryForTest swaps in a test factory and returns
+// a cleanup func that restores the previous one.
+func ReplaceBackupStackFactoryForTest(f func() *backup.Stack) func() {
+	prev := newBackupStack
+	newBackupStack = f
+	return func() { newBackupStack = prev }
+}
+
+// BackupFlags holds the parsed CLI flags for the `endstate backup` command tree.
+//
+// The command tree is positional: `endstate backup <subcommand> [flags]`.
+// `Subcommand` carries which leaf is being invoked; `Args` carries any
+// remaining positional arguments. Stdin is the canonical secret-input
+// channel — passphrases and recovery keys are never accepted as flags.
+type BackupFlags struct {
+	Subcommand string
+	Args       []string
+
+	// Email is the --email flag (login, recover).
+	Email string
+
+	// BackupID identifies an existing backup (versions, push, pull, delete).
+	BackupID string
+
+	// VersionID identifies a specific version of a backup (pull, delete-version).
+	VersionID string
+
+	// Profile is the --profile flag (push), pointing at the manifest/zip to upload.
+	Profile string
+
+	// Name is the --name flag (push), the human-readable label for the backup.
+	Name string
+
+	// To is the --to flag (pull), the directory the decrypted profile is
+	// written into.
+	To string
+
+	// Confirm is the --confirm flag required for destructive operations
+	// (delete, delete-version).
+	Confirm bool
+
+	// Events controls streaming event output ("jsonl" enables it).
+	Events string
+}
+
+// RunBackup dispatches to the appropriate backup subcommand handler.
+//
+// PR 1 (auth-client) wires login, logout, and status. The remaining
+// subcommands — list, versions, push, pull, delete, delete-version,
+// recover — ship in `add-backup-storage-client`.
+func RunBackup(flags BackupFlags) (interface{}, *envelope.Error) {
+	switch flags.Subcommand {
+	case "login":
+		return runBackupLogin(flags)
+	case "logout":
+		return runBackupLogout(flags)
+	case "status":
+		return runBackupStatus(flags)
+	case "":
+		return nil, envelope.NewError(envelope.ErrInternalError,
+			"backup requires a subcommand (login, logout, status)")
+	case "list", "versions", "push", "pull", "delete", "delete-version", "recover":
+		return nil, envelope.NewError(envelope.ErrInternalError,
+			"backup subcommand not yet implemented in this engine build: "+flags.Subcommand).
+			WithRemediation("Update the engine; this subcommand ships with add-backup-storage-client.")
+	default:
+		return nil, envelope.NewError(envelope.ErrInternalError,
+			"unknown backup subcommand: "+flags.Subcommand).
+			WithRemediation("Run `endstate backup --help` for the supported list.")
+	}
+}

--- a/go-engine/internal/commands/backup_login.go
+++ b/go-engine/internal/commands/backup_login.go
@@ -1,0 +1,101 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/Artexis10/endstate/go-engine/internal/backup/crypto"
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// LoginResult is the data payload for a successful `backup login` call.
+type LoginResult struct {
+	UserID             string `json:"userId"`
+	Email              string `json:"email"`
+	SubscriptionStatus string `json:"subscriptionStatus,omitempty"`
+}
+
+// loginPassphraseReader is the function used to read the passphrase. Tests
+// override it via WithPassphraseReader.
+var loginPassphraseReader = readPassphraseFromStdin
+
+// WithPassphraseReader returns a deferred function that restores the
+// previous reader. Tests use this seam to inject a deterministic
+// passphrase without touching os.Stdin.
+func WithPassphraseReader(fn func(io.Reader) (string, error)) func() {
+	prev := loginPassphraseReader
+	loginPassphraseReader = fn
+	return func() { loginPassphraseReader = prev }
+}
+
+func runBackupLogin(flags BackupFlags) (interface{}, *envelope.Error) {
+	if strings.TrimSpace(flags.Email) == "" {
+		return nil, envelope.NewError(envelope.ErrInternalError,
+			"backup login requires --email <address>").
+			WithRemediation("Pass --email <address>; the passphrase is read from stdin.")
+	}
+
+	passphrase, err := loginPassphraseReader(os.Stdin)
+	if err != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, "backup login: read passphrase: "+err.Error()).
+			WithRemediation("Pipe the passphrase to stdin or run from an interactive terminal.")
+	}
+	if passphrase == "" {
+		return nil, envelope.NewError(envelope.ErrInternalError,
+			"backup login: empty passphrase").
+			WithRemediation("Provide a non-empty passphrase via stdin.")
+	}
+
+	a := newBackupStack().Auth
+	ctx := context.Background()
+
+	pre, envErr := a.PreHandshake(ctx, flags.Email)
+	if envErr != nil {
+		return nil, envErr
+	}
+
+	// Derive serverPassword + masterKey via Argon2id. STUB until PROMPT 3
+	// — returns crypto.ErrNotImplemented.
+	if _, kerr := crypto.DeriveKeys(passphrase, []byte(pre.Salt), pre.KDFParams); kerr != nil {
+		if errors.Is(kerr, crypto.ErrNotImplemented) {
+			return nil, envelope.NewError(envelope.ErrInternalError,
+				"crypto module not yet implemented; login orchestration ready, key derivation lands in a follow-up change").
+				WithDetail(map[string]string{"phase": "kdf"}).
+				WithRemediation("Wait for the engine release that includes the crypto module (PROMPT 3).")
+		}
+		return nil, envelope.NewError(envelope.ErrInternalError, "derive keys: "+kerr.Error())
+	}
+
+	// (Unreachable in PR 1 — the lines below describe the post-PROMPT 3
+	// flow.) Once DeriveKeys returns real bytes, the orchestration is:
+	//
+	//   resp, envErr := a.CompleteLogin(ctx, flags.Email, derived.ServerPassword[:])
+	//   if envErr != nil { return nil, envErr }
+	//   dek, _ := crypto.UnwrapDEK([]byte(resp.WrappedDEK), derived.MasterKey)
+	//   _ = dek // cached on session for push/pull
+	//   return &LoginResult{UserID: resp.UserID, Email: flags.Email,
+	//       SubscriptionStatus: resp.SubscriptionStatus}, nil
+	//
+	// The ErrNotImplemented branch above returns before reaching here, so
+	// no compile-time dead code.
+	return nil, envelope.NewError(envelope.ErrInternalError, "login: unreachable post-stub")
+}
+
+// readPassphraseFromStdin reads a single line (terminated by \n) from r
+// and returns it with the trailing newline stripped. Suitable for both
+// interactive use (Enter terminates) and piped input.
+func readPassphraseFromStdin(r io.Reader) (string, error) {
+	br := bufio.NewReader(r)
+	line, err := br.ReadString('\n')
+	if err != nil && err != io.EOF {
+		return "", err
+	}
+	return strings.TrimRight(strings.TrimRight(line, "\n"), "\r"), nil
+}

--- a/go-engine/internal/commands/backup_logout.go
+++ b/go-engine/internal/commands/backup_logout.go
@@ -1,0 +1,23 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"context"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// LogoutResult is the data payload for a successful `backup logout` call.
+type LogoutResult struct {
+	SignedOut bool `json:"signedOut"`
+}
+
+func runBackupLogout(flags BackupFlags) (interface{}, *envelope.Error) {
+	a := newBackupStack().Auth
+	if err := a.Logout(context.Background()); err != nil {
+		return nil, err
+	}
+	return &LogoutResult{SignedOut: true}, nil
+}

--- a/go-engine/internal/commands/backup_status.go
+++ b/go-engine/internal/commands/backup_status.go
@@ -1,0 +1,61 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"context"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// StatusResult is the data payload for `backup status`.
+//
+// Field shape locked in the plan §"Envelope shapes (Question 6)":
+//
+//   {
+//     "signedIn":            bool,
+//     "email":               string?,
+//     "userId":              string?,
+//     "subscriptionStatus":  string?,
+//     "issuerUrl":           string,
+//     "lastBackupAt":        string?
+//   }
+//
+// Optional fields are present only when the user is signed in. issuerUrl
+// is always present so the GUI can show "you're configured to talk to <X>"
+// even when signed out.
+type StatusResult struct {
+	SignedIn           bool   `json:"signedIn"`
+	Email              string `json:"email,omitempty"`
+	UserID             string `json:"userId,omitempty"`
+	SubscriptionStatus string `json:"subscriptionStatus,omitempty"`
+	IssuerURL          string `json:"issuerUrl"`
+	LastBackupAt       string `json:"lastBackupAt,omitempty"`
+}
+
+func runBackupStatus(flags BackupFlags) (interface{}, *envelope.Error) {
+	a := newBackupStack().Auth
+	res := &StatusResult{
+		IssuerURL: a.Issuer().URL,
+	}
+
+	// If we have nothing in the keychain to talk to, return signed-out
+	// without making any network calls.
+	if !a.Session().SignedIn() {
+		return res, nil
+	}
+
+	// Hit /api/account/me to confirm the session is live and read the
+	// authoritative subscription status. Any error here propagates to the
+	// caller — the user wants to know if the connection is broken.
+	me, err := a.Me(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	res.SignedIn = true
+	res.Email = me.Email
+	res.UserID = me.UserID
+	res.SubscriptionStatus = me.SubscriptionStatus
+	return res, nil
+}

--- a/go-engine/internal/commands/backup_test.go
+++ b/go-engine/internal/commands/backup_test.go
@@ -1,0 +1,317 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands_test
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/Artexis10/endstate/go-engine/internal/backup"
+	"github.com/Artexis10/endstate/go-engine/internal/backup/auth"
+	"github.com/Artexis10/endstate/go-engine/internal/backup/client"
+	"github.com/Artexis10/endstate/go-engine/internal/backup/keychain"
+	"github.com/Artexis10/endstate/go-engine/internal/backup/oidc"
+	"github.com/Artexis10/endstate/go-engine/internal/commands"
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// fakeBackend mounts the discovery + auth + account routes on an httptest
+// server. Subset of the auth-package fixture, replicated here so the
+// commands tests stay independent.
+func fakeBackend(t *testing.T) *httptest.Server {
+	t.Helper()
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(oidc.Document{
+			Issuer:                            srv.URL,
+			JWKSURI:                           srv.URL + "/api/.well-known/jwks.json",
+			IDTokenSigningAlgValuesSupported:  []string{"EdDSA"},
+			EndstateExtensions: oidc.EndstateExtensions{
+				AuthSignupEndpoint:        srv.URL + "/api/auth/signup",
+				AuthLoginEndpoint:         srv.URL + "/api/auth/login",
+				AuthRefreshEndpoint:       srv.URL + "/api/auth/refresh",
+				AuthLogoutEndpoint:        srv.URL + "/api/auth/logout",
+				AuthRecoverEndpoint:       srv.URL + "/api/auth/recover",
+				BackupAPIBase:             srv.URL + "/api/backups",
+				SupportedKDFAlgorithms:    []string{"argon2id"},
+				SupportedEnvelopeVersions: []int{1},
+				MinKDFParams:              oidc.MinKDFParams{Memory: 65536, Iterations: 3, Parallelism: 4},
+			},
+		})
+	})
+	mux.HandleFunc("/api/.well-known/jwks.json", func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(oidc.JWKS{Keys: []oidc.JWK{}})
+	})
+	mux.HandleFunc("/api/auth/login", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "1.0")
+		var raw map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&raw)
+		if _, hasPwd := raw["serverPassword"]; hasPwd {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"userId":             "user-1",
+				"accessToken":        "access-1",
+				"refreshToken":       "refresh-1",
+				"wrappedDEK":         "AAAA",
+				"subscriptionStatus": "active",
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"salt": "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"kdfParams": map[string]interface{}{
+				"algorithm":   "argon2id",
+				"memory":      65536,
+				"iterations":  3,
+				"parallelism": 4,
+			},
+		})
+	})
+	mux.HandleFunc("/api/auth/logout", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "1.0")
+		_ = json.NewEncoder(w).Encode(map[string]bool{"ok": true})
+	})
+	mux.HandleFunc("/api/account/me", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "1.0")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"userId":             "user-1",
+			"email":              "user@example.com",
+			"subscriptionStatus": "active",
+			"createdAt":          "2026-05-02T00:00:00Z",
+		})
+	})
+	t.Cleanup(srv.Close)
+	return srv
+}
+
+// stackForBackend builds a Stack wired to the fake backend with the
+// supplied keychain. Returned so tests can pre-seed or assert state.
+func stackForBackend(srv *httptest.Server, kc keychain.Keychain) *backup.Stack {
+	store := auth.NewSessionStore(kc)
+	oc := oidc.NewClient(srv.URL, srv.Client())
+	rp := client.RetryPolicy{MaxRetries: 0, InitialWait: time.Millisecond, MaxWait: time.Millisecond}
+	hc := client.New(client.Options{Tokens: store, Retry: &rp})
+	a := auth.NewAuthenticator(auth.Issuer{URL: srv.URL, Audience: "endstate-backup"}, oc, hc, store)
+	return &backup.Stack{
+		Auth:    a,
+		Issuer:  srv.URL,
+		OIDC:    oc,
+		HTTP:    hc,
+		Session: store,
+	}
+}
+
+func TestBackupStatus_SignedOut(t *testing.T) {
+	srv := fakeBackend(t)
+	kc := keychain.NewMemory()
+	restore := commands.ReplaceBackupStackFactoryForTest(func() *backup.Stack {
+		return stackForBackend(srv, kc)
+	})
+	defer restore()
+
+	data, err := commands.RunBackup(commands.BackupFlags{Subcommand: "status"})
+	if err != nil {
+		t.Fatalf("status signed-out: %+v", err)
+	}
+	res, ok := data.(*commands.StatusResult)
+	if !ok {
+		t.Fatalf("data type = %T, want *StatusResult", data)
+	}
+	if res.SignedIn {
+		t.Error("expected signedIn=false")
+	}
+	if res.IssuerURL != srv.URL {
+		t.Errorf("issuerUrl = %q, want %q", res.IssuerURL, srv.URL)
+	}
+	if res.Email != "" || res.UserID != "" || res.SubscriptionStatus != "" {
+		t.Errorf("expected empty optional fields when signed out, got %+v", res)
+	}
+}
+
+func TestBackupStatus_SignedIn(t *testing.T) {
+	srv := fakeBackend(t)
+	kc := keychain.NewMemory()
+	// Pre-seed: a session for user-1 with a refresh token in the keychain.
+	if err := kc.Store(keychain.AccountForUser("user-1"), []byte("refresh-1")); err != nil {
+		t.Fatal(err)
+	}
+
+	st := stackForBackend(srv, kc)
+	if err := st.Auth.Session().Hydrate("user-1"); err != nil {
+		t.Fatal(err)
+	}
+
+	restore := commands.ReplaceBackupStackFactoryForTest(func() *backup.Stack { return st })
+	defer restore()
+
+	data, envErr := commands.RunBackup(commands.BackupFlags{Subcommand: "status"})
+	if envErr != nil {
+		t.Fatalf("status signed-in: %+v", envErr)
+	}
+	res := data.(*commands.StatusResult)
+	if !res.SignedIn {
+		t.Error("expected signedIn=true after Hydrate")
+	}
+	if res.Email != "user@example.com" {
+		t.Errorf("email = %q, want user@example.com", res.Email)
+	}
+	if res.SubscriptionStatus != "active" {
+		t.Errorf("subscription = %q, want active", res.SubscriptionStatus)
+	}
+}
+
+func TestBackupLogin_RequiresEmail(t *testing.T) {
+	_, err := commands.RunBackup(commands.BackupFlags{Subcommand: "login"})
+	if err == nil || err.Code != envelope.ErrInternalError {
+		t.Fatalf("got %+v, want INTERNAL_ERROR", err)
+	}
+	if !strings.Contains(err.Message, "--email") {
+		t.Errorf("message %q should mention --email", err.Message)
+	}
+}
+
+func TestBackupLogin_EmptyPassphrase(t *testing.T) {
+	defer commands.WithPassphraseReader(func(io.Reader) (string, error) { return "", nil })()
+	_, err := commands.RunBackup(commands.BackupFlags{Subcommand: "login", Email: "user@example.com"})
+	if err == nil || err.Code != envelope.ErrInternalError {
+		t.Fatalf("got %+v, want INTERNAL_ERROR", err)
+	}
+	if !strings.Contains(err.Message, "passphrase") {
+		t.Errorf("message %q should mention passphrase", err.Message)
+	}
+}
+
+func TestBackupLogin_PreHandshakeOK_CryptoStubBlocks(t *testing.T) {
+	srv := fakeBackend(t)
+	kc := keychain.NewMemory()
+	restore := commands.ReplaceBackupStackFactoryForTest(func() *backup.Stack {
+		return stackForBackend(srv, kc)
+	})
+	defer restore()
+	defer commands.WithPassphraseReader(func(io.Reader) (string, error) { return "secret-pass", nil })()
+
+	_, err := commands.RunBackup(commands.BackupFlags{Subcommand: "login", Email: "user@example.com"})
+	if err == nil {
+		t.Fatal("expected an error from the crypto stub")
+	}
+	if err.Code != envelope.ErrInternalError {
+		t.Errorf("code = %q, want INTERNAL_ERROR", err.Code)
+	}
+	if !strings.Contains(err.Message, "crypto") || !strings.Contains(err.Message, "not yet implemented") {
+		t.Errorf("message %q should reference the crypto stub", err.Message)
+	}
+}
+
+func TestBackupLogin_BackendUnreachable(t *testing.T) {
+	// Authenticator pointing at a closed port → BACKEND_UNREACHABLE.
+	store := auth.NewSessionStore(keychain.NewMemory())
+	oc := oidc.NewClient("http://127.0.0.1:1", &http.Client{Timeout: 100 * time.Millisecond})
+	rp := client.RetryPolicy{MaxRetries: 0, InitialWait: time.Millisecond, MaxWait: time.Millisecond}
+	hc := client.New(client.Options{Tokens: store, Retry: &rp})
+	a := auth.NewAuthenticator(auth.Issuer{URL: "http://127.0.0.1:1"}, oc, hc, store)
+	stack := &backup.Stack{Auth: a, Issuer: "http://127.0.0.1:1", OIDC: oc, HTTP: hc, Session: store}
+
+	restore := commands.ReplaceBackupStackFactoryForTest(func() *backup.Stack { return stack })
+	defer restore()
+	defer commands.WithPassphraseReader(func(io.Reader) (string, error) { return "secret-pass", nil })()
+
+	_, err := commands.RunBackup(commands.BackupFlags{Subcommand: "login", Email: "user@example.com"})
+	if err == nil || err.Code != envelope.ErrBackendUnreachable {
+		t.Errorf("got %+v, want BACKEND_UNREACHABLE", err)
+	}
+}
+
+func TestBackupLogout_NothingPersistedIsIdempotent(t *testing.T) {
+	srv := fakeBackend(t)
+	kc := keychain.NewMemory()
+	restore := commands.ReplaceBackupStackFactoryForTest(func() *backup.Stack {
+		return stackForBackend(srv, kc)
+	})
+	defer restore()
+
+	data, err := commands.RunBackup(commands.BackupFlags{Subcommand: "logout"})
+	if err != nil {
+		t.Fatalf("logout when signed-out: %+v", err)
+	}
+	if !data.(*commands.LogoutResult).SignedOut {
+		t.Errorf("expected signedOut=true")
+	}
+}
+
+func TestBackupLogout_ClearsPersistedSession(t *testing.T) {
+	srv := fakeBackend(t)
+	kc := keychain.NewMemory()
+	if err := kc.Store(keychain.AccountForUser("user-1"), []byte("refresh-1")); err != nil {
+		t.Fatal(err)
+	}
+	st := stackForBackend(srv, kc)
+	if err := st.Auth.Session().Hydrate("user-1"); err != nil {
+		t.Fatal(err)
+	}
+
+	restore := commands.ReplaceBackupStackFactoryForTest(func() *backup.Stack { return st })
+	defer restore()
+
+	if _, err := commands.RunBackup(commands.BackupFlags{Subcommand: "logout"}); err != nil {
+		t.Fatalf("logout: %+v", err)
+	}
+	if _, err := kc.Load(keychain.AccountForUser("user-1")); !errors.Is(err, keychain.ErrNotFound) {
+		t.Errorf("keychain entry remained after logout: %v", err)
+	}
+}
+
+func TestRunBackup_RequiresSubcommand(t *testing.T) {
+	_, err := commands.RunBackup(commands.BackupFlags{})
+	if err == nil || err.Code != envelope.ErrInternalError {
+		t.Errorf("got %+v, want INTERNAL_ERROR", err)
+	}
+}
+
+func TestRunAccount_DeleteStubbedInPR1(t *testing.T) {
+	// PR 1 (auth-client) wires the dispatcher only; the real handler
+	// ships with add-backup-storage-client. Until then `account delete`
+	// surfaces a clear "not yet implemented" envelope.
+	_, err := commands.RunAccount(commands.AccountFlags{Subcommand: "delete", Confirm: true})
+	if err == nil || err.Code != envelope.ErrInternalError {
+		t.Fatalf("got %+v, want INTERNAL_ERROR", err)
+	}
+	if !strings.Contains(err.Message, "not yet implemented") {
+		t.Errorf("message %q should reference the storage-client follow-up", err.Message)
+	}
+}
+
+func TestCapabilities_AdvertisesHostedBackup(t *testing.T) {
+	t.Setenv("ENDSTATE_OIDC_ISSUER_URL", "https://example-host.test")
+	t.Setenv("ENDSTATE_OIDC_AUDIENCE", "endstate-backup-test")
+
+	data, err := commands.RunCapabilities()
+	if err != nil {
+		t.Fatalf("RunCapabilities: %+v", err)
+	}
+	caps := data.(commands.CapabilitiesData)
+	if !caps.Features.HostedBackup.Supported {
+		t.Error("hostedBackup.supported = false, want true")
+	}
+	if caps.Features.HostedBackup.IssuerURL != "https://example-host.test" {
+		t.Errorf("issuerUrl = %q (want env-overridden value)", caps.Features.HostedBackup.IssuerURL)
+	}
+	if caps.Features.HostedBackup.Audience != "endstate-backup-test" {
+		t.Errorf("audience = %q (want env-overridden value)", caps.Features.HostedBackup.Audience)
+	}
+	if caps.Features.HostedBackup.MinSchemaVersion != "1.0" {
+		t.Errorf("minSchemaVersion = %q, want 1.0", caps.Features.HostedBackup.MinSchemaVersion)
+	}
+	if _, ok := caps.Commands["backup"]; !ok {
+		t.Error("Commands map missing 'backup'")
+	}
+	if _, ok := caps.Commands["account"]; !ok {
+		t.Error("Commands map missing 'account'")
+	}
+}

--- a/go-engine/internal/commands/capabilities.go
+++ b/go-engine/internal/commands/capabilities.go
@@ -7,6 +7,7 @@
 package commands
 
 import (
+	"github.com/Artexis10/endstate/go-engine/internal/backup"
 	"github.com/Artexis10/endstate/go-engine/internal/envelope"
 )
 
@@ -38,11 +39,23 @@ type CommandInfo struct {
 
 // FeaturesInfo is the features capability map returned in the capabilities response.
 type FeaturesInfo struct {
-	Streaming       bool `json:"streaming"`
-	ParallelInstall bool `json:"parallelInstall"`
-	ConfigModules   bool `json:"configModules"`
-	JSONOutput      bool `json:"jsonOutput"`
-	ManualApps      bool `json:"manualApps"`
+	Streaming       bool                 `json:"streaming"`
+	ParallelInstall bool                 `json:"parallelInstall"`
+	ConfigModules   bool                 `json:"configModules"`
+	JSONOutput      bool                 `json:"jsonOutput"`
+	ManualApps      bool                 `json:"manualApps"`
+	HostedBackup    HostedBackupFeature  `json:"hostedBackup"`
+}
+
+// HostedBackupFeature is the GUI-facing capability advertisement for the
+// Hosted Backup feature. The GUI gates its hosted-backup UI on this block
+// (contract §11). Issuer/Audience are populated at runtime so a self-host
+// configuration shows up correctly without rebuilding the engine.
+type HostedBackupFeature struct {
+	Supported        bool   `json:"supported"`
+	MinSchemaVersion string `json:"minSchemaVersion"`
+	IssuerURL        string `json:"issuerUrl"`
+	Audience         string `json:"audience"`
 }
 
 // PlatformInfo describes the host operating system and available package manager
@@ -114,6 +127,14 @@ func RunCapabilities() (interface{}, *envelope.Error) {
 				Supported: true,
 				Flags:     []string{"--json", "--events"},
 			},
+			"backup": {
+				Supported: true,
+				Flags:     []string{"--email", "--backup-id", "--version-id", "--profile", "--name", "--to", "--confirm", "--json", "--events"},
+			},
+			"account": {
+				Supported: true,
+				Flags:     []string{"--confirm", "--json"},
+			},
 		},
 		Features: FeaturesInfo{
 			Streaming:       false,
@@ -121,6 +142,12 @@ func RunCapabilities() (interface{}, *envelope.Error) {
 			ConfigModules:   true,
 			JSONOutput:      true,
 			ManualApps:      true,
+			HostedBackup: HostedBackupFeature{
+				Supported:        true,
+				MinSchemaVersion: "1.0",
+				IssuerURL:        backup.IssuerURL(),
+				Audience:         backup.Audience(),
+			},
 		},
 		Platform: PlatformInfo{
 			OS:      "windows",

--- a/go-engine/internal/envelope/envelope_test.go
+++ b/go-engine/internal/envelope/envelope_test.go
@@ -106,6 +106,14 @@ func TestErrorCodeSerialization(t *testing.T) {
 		{envelope.ErrPermissionDenied, "PERMISSION_DENIED"},
 		{envelope.ErrInternalError, "INTERNAL_ERROR"},
 		{envelope.ErrSchemaIncompatible, "SCHEMA_INCOMPATIBLE"},
+		{envelope.ErrAuthRequired, "AUTH_REQUIRED"},
+		{envelope.ErrSubscriptionRequired, "SUBSCRIPTION_REQUIRED"},
+		{envelope.ErrNotFound, "NOT_FOUND"},
+		{envelope.ErrRateLimited, "RATE_LIMITED"},
+		{envelope.ErrBackendError, "BACKEND_ERROR"},
+		{envelope.ErrBackendUnreachable, "BACKEND_UNREACHABLE"},
+		{envelope.ErrBackendIncompatible, "BACKEND_INCOMPATIBLE"},
+		{envelope.ErrStorageQuotaExceeded, "STORAGE_QUOTA_EXCEEDED"},
 	}
 
 	for _, tc := range cases {

--- a/go-engine/internal/envelope/errors.go
+++ b/go-engine/internal/envelope/errors.go
@@ -24,6 +24,17 @@ const (
 	ErrPermissionDenied       ErrorCode = "PERMISSION_DENIED"
 	ErrInternalError          ErrorCode = "INTERNAL_ERROR"
 	ErrSchemaIncompatible     ErrorCode = "SCHEMA_INCOMPATIBLE"
+
+	// Hosted-backup error codes. Mapped from substrate backend HTTP responses
+	// per docs/contracts/hosted-backup-contract.md and cli-json-contract.md.
+	ErrAuthRequired         ErrorCode = "AUTH_REQUIRED"
+	ErrSubscriptionRequired ErrorCode = "SUBSCRIPTION_REQUIRED"
+	ErrNotFound             ErrorCode = "NOT_FOUND"
+	ErrRateLimited          ErrorCode = "RATE_LIMITED"
+	ErrBackendError         ErrorCode = "BACKEND_ERROR"
+	ErrBackendUnreachable   ErrorCode = "BACKEND_UNREACHABLE"
+	ErrBackendIncompatible  ErrorCode = "BACKEND_INCOMPATIBLE"
+	ErrStorageQuotaExceeded ErrorCode = "STORAGE_QUOTA_EXCEEDED"
 )
 
 // Error is the structured error object included in the JSON envelope when success is false.

--- a/openspec/changes/add-backup-auth-client/.openspec.yaml
+++ b/openspec/changes/add-backup-auth-client/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-02

--- a/openspec/changes/add-backup-auth-client/design.md
+++ b/openspec/changes/add-backup-auth-client/design.md
@@ -1,0 +1,86 @@
+## Context
+
+This change is the engine-side scaffold for Endstate Hosted Backup, sized to be reviewable in isolation. It deliberately stops at "everything that talks to the backend, parses tokens, and persists secrets." The cryptographic primitives that make those tokens *useful* (Argon2id KDF, AES-256-GCM, BIP39 recovery) are isolated in a follow-up change so a security reviewer can assess them in a small, focused PR.
+
+Three properties shape the design:
+
+1. **Crypto stays at arm's length.** `internal/backup/crypto/` exports an interface; every body returns `ErrNotImplemented`. Login/recover surface `INTERNAL_ERROR` "crypto not yet implemented" until the crypto change merges. Compile-time integration is real; run-time behaviour blocks at the well-defined boundary.
+2. **One source of truth for HTTP semantics.** All backend calls go through `client.Client.Do`, which is the only place that maps HTTP status to engine error codes, retries, and validates the version header. Auth, status, and (later) push/pull/list/delete reuse it verbatim.
+3. **Test seams without test-only files.** Each layer takes its dependencies as interfaces (`HTTPDoer`, `TokenProvider`, `JWKSResolver`, `Keychain`) so unit tests use httptest and an in-memory keychain. The command-handler layer adds one swappable factory (`ReplaceBackupAuthFactoryForTest`) so command tests can inject the stack pointing at a fake backend.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Implement everything required to compile and integrate hosted-backup commands without crypto bodies
+- Bring `endstate backup login|logout|status` to a state where the orchestration paths are exercised end-to-end against a fake backend
+- Establish error-code mappings, retry policy, and version-check rules once, so subsequent backup commands inherit them
+- Add the capabilities feature flag the GUI gates on
+
+**Non-Goals:**
+
+- Cryptographic primitives (Argon2id, AES-256-GCM, DEK wrap, BIP39) — `add-backup-crypto-module`
+- Storage client (push/pull/list/versions/delete) — `add-backup-storage-client`
+- GUI changes — Prompt 4 in a separate repo
+- Any change to existing engine commands' behaviour
+
+## Decisions
+
+### 1. Stdlib `net/http` over a third-party HTTP library
+
+**Choice:** Use stdlib `net/http` wrapped by a thin `client` package.
+
+**Rationale:** The engine has no other HTTP client today, and the substrate API surface is small (≤10 endpoints in v1). Adding `resty` or similar buys nothing the wrapper can't deliver. Keeping the dep surface minimal also matters because each new dep is a future review burden.
+
+**Alternative considered:** `go-resty/resty/v2`. Rejected on dep-surface grounds. Re-evaluate if the wrapper grows past ~300 LOC.
+
+### 2. `github.com/golang-jwt/jwt/v5` for JWT parsing
+
+**Choice:** golang-jwt/jwt/v5.
+
+**Rationale:** De-facto Go choice; supports EdDSA per RFC 8037, which the contract requires; v5 has cleaner API than v4.
+
+**Alternative considered:** `lestrrat-go/jwx`. Heavier, more flexible than we need. Rejected to keep the verifier surface narrow.
+
+### 3. `github.com/danieljoos/wincred` for Windows Credential Manager
+
+**Choice:** wincred.
+
+**Rationale:** Mature, single-purpose, three years of stable releases, no transitive deps. Wrapped by our own `Keychain` interface so swapping later is trivial.
+
+**Alternative considered:** Direct CGO bindings to `wincred.h`. Rejected; we'd reinvent wincred for no gain.
+
+### 4. Single account name per user, not per-token
+
+**Choice:** Persist the refresh token under `endstate-refresh-<userID>`.
+
+**Rationale:** Simplest mapping; one user = one account = one refresh token. Rotation overwrites in place. If we later need multiple-tab/concurrent sessions we can extend the key, but no current requirement.
+
+### 5. Bounded retry policy: 3 retries, exp backoff w/ jitter, 4xx never
+
+**Choice:** Max 3 retries, initial 500 ms, ×2 backoff with ±25% jitter, capped at 8 s. Retry on 5xx and transport errors; never on 4xx; 429 honours `Retry-After`.
+
+**Rationale:** Standard exponential backoff. 4xx is the client's fault — retrying just amplifies the problem. The 401-refresh-then-retry hook is independent of the regular retry counter so an expired token doesn't burn a retry slot.
+
+**Alternative considered:** Idempotency keys for write-path retries. Deferred — substrate doesn't currently honour them, and our writes are rare and short.
+
+### 6. `client.Do` returns `*envelope.Error` directly, not `error`
+
+**Choice:** The HTTP client wrapper returns the engine's domain error type so command handlers can return the result verbatim. Internally the retry loop tracks both API errors (typed) and transport errors (plain) and maps the boundary.
+
+**Rationale:** Avoids round-tripping through `errors.As` at every call site. The auth package can introspect `err.Code` directly. Engine convention is `*envelope.Error` everywhere it crosses package boundaries.
+
+**Alternative considered:** Return `error` and force callers to `errors.As` to an `*APIError`. Rejected as ergonomically worse for the common case.
+
+### 7. Crypto stub returns `ErrNotImplemented`, not panic
+
+**Choice:** Stub bodies return a sentinel error.
+
+**Rationale:** Panicking would abort the engine; returning a typed error lets callers (login, recover) translate to a clear `INTERNAL_ERROR` envelope with remediation. The error message names the follow-up change explicitly so a confused engineer reading the engine logs immediately knows where to look.
+
+## Risks / Trade-offs
+
+- **[Risk] Login surface fails until PROMPT 3 lands.** Users running this engine cannot actually log in. Mitigation: the README and the error message both call out that crypto is in a follow-up change. The capabilities response advertises `hostedBackup.supported = true` because the *feature* exists; the GUI is expected to gate on engine version too (per contract §11).
+- **[Risk] Refresh-token persistence is platform-specific.** Non-Windows targets always error from `keychain.NewSystem()`. Mitigation: Endstate is Windows-first; cross-platform support is a separate change. Test coverage uses the memory keychain on all platforms.
+- **[Trade-off] `backup login` is "signup or login" but only the login path is wired.** PROMPT 2 calls out the merged surface, but the signup path needs DEK generation + recovery key + verifier production, all of which depend on PROMPT 3. The error message specifically targets the crypto stub so the GUI doesn't try to differentiate.
+- **[Trade-off] `account delete` is wired in `main.go` but the handler is stubbed.** This keeps the dispatcher table cohesive with the contract surface today; the storage-client change provides the working handler in a single coordinated change with backup deletion.

--- a/openspec/changes/add-backup-auth-client/proposal.md
+++ b/openspec/changes/add-backup-auth-client/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+`docs/contracts/hosted-backup-contract.md` (locked v1.0, 2026-05-02) defines a cross-repo contract for Endstate Hosted Backup. Substrate has shipped the backend (PR1+PR2). This change brings the engine-side scaffold online: the `endstate backup login|logout|status` subcommands, OIDC discovery + JWKS validation, EdDSA JWT verification, and refresh-token persistence in Windows Credential Manager.
+
+Crypto primitives are intentionally out of scope. They land in a follow-up change (`add-backup-crypto-module`) so that PR can be reviewed in isolation. Login/recover return `INTERNAL_ERROR` with a "crypto: not implemented" message until that crypto change merges. The HTTP, OIDC, JWT, keychain, and orchestration code in this change is real and tested.
+
+## What Changes
+
+- New `endstate backup login`, `endstate backup logout`, `endstate backup status` subcommands (`go-engine/internal/commands/backup_login.go`, `backup_logout.go`, `backup_status.go`)
+- New `internal/backup/` package tree: `oidc/`, `client/`, `auth/`, `keychain/`, `crypto/` (stubs only)
+- Capabilities response advertises a new `hostedBackup` feature block populated from `ENDSTATE_OIDC_ISSUER_URL` / `ENDSTATE_OIDC_AUDIENCE` env vars
+- New error codes: `AUTH_REQUIRED`, `SUBSCRIPTION_REQUIRED`, `NOT_FOUND`, `RATE_LIMITED`, `BACKEND_ERROR`, `BACKEND_UNREACHABLE`, `BACKEND_INCOMPATIBLE`, `STORAGE_QUOTA_EXCEEDED`
+- New dependencies: `github.com/golang-jwt/jwt/v5` for EdDSA JWT verification; `github.com/danieljoos/wincred` for Windows Credential Manager
+
+## Capabilities
+
+### New Capabilities
+
+- `hosted-backup-auth-client`: Engine-side authentication client for Endstate Hosted Backup. Discovers OIDC endpoints, validates EdDSA JWTs against a cached JWKS, persists the refresh token in the OS keychain, and orchestrates the login/logout/status flows defined in contract §5.
+
+### Modified Capabilities
+
+<!-- None — capabilities feature flag is additive. -->
+
+## Impact
+
+- **`go-engine/internal/commands/`** — three new command handlers + capabilities update
+- **`go-engine/internal/backup/`** — new package tree (8 subpackages)
+- **`go-engine/internal/envelope/errors.go`** — new error codes
+- **`go-engine/cmd/endstate/main.go`** — new `backup` and `account` dispatch cases, new flags (`--email`, `--backup-id`, `--version-id`, `--to`, `--confirm`)
+- **`go-engine/go.mod`** — adds `golang-jwt/jwt/v5` and `wincred`
+- **No changes to existing commands' behavior** — all changes are additive
+
+This change pairs with `add-backup-version-check` (engine ↔ backend version compatibility); both ship in PR 1.

--- a/openspec/changes/add-backup-auth-client/specs/hosted-backup-auth-client/spec.md
+++ b/openspec/changes/add-backup-auth-client/specs/hosted-backup-auth-client/spec.md
@@ -1,0 +1,137 @@
+## ADDED Requirements
+
+### Requirement: Engine Honours Two-Var OIDC Configuration
+
+The engine SHALL read its hosted-backup backend configuration from exactly two environment variables: `ENDSTATE_OIDC_ISSUER_URL` and `ENDSTATE_OIDC_AUDIENCE`. Both have defaults pointing at Endstate Cloud.
+
+#### Scenario: Defaults applied when env vars unset
+
+- **WHEN** the engine reads its backup configuration with no env vars set
+- **THEN** `ENDSTATE_OIDC_ISSUER_URL` SHALL default to `https://substratesystems.io`
+- **AND** `ENDSTATE_OIDC_AUDIENCE` SHALL default to `endstate-backup`
+
+#### Scenario: Self-host configuration overrides defaults
+
+- **WHEN** `ENDSTATE_OIDC_ISSUER_URL` is set to a self-host URL
+- **THEN** the engine SHALL fetch discovery from `${ISSUER}/.well-known/openid-configuration`
+- **AND** SHALL refuse the backend if `endstate_extensions` is missing or its `min_kdf_params` is below the v1 floor
+
+### Requirement: OIDC Discovery Caching
+
+The engine SHALL cache the OIDC discovery document for one hour and the JWKS for fifteen minutes. Cache invalidation MUST be available so a JWT signature failure can trigger a JWKS refresh without waiting out the TTL.
+
+#### Scenario: Discovery served from cache within TTL
+
+- **WHEN** the engine fetches discovery a second time within one hour of the first fetch
+- **THEN** the engine SHALL serve the cached document
+- **AND** SHALL NOT issue a network request
+
+#### Scenario: JWKS refreshed on signature failure
+
+- **WHEN** an access-token signature verification fails
+- **THEN** the engine SHALL invalidate its JWKS cache
+- **AND** the next access-token verification SHALL fetch the JWKS afresh
+
+### Requirement: EdDSA-Only JWT Verification
+
+Access tokens SHALL be verified with EdDSA (Ed25519) per RFC 8032/8037. Tokens signed with any other algorithm SHALL be rejected.
+
+#### Scenario: HMAC token rejected
+
+- **WHEN** an access token signed with HMAC-SHA256 is presented
+- **THEN** the engine SHALL refuse to verify the token
+- **AND** SHALL return an authentication error
+
+#### Scenario: Audience and issuer enforced
+
+- **WHEN** an access token has the wrong `aud` or `iss` claim
+- **THEN** verification SHALL fail
+- **AND** the engine SHALL return an authentication error without using the token's claims
+
+### Requirement: Refresh Token Persisted in Windows Credential Manager Only
+
+The refresh token SHALL be stored in Windows Credential Manager via a single named entry of the form `endstate-refresh-<userID>`. The engine SHALL NOT write the refresh token to a plaintext file as fallback.
+
+#### Scenario: Refresh token survives engine restart
+
+- **WHEN** the engine logs in successfully and exits
+- **AND** is invoked again
+- **THEN** the engine SHALL retrieve the refresh token from Credential Manager
+- **AND** the user SHALL NOT be prompted to log in again
+
+#### Scenario: Refresh token rotated atomically
+
+- **WHEN** `/api/auth/refresh` returns a new access + refresh token pair
+- **THEN** the engine SHALL update both the in-memory session and the Credential Manager entry
+- **AND** the previous refresh token SHALL no longer be retrievable
+
+#### Scenario: Logout clears Credential Manager regardless of backend reachability
+
+- **WHEN** `endstate backup logout` is invoked while the backend returns 5xx
+- **THEN** the engine SHALL still delete the Credential Manager entry
+- **AND** SHALL still report `signedOut: true`
+
+### Requirement: Stdin-Only Secret Input
+
+The engine SHALL read passphrases and recovery keys from stdin only. Accepting them as CLI flags is forbidden because that would expose secrets in shell history and process listings.
+
+#### Scenario: Passphrase flag rejected
+
+- **WHEN** a CLI invocation includes `--passphrase` or any equivalent flag
+- **THEN** the engine SHALL NOT accept the value
+- **AND** SHALL prompt the user (via stdin) for the passphrase
+
+### Requirement: HTTP Status Mapped to Stable Engine Error Codes
+
+Every backend response SHALL be translated to an engine error code suitable for inclusion in the standard JSON envelope. The mapping is fixed.
+
+#### Scenario: 401 maps to AUTH_REQUIRED after one refresh attempt
+
+- **WHEN** a backend response status is 401 Unauthorized
+- **THEN** the engine SHALL attempt to refresh the access token once
+- **AND** SHALL retry the original request
+- **AND** if the retry also returns 401, the engine SHALL return `AUTH_REQUIRED`
+
+#### Scenario: Status code mapping table
+
+- **WHEN** the backend returns a non-2xx response
+- **THEN** the engine SHALL map the status to one of: `AUTH_REQUIRED` (401), `SUBSCRIPTION_REQUIRED` (402), `NOT_FOUND` (404), `RATE_LIMITED` (429), `BACKEND_ERROR` (5xx and unmapped 4xx)
+- **AND** transport / DNS / timeout errors SHALL map to `BACKEND_UNREACHABLE`
+
+#### Scenario: Substrate error envelope passes remediation through
+
+- **WHEN** the backend returns a non-2xx response with a body matching the standard error envelope
+- **THEN** the engine SHALL surface the body's `remediation` and `docsKey` verbatim
+- **AND** SHALL fall back to engine defaults only when the backend omits them
+
+### Requirement: Bounded Retry on Transient Errors
+
+The engine SHALL retry transient backend failures up to three times with exponential backoff and jitter. 4xx responses (except 429) SHALL NOT be retried.
+
+#### Scenario: 5xx retried up to three times
+
+- **WHEN** a backend request returns 5xx
+- **THEN** the engine SHALL retry up to three additional times
+- **AND** SHALL apply exponential backoff with ±25% jitter capped at 8 seconds
+
+#### Scenario: 429 honours Retry-After
+
+- **WHEN** a backend response has status 429 with a `Retry-After: <seconds>` header
+- **THEN** the engine SHALL wait at least the indicated duration before retrying
+- **AND** SHALL still respect the maximum-retries limit
+
+#### Scenario: 4xx never retried
+
+- **WHEN** a backend response status is 400, 403, 404, or any 4xx other than 429
+- **THEN** the engine SHALL surface the mapped error code immediately without retrying
+
+### Requirement: Capabilities Feature Flag
+
+The engine's capabilities response SHALL advertise a `hostedBackup` feature block populated from the resolved OIDC configuration so the GUI can gate hosted-backup UI surfaces accordingly.
+
+#### Scenario: Capabilities advertises issuer and audience
+
+- **WHEN** the GUI queries `endstate capabilities --json`
+- **THEN** `data.features.hostedBackup` SHALL be present with `supported: true`
+- **AND** `issuerUrl` and `audience` SHALL reflect the active env-var configuration
+- **AND** `minSchemaVersion` SHALL be `"1.0"`

--- a/openspec/changes/add-backup-auth-client/tasks.md
+++ b/openspec/changes/add-backup-auth-client/tasks.md
@@ -1,0 +1,72 @@
+## 1. Error codes
+
+- [x] 1.1 Add `AUTH_REQUIRED`, `SUBSCRIPTION_REQUIRED`, `NOT_FOUND`, `RATE_LIMITED`, `BACKEND_ERROR`, `BACKEND_UNREACHABLE`, `BACKEND_INCOMPATIBLE`, `STORAGE_QUOTA_EXCEEDED` constants in `go-engine/internal/envelope/errors.go`
+- [x] 1.2 Extend `TestErrorCodeSerialization` in `envelope_test.go` to cover the new codes
+
+## 2. Crypto stub package (interface only)
+
+- [x] 2.1 Create `go-engine/internal/backup/crypto/` with stubbed `DeriveKeys`, `GenerateDEK`, `WrapDEK`, `UnwrapDEK`, `EncryptChunk`, `DecryptChunk`, `EncryptManifest`, `DecryptManifest`, `GenerateRecoveryKey`, `ParseRecoveryPhrase`, `DeriveRecoveryKey`, `RecoveryKeyVerifier`
+- [x] 2.2 Each function returns `crypto.ErrNotImplemented` with a `// TODO(prompt-3)` marker
+- [x] 2.3 Lock the contract constants in code: `DEKSize=32`, `SaltSize=16`, `NonceSize=12`, `GCMTagSize=16`, `ChunkPlainSize=4 MiB`, `EnvelopeVersion=1`, `ManifestAAD=0xFFFFFFFF`, `RecoveryMnemonicWords=24`
+- [x] 2.4 `KDFParams` matches the contract object; `DefaultKDFParams()` returns the v1 values; `MeetsFloor()` enforces the engine's refusal to derive keys below the floor
+
+## 3. Keychain wrapper
+
+- [x] 3.1 Create `internal/backup/keychain/` with `Keychain` interface (`Store`, `Load`, `Delete`, `ErrNotFound`)
+- [x] 3.2 Windows implementation via `github.com/danieljoos/wincred` (`keychain_windows.go`)
+- [x] 3.3 Non-Windows stub (`keychain_other.go`) that errors — Endstate is Windows-first; no plaintext fallback
+- [x] 3.4 Memory implementation for tests (`memory.go`) with defensive copies on `Store`
+- [x] 3.5 `AccountForUser(userID)` helper produces stable `endstate-refresh-<userID>` account names
+
+## 4. OIDC discovery + JWKS
+
+- [x] 4.1 Create `internal/backup/oidc/` with `Client.Discovery(ctx)` and `Client.JWKS(ctx)`
+- [x] 4.2 Discovery cached in-memory for `DiscoveryTTL` (1h); JWKS for `JWKSTTL` (15m)
+- [x] 4.3 `validateDocument` rejects missing `endstate_extensions`, missing `argon2id`, missing envelope v1, weak KDF floor → `ErrIncompatibleIssuer`
+- [x] 4.4 Issuer mismatch in returned `iss` field → distinct error (not `ErrIncompatibleIssuer`)
+- [x] 4.5 `InvalidateJWKS()` triggers a refetch on next `JWKS(ctx)` call so JWT verifier can react to key rotation
+- [x] 4.6 Unit tests cover cache TTL, missing-extension rejection, weak-KDF rejection, missing-EdDSA rejection, network-error propagation
+
+## 5. HTTP client wrapper
+
+- [x] 5.1 Create `internal/backup/client/` with `Client.Do(ctx, req, out)` returning `*envelope.Error`
+- [x] 5.2 Bearer-token injection via the `TokenProvider` interface (`Anonymous{}` for unauth flows)
+- [x] 5.3 JSON marshal/unmarshal with `Content-Type: application/json` and `Accept: application/json`
+- [x] 5.4 `X-Endstate-API-Version` parsing on every response; major mismatch → `SCHEMA_INCOMPATIBLE` always; minor mismatch → warn-and-proceed for `ReadOnly` requests, `SCHEMA_INCOMPATIBLE` for writes
+- [x] 5.5 Status → ErrorCode mapping: 401 → `AUTH_REQUIRED`, 402 → `SUBSCRIPTION_REQUIRED`, 404 → `NOT_FOUND`, 429 → `RATE_LIMITED`, 5xx → `BACKEND_ERROR`, transport → `BACKEND_UNREACHABLE`
+- [x] 5.6 Retry policy: max 3 retries on 5xx + transport errors only; 4xx never retried; 429 honours `Retry-After` (delta-seconds form); exponential backoff with ±25% jitter capped at 8 s
+- [x] 5.7 401 response triggers a single refresh-then-retry hop via `TokenProvider.RefreshAccessToken`; subsequent 401 returns `AUTH_REQUIRED`
+- [x] 5.8 Substrate body code `STORAGE_QUOTA_EXCEEDED` (any 4xx/5xx) overrides the status-derived code
+- [x] 5.9 Unit tests cover happy path, bearer injection, 401-refresh-retry, 401×2 → AUTH_REQUIRED, 402 → SUB_REQUIRED, 404 → NOT_FOUND, 429 retry-then-give-up, 5xx-then-200, 5xx-exhausted, 4xx-no-retry, version major/minor mismatch, transport-unreachable, body remediation passthrough, STORAGE_QUOTA_EXCEEDED from body
+
+## 6. Auth orchestration
+
+- [x] 6.1 Create `internal/backup/auth/` with `SessionStore` (in-memory + keychain persistence)
+- [x] 6.2 `Authenticator` exposes `PreHandshake`, `CompleteLogin`, `Logout`, `Me`; refresh wired via `Session().WithRefreshFn`
+- [x] 6.3 `PreHandshake` rejects KDF params below the v1 floor → `BACKEND_INCOMPATIBLE`
+- [x] 6.4 `CompleteLogin` persists the refresh token to the keychain on success; persistence failure surfaces as `INTERNAL_ERROR` rather than silent loss
+- [x] 6.5 `Logout` is best-effort against the backend; local state is wiped regardless of backend reachability
+- [x] 6.6 `Me` updates the cached session from the authoritative `/api/account/me` response
+- [x] 6.7 `Verify` (JWT verification) checks signature against JWKS, `iss`, `aud`, `exp`, `nbf` with 60s leeway; signature failures invalidate the JWKS cache so the next call refreshes keys
+- [x] 6.8 Unit tests cover JWT happy path + expired + wrong-aud + wrong-iss + bad-signature + rotated-kid; httptest-driven Authenticator tests cover login persist, refresh rotation, logout-while-backend-down, Me, 404 on PreHandshake → `NOT_FOUND`
+
+## 7. Top-level wiring
+
+- [x] 7.1 Create `internal/backup/backup.go` with `IssuerURL()`, `Audience()`, `Concurrency()`, and `NewAuthenticator()` constructors honouring `ENDSTATE_OIDC_ISSUER_URL`, `ENDSTATE_OIDC_AUDIENCE`, `ENDSTATE_BACKUP_CONCURRENCY`
+- [x] 7.2 Add `commands.BackupFlags` + `commands.RunBackup` dispatcher
+- [x] 7.3 Add `commands.AccountFlags` + `commands.RunAccount` dispatcher (delete handler stubbed for the storage-client change)
+- [x] 7.4 Implement `runBackupLogin`, `runBackupLogout`, `runBackupStatus`
+- [x] 7.5 Stdin-only passphrase reader; `WithPassphraseReader` test seam
+- [x] 7.6 Wire `backup` and `account` cases into `cmd/endstate/main.go` `dispatch()`
+- [x] 7.7 Add new flags (`--email`, `--backup-id`, `--version-id`, `--to`, `--confirm`) to `parseArgs()`
+- [x] 7.8 Add `backup` and `account` blurbs to `commandUsage()` and `usageText`
+- [x] 7.9 Update `commands/capabilities.go` to advertise `hostedBackup` and register `backup` / `account` commands
+
+## 8. Tests
+
+- [x] 8.1 `backup_test.go` covers signed-out status, signed-in status, login no-email, login empty-passphrase, login pre-handshake-OK-then-crypto-stub-blocks, login backend-unreachable, logout idempotent, logout clears keychain, runbackup-no-subcommand, runaccount-delete-stubbed, capabilities advertises hostedBackup with env-overridden values
+- [x] 8.2 `go test ./...` green; `go vet ./...` clean
+
+## 9. Documentation
+
+- [ ] 9.1 Add "Hosted Backup" section to `README.md` describing env vars + command tree + the PR-2/PR-3 caveats

--- a/openspec/changes/add-backup-version-check/.openspec.yaml
+++ b/openspec/changes/add-backup-version-check/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-02

--- a/openspec/changes/add-backup-version-check/proposal.md
+++ b/openspec/changes/add-backup-version-check/proposal.md
@@ -1,0 +1,28 @@
+## Why
+
+Contract §11 defines the engine ↔ backend version compatibility protocol: the backend stamps every response with `X-Endstate-API-Version: MAJOR.MINOR`; the engine refuses to write across a major mismatch and warns on a higher minor for read-only operations. Without a structured check the engine would silently send v1 requests to a v2 backend (or vice versa) and surface inscrutable parse errors instead of a clear "update the engine" remediation.
+
+## What Changes
+
+- The hosted-backup HTTP client wrapper (`internal/backup/client/`) inspects `X-Endstate-API-Version` on every response
+- Major mismatch → `SCHEMA_INCOMPATIBLE` (already defined; reused here)
+- Minor mismatch on a read-only request → warn via `slog`, proceed
+- Minor mismatch on a write → `SCHEMA_INCOMPATIBLE`
+- Engine's expected version is `1.0` (constants in `version.go`)
+
+## Capabilities
+
+### New Capabilities
+
+- `hosted-backup-version-compatibility`: Engine policy for evaluating the backend-advertised hosted-backup API schema version on every response.
+
+### Modified Capabilities
+
+<!-- None — the rule is new and lives entirely inside the new client wrapper. -->
+
+## Impact
+
+- **`go-engine/internal/backup/client/version.go`** — new file with the version-check rule
+- **`go-engine/internal/backup/client/client.go`** — calls into the rule from `processResponse`
+- **No public API change** — `Request.ReadOnly` is the only surface, used internally by every backup command
+- **Pairs with `add-backup-auth-client`** — the auth client is the first consumer; the storage client (later change) inherits the rule transparently.

--- a/openspec/changes/add-backup-version-check/specs/hosted-backup-version-compatibility/spec.md
+++ b/openspec/changes/add-backup-version-check/specs/hosted-backup-version-compatibility/spec.md
@@ -1,0 +1,58 @@
+## ADDED Requirements
+
+### Requirement: Engine Inspects Version Header on Every Response
+
+The hosted-backup HTTP client SHALL parse `X-Endstate-API-Version` from every backend response. The header value is `MAJOR.MINOR` and reflects the schema major + minor the backend implements.
+
+#### Scenario: Header missing logs a warning, request proceeds
+
+- **WHEN** a backend response omits the `X-Endstate-API-Version` header
+- **THEN** the engine SHALL log a warning
+- **AND** SHALL still process the response per the standard rules
+
+#### Scenario: Header malformed logs a warning, request proceeds
+
+- **WHEN** the header is present but cannot be parsed as `MAJOR.MINOR`
+- **THEN** the engine SHALL log a warning naming the offending value
+- **AND** SHALL still process the response per the standard rules
+
+### Requirement: Major Mismatch Always Blocks
+
+If the backend advertises a major version other than the engine's expected major, the request SHALL fail with `SCHEMA_INCOMPATIBLE` regardless of whether the request is a read or a write.
+
+#### Scenario: Major-2 backend rejected on a read
+
+- **GIVEN** the engine expects major `1`
+- **WHEN** the backend returns `X-Endstate-API-Version: 2.0` on a `ReadOnly: true` request
+- **THEN** the engine SHALL return `SCHEMA_INCOMPATIBLE`
+- **AND** SHALL NOT decode the response body
+
+### Requirement: Minor Mismatch Distinguishes Read From Write
+
+If the backend advertises a higher minor than the engine knows about, the engine SHALL distinguish read-only from write-path requests:
+
+- Read-only: log a warning, proceed
+- Write: `SCHEMA_INCOMPATIBLE`
+
+#### Scenario: 1.5 backend tolerated on read
+
+- **GIVEN** the engine knows `1.0`
+- **WHEN** the backend returns `X-Endstate-API-Version: 1.5` on a `ReadOnly: true` request
+- **THEN** the engine SHALL log a warning
+- **AND** SHALL still decode the response body and return success
+
+#### Scenario: 1.5 backend rejected on write
+
+- **GIVEN** the engine knows `1.0`
+- **WHEN** the backend returns `X-Endstate-API-Version: 1.5` on a write request
+- **THEN** the engine SHALL return `SCHEMA_INCOMPATIBLE`
+
+### Requirement: Mismatch Skips Retry Loop
+
+When the version check produces `SCHEMA_INCOMPATIBLE`, the engine SHALL NOT retry the request. Retrying an incompatible backend wastes time and obscures the diagnosis.
+
+#### Scenario: Mismatch ends the retry loop
+
+- **WHEN** the version check returns `SCHEMA_INCOMPATIBLE`
+- **THEN** the engine SHALL return immediately
+- **AND** SHALL NOT consume any retry attempts on the same incompatible backend

--- a/openspec/changes/add-backup-version-check/tasks.md
+++ b/openspec/changes/add-backup-version-check/tasks.md
@@ -1,0 +1,28 @@
+## 1. Version constants
+
+- [x] 1.1 Define `EngineSchemaMajor=1`, `EngineSchemaMinor=0`, `versionHeader="X-Endstate-API-Version"` in `internal/backup/client/version.go`
+
+## 2. Header parsing
+
+- [x] 2.1 `parseVersionHeader(v)` extracts `MAJOR.MINOR`; rejects malformed values; returns wrapped error
+- [x] 2.2 Malformed header logs a warning via `slog.Warn` and proceeds (does not block the response)
+
+## 3. Mismatch policy
+
+- [x] 3.1 Major mismatch → `SCHEMA_INCOMPATIBLE` always, on both reads and writes
+- [x] 3.2 Higher minor on read-only request → `slog.Warn` and proceed (returns `(nil, true)` from `versionMismatch`)
+- [x] 3.3 Higher minor on write request → `SCHEMA_INCOMPATIBLE`
+- [x] 3.4 Same major + lower-or-equal minor → no action
+
+## 4. Wiring
+
+- [x] 4.1 `client.Client.processResponse` reads `X-Endstate-API-Version` before status mapping
+- [x] 4.2 Mismatch returns from `processResponse` immediately so retries do not consume slots on an incompatible backend
+- [x] 4.3 `Request.ReadOnly` flag controls minor-mismatch tolerance (true → tolerant; false → strict)
+
+## 5. Tests
+
+- [x] 5.1 Major mismatch → `SCHEMA_INCOMPATIBLE` for both `ReadOnly: true` and `ReadOnly: false`
+- [x] 5.2 Minor mismatch on `ReadOnly: true` → request succeeds (cmd handler receives parsed body)
+- [x] 5.3 Minor mismatch on `ReadOnly: false` → `SCHEMA_INCOMPATIBLE`
+- [x] 5.4 Matching version (`1.0`) → no error, no warning

--- a/readme.md
+++ b/readme.md
@@ -231,6 +231,66 @@ Endstate prioritizes safety over speed:
 
 ---
 
+## Hosted Backup (optional, paid tier)
+
+End-to-end encrypted profile backups via Endstate Cloud (or any self-host
+backend implementing `docs/contracts/hosted-backup-contract.md`). The
+engine authenticates against the backend's OIDC endpoints, persists the
+refresh token in Windows Credential Manager, and orchestrates chunked
+upload/download against R2 presigned URLs.
+
+The cryptographic primitives (Argon2id KDF, AES-256-GCM, BIP39 recovery
+key) are isolated in a follow-up engine release for focused security
+review. Until that release, `backup login`, `backup push`, `backup pull`,
+and `backup recover` surface a clear `INTERNAL_ERROR` "crypto module not
+yet implemented" message — the orchestration is wired and tested but the
+key derivation cannot complete.
+
+### Configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `ENDSTATE_OIDC_ISSUER_URL` | `https://substratesystems.io` | OIDC issuer / backend URL |
+| `ENDSTATE_OIDC_AUDIENCE` | `endstate-backup` | JWT audience claim |
+| `ENDSTATE_BACKUP_CONCURRENCY` | `4` | Upload/download worker pool size (clamped 1–16) |
+
+### Commands
+
+```bash
+# Sign in (passphrase via stdin — never as a flag)
+endstate backup login --email you@example.com
+
+# Report current session state
+endstate backup status --json
+
+# Sign out (clears local keychain entry; backend logout is best-effort)
+endstate backup logout
+
+# Inventory
+endstate backup list --json
+endstate backup versions --backup-id <id> --json
+
+# Push and pull profile snapshots
+endstate backup push --profile <path> [--name <label>]
+endstate backup pull --backup-id <id> [--version-id <id>] --to <path>
+
+# Destructive operations require --confirm
+endstate backup delete --backup-id <id> --confirm
+endstate backup delete-version --backup-id <id> --version-id <id> --confirm
+
+# Forgotten passphrase (recovery key + new passphrase via stdin)
+endstate backup recover --email you@example.com
+
+# GDPR account deletion (destroys backups + subscription)
+endstate account delete --confirm
+```
+
+The capabilities response (`endstate capabilities --json`) advertises the
+configured issuer and audience under `data.features.hostedBackup`, so the
+GUI can gate hosted-backup UI on a single handshake.
+
+---
+
 ## Prerequisites
 
 | Requirement | Version | Purpose |


### PR DESCRIPTION
## Summary

PROMPT 2 of the Hosted Backup v2 build (engine side, no crypto): the engine-side authentication client and the response-time schema-version check. Pairs with the substrate backend already deployed at substratesystems.io.

OpenSpec changes carried by this PR:
- **`add-backup-auth-client`** — login / logout / status, OIDC discovery + JWKS, EdDSA JWT verification, refresh-token persistence in Windows Credential Manager
- **`add-backup-version-check`** — `X-Endstate-API-Version` policy in the HTTP client (major mismatch always fails; minor mismatch warns on read, fails on write)

Crypto stays as a stub (`internal/backup/crypto/`) returning `ErrNotImplemented`. PROMPT 3 fills it in. Until then `endstate backup login` surfaces a clear `INTERNAL_ERROR` *"crypto module not yet implemented"* — the HTTP, OIDC, JWT, keychain, and orchestration code is real and tested.

The `add-backup-storage-client` change (push/pull/list/versions/delete/recover, account delete, manifest + storage packages) follows in a separate stacked PR.

## What's in this PR

- `internal/backup/{crypto,keychain,oidc,client,auth}` packages
- `internal/backup/backup.go` — `NewStack()` / `NewAuthenticator()` constructors
- `endstate backup login | logout | status` (passphrase via stdin only)
- `endstate account` dispatcher (delete handler stubbed for the storage-client follow-up)
- `ENDSTATE_OIDC_ISSUER_URL` / `ENDSTATE_OIDC_AUDIENCE` env vars (defaults: `https://substratesystems.io` / `endstate-backup`)
- `capabilities.features.hostedBackup` block populated at runtime
- New error codes: `AUTH_REQUIRED`, `SUBSCRIPTION_REQUIRED`, `NOT_FOUND`, `RATE_LIMITED`, `BACKEND_ERROR`, `BACKEND_UNREACHABLE`, `BACKEND_INCOMPATIBLE`, `STORAGE_QUOTA_EXCEEDED`
- `docs/contracts/cli-json-contract.md` updated with the new codes table
- README "Hosted Backup" section
- New deps: `github.com/golang-jwt/jwt/v5`, `github.com/danieljoos/wincred`

## Design highlights

- **HTTP client** (`internal/backup/client/`) is the only place that maps HTTP status to engine error codes, retries (3x exp backoff w/ jitter on 5xx + transport, never on 4xx, 429 honours `Retry-After`), and validates `X-Endstate-API-Version`. 401 triggers a single refresh-then-retry hook; the refresh endpoint itself opts out via `Request.SkipAuthRefresh` to prevent recursion.
- **Crypto stub** lives behind a fully-defined interface so PROMPT 3 fills bodies without changing the surface. Locked constants (DEK size, AAD sentinel `0xFFFFFFFF`, manifest envelope version, etc.) and the v1 KDF parameter floor are codified now.
- **Storage** (Windows Credential Manager via `wincred`) is wrapped by a narrow `Keychain` interface; tests use an in-memory backend.
- **Manifest URL convention** (`chunkIndex == -1` per contract §7) is documented as independent of the AAD sentinel `0xFFFFFFFF` (contract §3) at every relevant call site — they are wire-protocol vs. cryptographic binding, never to be conflated.

## Test plan

- [x] `cd go-engine && go build ./...`
- [x] `cd go-engine && go vet ./...`
- [x] `cd go-engine && go test ./...` — full suite green (19 packages)
- [x] `npm run openspec:validate` — 44/44 items
- [x] Smoke: `endstate capabilities --json` → `data.features.hostedBackup` populated from env vars
- [x] Smoke: `endstate backup status --json` (signed-out) → `{ signedIn: false, issuerUrl: ... }`
- [x] `endstate backup login` against a `httptest` substrate fixture → returns the documented "crypto not yet implemented" envelope after pre-handshake succeeds

## Notes

- Stacked PR: `add-backup-storage-client` will branch from this one and merge after.
- 2026-05-02 commit on main (manifest URL clarification in `hosted-backup-contract.md`) is included in this PR's diff because the engine code in PR 1 references that locked convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)