### PR TITLE
fix(backup): surface keychain-access failures via StatusResult.keychainError

### DIFF
--- a/go-engine/internal/backup/auth/session.go
+++ b/go-engine/internal/backup/auth/session.go
@@ -35,6 +35,16 @@ type SessionStore struct {
 	subscription   string
 	keychainClient keychain.Keychain
 	refreshFn      refreshFunc
+
+	// lastHydrateErr is the most recent non-ErrNotFound error encountered
+	// by HydrateFromCurrent when reading the current-user pointer, or nil
+	// if the keychain is healthy. Surfaced to the user via
+	// `backup status` so a flaky keychain doesn't read identically to "no
+	// session" — the original review-endstate finding on the keychain-fix
+	// commit. ErrNotFound at the pointer (i.e. genuinely signed out) is
+	// not recorded; only access failures (permissions, locked store, etc.)
+	// land here.
+	lastHydrateErr error
 }
 
 // NewSessionStore constructs a SessionStore backed by the supplied
@@ -91,17 +101,34 @@ func (s *SessionStore) Persist() error {
 // in-memory session. Called by the stack factory before returning to a
 // command handler so every command starts hydrated.
 //
-// Treats keychain.ErrNotFound at either level as "signed out" and
-// returns nil — a fresh OS user with no Endstate session is not an
-// error condition, just an empty session. Other keychain errors
-// (permissions, locked store) also return nil; the session stays empty
-// and the next signed-in operation will surface the underlying issue
-// when it tries to write.
+// Always returns nil so the stack factory does not need to special-case
+// signed-out vs broken-keychain. Two distinct outcomes are encoded:
+//
+//   - keychain.ErrNotFound at the pointer → signed-out; lastHydrateErr
+//     is cleared.
+//   - any other error at the pointer → keychain access failure;
+//     lastHydrateErr is set and `backup status` surfaces it via the
+//     KeychainError field. Session stays empty.
+//
+// A successful pointer read followed by a Hydrate failure is treated as
+// signed-out without recording the error — that case is "stale pointer"
+// (pointer present, refresh entry absent), rare in practice, and self-
+// heals on the next login.
 func (s *SessionStore) HydrateFromCurrent() error {
 	uidBytes, err := s.keychainClient.Load(keychain.AccountForCurrentUser())
 	if err != nil {
+		s.mu.Lock()
+		if err == keychain.ErrNotFound {
+			s.lastHydrateErr = nil
+		} else {
+			s.lastHydrateErr = err
+		}
+		s.mu.Unlock()
 		return nil
 	}
+	s.mu.Lock()
+	s.lastHydrateErr = nil
+	s.mu.Unlock()
 	uid := string(uidBytes)
 	if uid == "" {
 		return nil
@@ -110,6 +137,17 @@ func (s *SessionStore) HydrateFromCurrent() error {
 		return nil
 	}
 	return nil
+}
+
+// LastHydrateError returns the most recent non-ErrNotFound error from
+// HydrateFromCurrent's pointer load, or nil if the last hydration was
+// healthy or genuinely signed out. `backup status` reads this to populate
+// the StatusResult.KeychainError field so users can tell "no session"
+// apart from "keychain is broken".
+func (s *SessionStore) LastHydrateError() error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.lastHydrateErr
 }
 
 // Forget clears the in-memory session and removes both the refresh token

--- a/go-engine/internal/backup/auth/session_test.go
+++ b/go-engine/internal/backup/auth/session_test.go
@@ -4,12 +4,24 @@
 package auth_test
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/Artexis10/endstate/go-engine/internal/backup/auth"
 	"github.com/Artexis10/endstate/go-engine/internal/backup/keychain"
 )
+
+// faultyKeychain wraps a memory keychain but returns loadErr from any
+// Load call instead of consulting the underlying store. Used to simulate
+// permission/locked-store failures.
+type faultyKeychain struct {
+	loadErr error
+}
+
+func (f *faultyKeychain) Store(account string, secret []byte) error  { return f.loadErr }
+func (f *faultyKeychain) Load(account string) ([]byte, error)        { return nil, f.loadErr }
+func (f *faultyKeychain) Delete(account string) error                { return f.loadErr }
 
 // TestSessionStore_PersistThenHydrateAcrossInstances locks the cross-process
 // invariant: a SessionStore that has been Persisted on one instance is
@@ -61,6 +73,69 @@ func TestSessionStore_HydrateFromCurrent_NoEntryIsSignedOut(t *testing.T) {
 	}
 	if store.SignedIn() {
 		t.Fatal("empty-keychain hydrate left store SignedIn=true")
+	}
+}
+
+// TestSessionStore_HydrateFromCurrent_RecordsNonNotFoundError verifies
+// that a permission-denied / locked-store style keychain failure is
+// captured in lastHydrateErr so `backup status` can surface it through
+// the KeychainError envelope field. The fix-keychain-error-surface
+// follow-up to the original keychain-pointer fix.
+func TestSessionStore_HydrateFromCurrent_RecordsNonNotFoundError(t *testing.T) {
+	wantErr := errors.New("synthetic: keychain locked")
+	store := auth.NewSessionStore(&faultyKeychain{loadErr: wantErr})
+
+	if err := store.HydrateFromCurrent(); err != nil {
+		t.Fatalf("HydrateFromCurrent should always return nil to keep signed-out paths working; got %v", err)
+	}
+	if store.SignedIn() {
+		t.Fatal("a faulty keychain must not produce a signed-in session")
+	}
+	got := store.LastHydrateError()
+	if got == nil {
+		t.Fatal("LastHydrateError() == nil; want the synthetic keychain error")
+	}
+	if got.Error() != wantErr.Error() {
+		t.Errorf("LastHydrateError() = %q, want %q", got, wantErr)
+	}
+}
+
+// TestSessionStore_HydrateFromCurrent_NotFoundIsNotRecorded asserts the
+// "no session" path is genuinely silent — ErrNotFound at the pointer is
+// the canonical signed-out signal and must not surface as a keychain
+// error to the user.
+func TestSessionStore_HydrateFromCurrent_NotFoundIsNotRecorded(t *testing.T) {
+	store := auth.NewSessionStore(keychain.NewMemory())
+	if err := store.HydrateFromCurrent(); err != nil {
+		t.Fatalf("HydrateFromCurrent: %v", err)
+	}
+	if got := store.LastHydrateError(); got != nil {
+		t.Errorf("LastHydrateError() = %v on an empty keychain; want nil (signed-out is normal)", got)
+	}
+}
+
+// TestSessionStore_HydrateFromCurrent_HealthyClearsPriorError covers the
+// recovery case: a previous call recorded an error, the keychain is
+// now healthy, the next HydrateFromCurrent must clear the stale error
+// so `backup status` stops surfacing it.
+func TestSessionStore_HydrateFromCurrent_HealthyClearsPriorError(t *testing.T) {
+	store := auth.NewSessionStore(&faultyKeychain{loadErr: errors.New("synthetic: keychain locked")})
+	_ = store.HydrateFromCurrent()
+	if store.LastHydrateError() == nil {
+		t.Fatal("setup: expected an error to be recorded")
+	}
+
+	// Swap to a fresh, healthy keychain by constructing a new store on it
+	// — simulates the "user fixes the keychain and re-runs" path. We
+	// can't swap the keychain on the existing store (no setter on
+	// purpose) so a new store-on-same-fix-state is the natural way to
+	// model a recovered process.
+	healthy := auth.NewSessionStore(keychain.NewMemory())
+	if err := healthy.HydrateFromCurrent(); err != nil {
+		t.Fatalf("HydrateFromCurrent: %v", err)
+	}
+	if got := healthy.LastHydrateError(); got != nil {
+		t.Errorf("LastHydrateError() on healthy fresh keychain = %v; want nil", got)
 	}
 }
 

--- a/go-engine/internal/commands/backup_status.go
+++ b/go-engine/internal/commands/backup_status.go
@@ -19,12 +19,16 @@ import (
 //     "userId":              string?,
 //     "subscriptionStatus":  string?,
 //     "issuerUrl":           string,
-//     "lastBackupAt":        string?
+//     "lastBackupAt":        string?,
+//     "keychainError":       string?
 //   }
 //
 // Optional fields are present only when the user is signed in. issuerUrl
 // is always present so the GUI can show "you're configured to talk to <X>"
-// even when signed out.
+// even when signed out. keychainError is populated when the OS keychain
+// could not be read at startup (permissions, locked store, etc.) so a
+// flaky keychain does not read identically to "no session" — see
+// SessionStore.LastHydrateError.
 type StatusResult struct {
 	SignedIn           bool   `json:"signedIn"`
 	Email              string `json:"email,omitempty"`
@@ -32,6 +36,7 @@ type StatusResult struct {
 	SubscriptionStatus string `json:"subscriptionStatus,omitempty"`
 	IssuerURL          string `json:"issuerUrl"`
 	LastBackupAt       string `json:"lastBackupAt,omitempty"`
+	KeychainError      string `json:"keychainError,omitempty"`
 }
 
 func runBackupStatus(flags BackupFlags) (interface{}, *envelope.Error) {
@@ -39,9 +44,14 @@ func runBackupStatus(flags BackupFlags) (interface{}, *envelope.Error) {
 	res := &StatusResult{
 		IssuerURL: a.Issuer().URL,
 	}
+	if hErr := a.Session().LastHydrateError(); hErr != nil {
+		res.KeychainError = hErr.Error()
+	}
 
 	// If we have nothing in the keychain to talk to, return signed-out
-	// without making any network calls.
+	// without making any network calls. KeychainError (if set above) lets
+	// the caller distinguish "genuinely signed out" from "keychain access
+	// failed".
 	if !a.Session().SignedIn() {
 		return res, nil
 	}

--- a/go-engine/internal/commands/backup_test.go
+++ b/go-engine/internal/commands/backup_test.go
@@ -171,6 +171,69 @@ func TestBackupStatus_SignedIn(t *testing.T) {
 	}
 }
 
+// faultyTestKeychain returns loadErr from every Load call, leaving
+// Store/Delete as no-ops. Models a permission-denied / locked-store
+// failure for status-reporting tests.
+type faultyTestKeychain struct {
+	loadErr error
+}
+
+func (f *faultyTestKeychain) Store(account string, secret []byte) error { return f.loadErr }
+func (f *faultyTestKeychain) Load(account string) ([]byte, error)       { return nil, f.loadErr }
+func (f *faultyTestKeychain) Delete(account string) error               { return f.loadErr }
+
+// TestBackupStatus_KeychainErrorSurfaced locks the wiring from
+// SessionStore.LastHydrateError to StatusResult.KeychainError. With a
+// keychain that fails on Load, status MUST report signedIn=false (no
+// session could be loaded) AND populate KeychainError with the
+// underlying failure so the caller can distinguish "broken keychain"
+// from "no session". Without this surfacing the two states look
+// identical to the user.
+func TestBackupStatus_KeychainErrorSurfaced(t *testing.T) {
+	srv := fakeBackend(t)
+	synthetic := errors.New("synthetic: keychain locked")
+	kc := &faultyTestKeychain{loadErr: synthetic}
+
+	// Build the stack manually with the faulty keychain. We call
+	// HydrateFromCurrent ourselves to mirror what backup.newStack does
+	// in production — the test seam (stackForBackend) does not auto-
+	// hydrate, so we replicate that step here.
+	store := auth.NewSessionStore(kc)
+	_ = store.HydrateFromCurrent()
+
+	oc := oidc.NewClient(srv.URL, srv.Client())
+	rp := client.RetryPolicy{MaxRetries: 0, InitialWait: time.Millisecond, MaxWait: time.Millisecond}
+	hc := client.New(client.Options{Tokens: store, Retry: &rp})
+	a := auth.NewAuthenticator(auth.Issuer{URL: srv.URL, Audience: "endstate-backup"}, oc, hc, store)
+	st := storage.New(srv.URL, hc)
+	stack := &backup.Stack{
+		Auth:    a,
+		Storage: st,
+		Issuer:  srv.URL,
+		OIDC:    oc,
+		HTTP:    hc,
+		Session: store,
+	}
+
+	restore := commands.ReplaceBackupStackFactoryForTest(func() *backup.Stack { return stack })
+	defer restore()
+
+	data, envErr := commands.RunBackup(commands.BackupFlags{Subcommand: "status"})
+	if envErr != nil {
+		t.Fatalf("status with faulty keychain: %+v", envErr)
+	}
+	res := data.(*commands.StatusResult)
+	if res.SignedIn {
+		t.Error("expected signedIn=false on a faulty keychain")
+	}
+	if res.KeychainError == "" {
+		t.Fatal("StatusResult.KeychainError was not populated; the wiring from LastHydrateError is broken")
+	}
+	if !strings.Contains(res.KeychainError, "synthetic: keychain locked") {
+		t.Errorf("KeychainError = %q, want it to contain the synthetic error message", res.KeychainError)
+	}
+}
+
 func TestBackupLogin_RequiresEmail(t *testing.T) {
 	_, err := commands.RunBackup(commands.BackupFlags{Subcommand: "login"})
 	if err == nil || err.Code != envelope.ErrInternalError {


### PR DESCRIPTION
## Summary

Follow-up to PR #24's keychain-pointer fix. The `review-endstate` skill on that commit flagged that `SessionStore.HydrateFromCurrent` silently swallows non-`ErrNotFound` keychain errors (permission denied, locked store, etc.) so a user who just successfully ran `backup login` then immediately runs `backup status` against a flaky keychain sees `signedIn:false` with no diagnostic hook — indistinguishable from a fresh OS user with no Endstate session.

This PR captures the underlying error in `SessionStore.lastHydrateErr` (reset on every `HydrateFromCurrent` call), exposes it via a new `LastHydrateError()` accessor, and surfaces it through a new optional `StatusResult.keychainError` field. `ErrNotFound` at the pointer remains the canonical signed-out signal and is **not** recorded — only real access failures land in the new field.

## Wire change

Before:
```json
{ "signedIn": false, "issuerUrl": "https://substratesystems.io" }     // healthy keychain, no session
{ "signedIn": false, "issuerUrl": "https://substratesystems.io" }     // broken keychain  ← identical
```

After:
```json
{ "signedIn": false, "issuerUrl": "https://substratesystems.io" }                                     // healthy keychain, no session
{ "signedIn": false, "issuerUrl": "https://substratesystems.io", "keychainError": "<diag>" }          // broken keychain
```

Field is `omitempty` so existing GUI code that doesn't read it is unaffected; signed-in responses also include it only when there's something to report.

## Test plan

- [x] `go test ./internal/backup/auth/... ./internal/commands/...` green (full + `-short` modes)
- [x] New unit tests in `internal/backup/auth/session_test.go`:
  - `TestSessionStore_HydrateFromCurrent_RecordsNonNotFoundError` — synthetic faulty keychain → `LastHydrateError() != nil`
  - `TestSessionStore_HydrateFromCurrent_NotFoundIsNotRecorded` — empty memory keychain → no error recorded (signed-out is normal)
  - `TestSessionStore_HydrateFromCurrent_HealthyClearsPriorError` — recovery path, fresh healthy store reports no error
- [x] New orchestration test in `internal/commands/backup_test.go`:
  - `TestBackupStatus_KeychainErrorSurfaced` — injects faulty keychain via stack factory, asserts `StatusResult.KeychainError` contains the synthetic error message. Locks the `LastHydrateError → KeychainError` wiring.

## Out of scope

- HTTP-layer keychain failures during `Persist()` (login/signup) — those already surface as `INTERNAL_ERROR` envelope errors with their own remediation; no need for this channel.
- The "stale pointer" case (current-user pointer present but refresh entry absent at `Hydrate(uid)` time) — rare, self-heals on next login, intentionally not surfaced through this field. Kept that decision documented in the `HydrateFromCurrent` doc comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)