### PR TITLE
fix(backup): persist access token + expiry to skip per-call refresh

### DIFF
--- a/go-engine/internal/backup/auth/authenticator.go
+++ b/go-engine/internal/backup/auth/authenticator.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/golang-jwt/jwt/v5"
+
 	"github.com/Artexis10/endstate/go-engine/internal/backup/client"
 	"github.com/Artexis10/endstate/go-engine/internal/backup/crypto"
 	"github.com/Artexis10/endstate/go-engine/internal/backup/oidc"
@@ -130,7 +132,7 @@ func (a *Authenticator) CompleteLogin(ctx context.Context, email string, serverP
 	}, &resp); cerr != nil {
 		return nil, cerr
 	}
-	a.session.SetTokens(resp.UserID, strings.ToLower(email), resp.AccessToken, resp.RefreshToken, resp.SubscriptionStatus, time.Time{})
+	a.session.SetTokens(resp.UserID, strings.ToLower(email), resp.AccessToken, resp.RefreshToken, resp.SubscriptionStatus, parseAccessExpiry(resp.AccessToken))
 	if perr := a.session.Persist(); perr != nil {
 		// Persisting to the keychain failed — the session is still good
 		// in-process but won't survive a restart. Surface as INTERNAL_ERROR
@@ -170,7 +172,18 @@ func (a *Authenticator) refreshAccessToken(ctx context.Context) (string, error) 
 	}, &resp); cerr != nil {
 		return "", fmt.Errorf("auth: refresh: %s: %s", cerr.Code, cerr.Message)
 	}
-	a.session.SetTokens(snap.UserID, snap.Email, resp.AccessToken, resp.RefreshToken, snap.SubscriptionStatus, time.Time{})
+	// Contract guardrail (hosted-backup-contract.md §5.3 line 205-207): the
+	// refresh response must carry both tokens. Sliding-window rotation
+	// means the refresh token we just sent is now invalid server-side;
+	// accepting a response without a fresh refreshToken would leave the
+	// stale-and-invalid one in the keychain to fail on the next subprocess.
+	if resp.AccessToken == "" {
+		return "", errors.New("auth: refresh: substrate response missing accessToken")
+	}
+	if resp.RefreshToken == "" {
+		return "", errors.New("auth: refresh: substrate response missing refreshToken (sliding-window rotation requires a new RT; keychain RT is now stale)")
+	}
+	a.session.SetTokens(snap.UserID, snap.Email, resp.AccessToken, resp.RefreshToken, snap.SubscriptionStatus, parseAccessExpiry(resp.AccessToken))
 	if perr := a.session.Persist(); perr != nil {
 		return "", fmt.Errorf("auth: refresh: persist refresh token: %w", perr)
 	}
@@ -234,7 +247,7 @@ func (a *Authenticator) Signup(ctx context.Context, body SignupBody) (*CompleteL
 	}, &resp); cerr != nil {
 		return nil, cerr
 	}
-	a.session.SetTokens(resp.UserID, body.Email, resp.AccessToken, resp.RefreshToken, resp.SubscriptionStatus, time.Time{})
+	a.session.SetTokens(resp.UserID, body.Email, resp.AccessToken, resp.RefreshToken, resp.SubscriptionStatus, parseAccessExpiry(resp.AccessToken))
 	if perr := a.session.Persist(); perr != nil {
 		return &resp, envelope.NewError(envelope.ErrInternalError,
 			"signup succeeded but refresh token could not be saved to the OS keychain: "+perr.Error()).
@@ -324,7 +337,7 @@ func (a *Authenticator) RecoverFinalize(ctx context.Context, recoveryToken, emai
 	}, &resp); cerr != nil {
 		return nil, cerr
 	}
-	a.session.SetTokens(resp.UserID, strings.ToLower(email), resp.AccessToken, resp.RefreshToken, resp.SubscriptionStatus, time.Time{})
+	a.session.SetTokens(resp.UserID, strings.ToLower(email), resp.AccessToken, resp.RefreshToken, resp.SubscriptionStatus, parseAccessExpiry(resp.AccessToken))
 	if perr := a.session.Persist(); perr != nil {
 		return &resp, envelope.NewError(envelope.ErrInternalError,
 			"recovery finalize succeeded but refresh token could not be saved to the OS keychain: "+perr.Error()).
@@ -389,4 +402,30 @@ func mapDiscoveryError(err error) *envelope.Error {
 // base64Encode is a tiny helper that keeps the call sites readable.
 func base64Encode(b []byte) string {
 	return stdBase64.EncodeToString(b)
+}
+
+// parseAccessExpiry extracts the `exp` claim from a substrate-issued
+// access token without verifying the signature. We trust the token
+// substrate just handed us over TLS-validated HTTPS; we only need the
+// exp to decide when the cached value is no longer safe to send.
+//
+// Returns time.Time{} for unparseable input (e.g. tests that pass
+// opaque strings like "access-1" or a future substrate that issues
+// non-JWT access tokens). A zero return is the documented
+// "expiry unknown" signal and means SessionStore won't persist the
+// token to the keychain — the pre-F4 best-effort behavior continues.
+func parseAccessExpiry(token string) time.Time {
+	if token == "" {
+		return time.Time{}
+	}
+	parser := jwt.NewParser()
+	tok, _, err := parser.ParseUnverified(token, &Claims{})
+	if err != nil {
+		return time.Time{}
+	}
+	claims, ok := tok.Claims.(*Claims)
+	if !ok || claims.ExpiresAt == nil {
+		return time.Time{}
+	}
+	return claims.ExpiresAt.Time
 }

--- a/go-engine/internal/backup/auth/authenticator_test.go
+++ b/go-engine/internal/backup/auth/authenticator_test.go
@@ -5,6 +5,8 @@ package auth_test
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -12,6 +14,8 @@ import (
 	"sync/atomic"
 	"testing"
 	"time"
+
+	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/Artexis10/endstate/go-engine/internal/backup/auth"
 	"github.com/Artexis10/endstate/go-engine/internal/backup/client"
@@ -221,6 +225,269 @@ func TestAuthenticator_RefreshRotatesRefreshToken(t *testing.T) {
 	stored, _ := kc.Load(keychain.AccountForUser("user-1"))
 	if string(stored) != "refresh-2" {
 		t.Errorf("keychain entry = %q, want refresh-2 (rotated)", stored)
+	}
+}
+
+// TestAuthenticator_Refresh_RejectsMissingRefreshToken locks in the
+// fail-fast guardrail for substrate's sliding-window rotation contract
+// (hosted-backup-contract.md §5.3 line 207: "each refresh issues a new
+// refresh token; the old one is invalidated"). If substrate returns a
+// response without a fresh refreshToken, the previously persisted
+// refresh token is now server-side invalid — silently keeping it in the
+// keychain would surface as AUTH_REQUIRED on the next subprocess that
+// tries to use it (the "session disappears between subprocess
+// invocations" repro on engine 2.0.0).
+//
+// Required behavior: RefreshAccessToken returns an explicit error and
+// neither the in-memory session nor the keychain are mutated, so the
+// caller (the client's 401-refresh hook) propagates a clear error to
+// the user instead of leaving a stale RT behind to fail on the next call.
+func TestAuthenticator_Refresh_RejectsMissingRefreshToken(t *testing.T) {
+	fb := newFakeBackend(t)
+	a, kc := newAuthForTest(t, fb)
+	if _, err := a.CompleteLogin(context.Background(), "user@example.com", []byte("pw")); err != nil {
+		t.Fatal(err)
+	}
+	// Substrate returns an accessToken but omits the rotated refreshToken.
+	fb.refreshFn = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "2.0")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"accessToken": "access-2",
+		})
+	}
+
+	_, err := a.Session().RefreshAccessToken(context.Background())
+	if err == nil {
+		t.Fatal("RefreshAccessToken returned nil, want explicit error for missing refreshToken")
+	}
+
+	// The original refresh token must survive an invalid response so the
+	// user can re-login without re-deriving keys. (More important: if the
+	// in-memory rt is wiped, Persist's empty-rt early-return is the only
+	// reason the keychain wasn't corrupted — defending in two places.)
+	snap := a.Session().Snapshot()
+	if snap.RefreshToken != "refresh-1" {
+		t.Errorf("in-memory refreshToken = %q, want refresh-1 (must not be wiped on bad refresh response)", snap.RefreshToken)
+	}
+	stored, kerr := kc.Load(keychain.AccountForUser("user-1"))
+	if kerr != nil {
+		t.Fatalf("keychain.Load: %v", kerr)
+	}
+	if string(stored) != "refresh-1" {
+		t.Errorf("keychain entry = %q, want refresh-1 (must not be overwritten on bad refresh response)", stored)
+	}
+}
+
+// TestAuthenticator_Refresh_RejectsMissingAccessToken locks in the
+// symmetric guardrail: a refresh response with an empty accessToken is
+// also a contract violation. Without the guardrail the client's
+// 401-refresh hook would happily retry the original request with an
+// empty bearer, producing another 401 and a confusing AUTH_REQUIRED.
+func TestAuthenticator_Refresh_RejectsMissingAccessToken(t *testing.T) {
+	fb := newFakeBackend(t)
+	a, kc := newAuthForTest(t, fb)
+	if _, err := a.CompleteLogin(context.Background(), "user@example.com", []byte("pw")); err != nil {
+		t.Fatal(err)
+	}
+	fb.refreshFn = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "2.0")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"refreshToken": "refresh-2",
+		})
+	}
+
+	_, err := a.Session().RefreshAccessToken(context.Background())
+	if err == nil {
+		t.Fatal("RefreshAccessToken returned nil, want explicit error for missing accessToken")
+	}
+
+	stored, kerr := kc.Load(keychain.AccountForUser("user-1"))
+	if kerr != nil {
+		t.Fatalf("keychain.Load: %v", kerr)
+	}
+	if string(stored) != "refresh-1" {
+		t.Errorf("keychain entry = %q, want refresh-1 (must not be overwritten when accessToken is missing)", stored)
+	}
+}
+
+// TestAuthenticator_CompleteLogin_PersistsAccessTokenWithExpiry locks
+// the F4 fix: login parses the JWT's `exp` claim and persists the access
+// token to the keychain so subsequent subprocesses skip the per-call
+// refresh round-trip that was racing with substrate's reuse detection.
+func TestAuthenticator_CompleteLogin_PersistsAccessTokenWithExpiry(t *testing.T) {
+	fb := newFakeBackend(t)
+
+	// Mint a real EdDSA JWT carrying a known exp so we can decode the
+	// persisted entry and compare. The signature is not validated by
+	// parseAccessExpiry (we trust substrate's TLS), so the keypair is
+	// only here to produce a parseable token.
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	_ = pub
+	exp := time.Now().Add(15 * time.Minute).UTC().Truncate(time.Second)
+	jwtTok := signTestToken(t, "kid-1", priv, func(c *auth.Claims) {
+		c.ExpiresAt = jwt.NewNumericDate(exp)
+	})
+
+	fb.loginCompleteFn = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "2.0")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"userId":             "user-1",
+			"accessToken":        jwtTok,
+			"refreshToken":       "refresh-1",
+			"wrappedDEK":         "AAAA",
+			"subscriptionStatus": "active",
+		})
+	}
+
+	a, kc := newAuthForTest(t, fb)
+	if _, err := a.CompleteLogin(context.Background(), "user@example.com", []byte("pw")); err != nil {
+		t.Fatalf("CompleteLogin: %v", err)
+	}
+	raw, kerr := kc.Load(keychain.AccountForAccessToken("user-1"))
+	if kerr != nil {
+		t.Fatalf("expected access entry persisted after login, got %v", kerr)
+	}
+	var entry struct {
+		Token     string    `json:"token"`
+		ExpiresAt time.Time `json:"expiresAt"`
+	}
+	if err := json.Unmarshal(raw, &entry); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if entry.Token != jwtTok {
+		t.Errorf("persisted token mismatch")
+	}
+	if !entry.ExpiresAt.Equal(exp) {
+		t.Errorf("persisted exp = %v, want %v (must come from JWT exp claim)", entry.ExpiresAt, exp)
+	}
+}
+
+// TestAuthenticator_Refresh_PersistsAccessTokenWithExpiry verifies the
+// rotated access token also lands in the keychain with the new exp.
+func TestAuthenticator_Refresh_PersistsAccessTokenWithExpiry(t *testing.T) {
+	fb := newFakeBackend(t)
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	newExp := time.Now().Add(15 * time.Minute).UTC().Truncate(time.Second)
+	newJWT := signTestToken(t, "kid-1", priv, func(c *auth.Claims) {
+		c.ExpiresAt = jwt.NewNumericDate(newExp)
+	})
+
+	fb.refreshFn = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "2.0")
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"accessToken":  newJWT,
+			"refreshToken": "refresh-2",
+		})
+	}
+
+	a, kc := newAuthForTest(t, fb)
+	if _, err := a.CompleteLogin(context.Background(), "user@example.com", []byte("pw")); err != nil {
+		t.Fatalf("CompleteLogin: %v", err)
+	}
+	if _, err := a.Session().RefreshAccessToken(context.Background()); err != nil {
+		t.Fatalf("RefreshAccessToken: %v", err)
+	}
+	raw, kerr := kc.Load(keychain.AccountForAccessToken("user-1"))
+	if kerr != nil {
+		t.Fatalf("expected access entry persisted after refresh, got %v", kerr)
+	}
+	var entry struct {
+		Token     string    `json:"token"`
+		ExpiresAt time.Time `json:"expiresAt"`
+	}
+	if err := json.Unmarshal(raw, &entry); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if entry.Token != newJWT {
+		t.Errorf("persisted token didn't rotate after refresh")
+	}
+	if !entry.ExpiresAt.Equal(newExp) {
+		t.Errorf("persisted exp = %v, want %v", entry.ExpiresAt, newExp)
+	}
+}
+
+// TestAuthenticator_Refresh_NotCalledWhenCachedAccessTokenIsValid is the
+// behavioral root of the F4 fix: with a cached access token, calling Me()
+// in a fresh-session-from-keychain scenario must NOT trigger a refresh.
+// That's what eliminates the race with substrate's reuse-detection.
+func TestAuthenticator_Refresh_NotCalledWhenCachedAccessTokenIsValid(t *testing.T) {
+	fb := newFakeBackend(t)
+
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	exp := time.Now().Add(15 * time.Minute).UTC().Truncate(time.Second)
+	jwtTok := signTestToken(t, "kid-1", priv, func(c *auth.Claims) {
+		c.ExpiresAt = jwt.NewNumericDate(exp)
+	})
+
+	fb.loginCompleteFn = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "2.0")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"userId":             "user-1",
+			"accessToken":        jwtTok,
+			"refreshToken":       "refresh-1",
+			"wrappedDEK":         "AAAA",
+			"subscriptionStatus": "active",
+		})
+	}
+	// /api/account/me must require auth or the test passes vacuously —
+	// pre-F4 the engine would send no bearer (empty AT in a fresh
+	// subprocess) but the default fakeBackend /me accepts that, so the
+	// refresh-not-fired assertion needs teeth.
+	fb.meFn = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "2.0")
+		if r.Header.Get("Authorization") == "" {
+			w.WriteHeader(http.StatusUnauthorized)
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"success": false,
+				"error":   map[string]string{"code": "AUTH_REQUIRED", "message": "no bearer"},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"userId":             "user-1",
+			"email":              "user@example.com",
+			"subscriptionStatus": "active",
+			"createdAt":          "2026-05-02T00:00:00Z",
+		})
+	}
+
+	// Login on one session (writes the access entry to the shared
+	// keychain), then create a fresh session backed by the same keychain
+	// and call Me() — that simulates a `backup status` subprocess.
+	a1, kc := newAuthForTest(t, fb)
+	if _, err := a1.CompleteLogin(context.Background(), "user@example.com", []byte("pw")); err != nil {
+		t.Fatalf("CompleteLogin: %v", err)
+	}
+
+	// Fresh stack on the same keychain — the real-world "second
+	// subprocess" case. Reuses the fakeBackend so /api/account/me still
+	// works, and tracks refresh hits to assert none fire.
+	storeB := auth.NewSessionStore(kc)
+	oc := oidc.NewClient(fb.URL(), fb.srv.Client())
+	rp := client.RetryPolicy{MaxRetries: 0, InitialWait: time.Millisecond, Multiplier: 1, MaxWait: time.Millisecond}
+	hc := client.New(client.Options{Tokens: storeB, Retry: &rp})
+	a2 := auth.NewAuthenticator(auth.IssuerFromOIDC(oc, "endstate-backup"), oc, hc, storeB)
+	if err := storeB.HydrateFromCurrent(); err != nil {
+		t.Fatalf("HydrateFromCurrent: %v", err)
+	}
+
+	before := atomic.LoadInt32(&fb.refreshHits)
+	if _, err := a2.Me(context.Background()); err != nil {
+		t.Fatalf("Me on fresh stack: %v", err)
+	}
+	after := atomic.LoadInt32(&fb.refreshHits)
+	if after != before {
+		t.Errorf("refresh fired %d times on the second subprocess; want 0 (cached AT should be sufficient)", after-before)
 	}
 }
 

--- a/go-engine/internal/backup/auth/session.go
+++ b/go-engine/internal/backup/auth/session.go
@@ -14,6 +14,7 @@ package auth
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"sync"
 	"time"
@@ -21,6 +22,21 @@ import (
 	"github.com/Artexis10/endstate/go-engine/internal/backup/keychain"
 	"github.com/Artexis10/endstate/go-engine/internal/backup/oidc"
 )
+
+// accessSkewBuffer is how much wall-clock margin we add when deciding
+// whether a cached access token is "still good enough to use". Keeps a
+// freshly-hydrated token from being judged expired in flight just
+// because the substrate clock is a few seconds ahead of ours.
+const accessSkewBuffer = 30 * time.Second
+
+// persistedAccess is the on-disk JSON shape of the `endstate-access-{userId}`
+// keychain entry. Kept tiny on purpose: any growth here should be a
+// versioned migration, not an additive struct field — the keychain has no
+// schema-version channel of its own.
+type persistedAccess struct {
+	Token     string    `json:"token"`
+	ExpiresAt time.Time `json:"expiresAt"`
+}
 
 // SessionStore caches the access + refresh tokens for the current process
 // invocation. The refresh token is also persisted to the OS keychain so
@@ -57,16 +73,47 @@ func NewSessionStore(kc keychain.Keychain) *SessionStore {
 // into the in-memory session. Called by command handlers on startup so
 // subsequent calls have a session to act on. Returns keychain.ErrNotFound
 // if no refresh token is persisted (i.e. the user is signed out).
+//
+// Also opportunistically loads the persisted access token + expiry from
+// the F4 entry: if present and not yet within accessSkewBuffer of
+// expiry, the in-memory accessToken/accessExpiry fields are populated so
+// the next request can skip the 401-refresh hop. Missing or expired
+// access entries are silently ignored — the refresh path is the fallback.
 func (s *SessionStore) Hydrate(userID string) error {
 	rt, err := s.keychainClient.Load(keychain.AccountForUser(userID))
 	if err != nil {
 		return err
 	}
+	access, accessExp := s.loadCachedAccess(userID)
 	s.mu.Lock()
 	s.userID = userID
 	s.refreshToken = string(rt)
+	s.accessToken = access
+	s.accessExpiry = accessExp
 	s.mu.Unlock()
 	return nil
+}
+
+// loadCachedAccess reads and validates the F4 access-token entry for the
+// given userId. Returns ("", time.Time{}) when the entry is missing,
+// unparseable, or within accessSkewBuffer of expiring — in all such
+// cases the caller falls through to the refresh path.
+func (s *SessionStore) loadCachedAccess(userID string) (string, time.Time) {
+	raw, err := s.keychainClient.Load(keychain.AccountForAccessToken(userID))
+	if err != nil {
+		return "", time.Time{}
+	}
+	var entry persistedAccess
+	if err := json.Unmarshal(raw, &entry); err != nil {
+		return "", time.Time{}
+	}
+	if entry.Token == "" || entry.ExpiresAt.IsZero() {
+		return "", time.Time{}
+	}
+	if time.Now().Add(accessSkewBuffer).After(entry.ExpiresAt) {
+		return "", time.Time{}
+	}
+	return entry.Token, entry.ExpiresAt
 }
 
 // Persist writes the refresh token to the keychain under the canonical
@@ -86,12 +133,28 @@ func (s *SessionStore) Persist() error {
 	s.mu.Lock()
 	uid := s.userID
 	rt := s.refreshToken
+	access := s.accessToken
+	accessExp := s.accessExpiry
 	s.mu.Unlock()
 	if uid == "" || rt == "" {
 		return nil
 	}
 	if err := s.keychainClient.Store(keychain.AccountForUser(uid), []byte(rt)); err != nil {
 		return err
+	}
+	// F4: persist the access token alongside the refresh token when the
+	// caller supplied a parsed expiry. With no expiry we can't decide
+	// when to evict, so we skip rather than store an entry we can't
+	// trust. Callers (login/refresh) that parse the JWT pass a real
+	// expiry; pre-F4 callers fall through harmlessly.
+	if access != "" && !accessExp.IsZero() {
+		entry, mErr := json.Marshal(persistedAccess{Token: access, ExpiresAt: accessExp})
+		if mErr != nil {
+			return mErr
+		}
+		if err := s.keychainClient.Store(keychain.AccountForAccessToken(uid), entry); err != nil {
+			return err
+		}
 	}
 	return s.keychainClient.Store(keychain.AccountForCurrentUser(), []byte(uid))
 }
@@ -185,6 +248,11 @@ func (s *SessionStore) Forget() error {
 		}
 	}
 	if err := s.keychainClient.Delete(keychain.AccountForWrappedDEK(uid)); err != nil && err != keychain.ErrNotFound {
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	if err := s.keychainClient.Delete(keychain.AccountForAccessToken(uid)); err != nil && err != keychain.ErrNotFound {
 		if firstErr == nil {
 			firstErr = err
 		}
@@ -326,13 +394,18 @@ func (s *SessionStore) SignedIn() bool {
 
 // AccessToken implements client.TokenProvider.
 //
-// If the cached access token is expired (or expires within 30s), the
-// caller is expected to invoke a refresh before this returns. For the
-// integration scaffold we return whatever we have; the client package's
-// 401-refresh hook handles the rotation when needed.
+// F4: when the cached expiry is non-zero and within accessSkewBuffer of
+// expiring, return "" so the client.go 401-refresh hook fires on the
+// next request instead of sending a doomed bearer. When the expiry is
+// zero ("unknown") we trust the cached token — keeps pre-F4 callers
+// (and the recovery-finalize bearer, which has no parsed exp) working
+// unchanged.
 func (s *SessionStore) AccessToken(_ context.Context) (string, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if !s.accessExpiry.IsZero() && time.Now().Add(accessSkewBuffer).After(s.accessExpiry) {
+		return "", nil
+	}
 	return s.accessToken, nil
 }
 

--- a/go-engine/internal/backup/auth/session_test.go
+++ b/go-engine/internal/backup/auth/session_test.go
@@ -4,6 +4,8 @@
 package auth_test
 
 import (
+	"context"
+	"encoding/json"
 	"errors"
 	"testing"
 	"time"
@@ -136,6 +138,190 @@ func TestSessionStore_HydrateFromCurrent_HealthyClearsPriorError(t *testing.T) {
 	}
 	if got := healthy.LastHydrateError(); got != nil {
 		t.Errorf("LastHydrateError() on healthy fresh keychain = %v; want nil", got)
+	}
+}
+
+// TestSessionStore_AccessTokenHydratesWhenUnexpired locks in the F4
+// behavior: a persisted access token whose `expiresAt` is comfortably in
+// the future is re-hydrated into the in-memory session on a fresh
+// process. This eliminates the per-call refresh round-trip that races
+// with substrate's refresh-token reuse detection (the session-disappears
+// repro), because a valid cached AT lets `Me()` succeed without going
+// through `/api/auth/refresh`.
+func TestSessionStore_AccessTokenHydratesWhenUnexpired(t *testing.T) {
+	kc := keychain.NewMemory()
+	storeA := auth.NewSessionStore(kc)
+	exp := time.Now().Add(10 * time.Minute)
+	storeA.SetTokens("user-1", "user@example.com", "access-tok", "refresh-tok", "active", exp)
+	if err := storeA.Persist(); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+
+	storeB := auth.NewSessionStore(kc)
+	if err := storeB.HydrateFromCurrent(); err != nil {
+		t.Fatalf("HydrateFromCurrent: %v", err)
+	}
+	snap := storeB.Snapshot()
+	if snap.AccessToken != "access-tok" {
+		t.Errorf("AccessToken = %q, want access-tok (must be hydrated when expiry is in the future)", snap.AccessToken)
+	}
+	if snap.AccessExpiry.IsZero() {
+		t.Error("AccessExpiry is zero after hydrate; want the persisted expiry")
+	}
+	// Allow 1s skew for JSON RFC3339 round-trip.
+	if delta := snap.AccessExpiry.Sub(exp); delta > time.Second || delta < -time.Second {
+		t.Errorf("AccessExpiry off by %v from persisted value", delta)
+	}
+}
+
+// TestSessionStore_AccessTokenSkippedWhenExpired verifies the eviction
+// path: a persisted access token whose `expiresAt` is in the past (or
+// within the 30s skew window) is NOT hydrated, even though the
+// surrounding session state is. The refresh token still hydrates, so
+// `SignedIn()` stays true and the 401-refresh hook fires on the next
+// request — which is the correct fall-through.
+func TestSessionStore_AccessTokenSkippedWhenExpired(t *testing.T) {
+	kc := keychain.NewMemory()
+	storeA := auth.NewSessionStore(kc)
+	storeA.SetTokens("user-1", "u@e.com", "access-tok", "refresh-tok", "active", time.Now().Add(-time.Minute))
+	if err := storeA.Persist(); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+
+	storeB := auth.NewSessionStore(kc)
+	if err := storeB.HydrateFromCurrent(); err != nil {
+		t.Fatalf("HydrateFromCurrent: %v", err)
+	}
+	if !storeB.SignedIn() {
+		t.Fatal("expired AT must not affect SignedIn() — RT should still hydrate")
+	}
+	snap := storeB.Snapshot()
+	if snap.AccessToken != "" {
+		t.Errorf("AccessToken = %q, want empty (expired AT must not hydrate)", snap.AccessToken)
+	}
+	if snap.RefreshToken != "refresh-tok" {
+		t.Errorf("RefreshToken = %q, want refresh-tok (RT must still hydrate when AT is expired)", snap.RefreshToken)
+	}
+}
+
+// TestSessionStore_AccessTokenNotPersistedWhenZeroExpiry locks the
+// back-compat behavior: callers that don't supply a parsed expiry (the
+// existing `time.Time{}` shape that pre-F4 tests use) must not have their
+// access token persisted. Without an expiry we can't safely evict, so
+// the value never enters the keychain.
+func TestSessionStore_AccessTokenNotPersistedWhenZeroExpiry(t *testing.T) {
+	kc := keychain.NewMemory()
+	store := auth.NewSessionStore(kc)
+	store.SetTokens("user-1", "u@e.com", "access-tok", "refresh-tok", "active", time.Time{})
+	if err := store.Persist(); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+	if _, err := kc.Load(keychain.AccountForAccessToken("user-1")); err != keychain.ErrNotFound {
+		t.Errorf("access entry should be absent when expiry is zero; got err=%v", err)
+	}
+	// Refresh entry must still be written — back-compat with existing tests.
+	if _, err := kc.Load(keychain.AccountForUser("user-1")); err != nil {
+		t.Errorf("refresh entry should still be persisted; got err=%v", err)
+	}
+}
+
+// TestSessionStore_AccessTokenReturnsEmptyWhenExpired verifies the
+// TokenProvider contract: AccessToken() returns "" when the cached
+// expiry has passed, forcing the client.go 401-refresh hook to fire on
+// the next request. Without this, an expired AT would be sent in the
+// Authorization header and substrate would reject it as 401 anyway —
+// returning "" lets the engine skip that doomed round-trip.
+func TestSessionStore_AccessTokenReturnsEmptyWhenExpired(t *testing.T) {
+	store := auth.NewSessionStore(keychain.NewMemory())
+	store.SetTokens("user-1", "u@e.com", "access-tok", "refresh-tok", "active", time.Now().Add(-time.Minute))
+	got, err := store.AccessToken(context.Background())
+	if err != nil {
+		t.Fatalf("AccessToken: %v", err)
+	}
+	if got != "" {
+		t.Errorf("AccessToken() = %q, want empty (cached AT is expired)", got)
+	}
+}
+
+// TestSessionStore_AccessTokenReturnsValueWhenUnexpired is the positive
+// counterpart: a non-expired AT must round-trip through AccessToken().
+func TestSessionStore_AccessTokenReturnsValueWhenUnexpired(t *testing.T) {
+	store := auth.NewSessionStore(keychain.NewMemory())
+	store.SetTokens("user-1", "u@e.com", "access-tok", "refresh-tok", "active", time.Now().Add(10*time.Minute))
+	got, err := store.AccessToken(context.Background())
+	if err != nil {
+		t.Fatalf("AccessToken: %v", err)
+	}
+	if got != "access-tok" {
+		t.Errorf("AccessToken() = %q, want access-tok", got)
+	}
+}
+
+// TestSessionStore_AccessTokenReturnsValueWhenExpiryZero preserves the
+// pre-F4 default: when no expiry is known, AccessToken() returns the
+// cached value unchanged. Login/refresh paths that don't yet parse the
+// JWT continue to work; only callers that pass a parsed expiry get the
+// expiry-aware behavior.
+func TestSessionStore_AccessTokenReturnsValueWhenExpiryZero(t *testing.T) {
+	store := auth.NewSessionStore(keychain.NewMemory())
+	store.SetTokens("user-1", "u@e.com", "access-tok", "refresh-tok", "active", time.Time{})
+	got, err := store.AccessToken(context.Background())
+	if err != nil {
+		t.Fatalf("AccessToken: %v", err)
+	}
+	if got != "access-tok" {
+		t.Errorf("AccessToken() = %q, want access-tok (zero expiry is treated as unknown, not expired)", got)
+	}
+}
+
+// TestSessionStore_ForgetClearsAccessTokenEntry ensures logout fully
+// wipes session state. Without this, a stale access entry would survive
+// a re-login under a different account on the same machine.
+func TestSessionStore_ForgetClearsAccessTokenEntry(t *testing.T) {
+	kc := keychain.NewMemory()
+	store := auth.NewSessionStore(kc)
+	store.SetTokens("user-1", "u@e.com", "access-tok", "refresh-tok", "active", time.Now().Add(10*time.Minute))
+	if err := store.Persist(); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+	if _, err := kc.Load(keychain.AccountForAccessToken("user-1")); err != nil {
+		t.Fatalf("expected access entry present after Persist, got %v", err)
+	}
+	if err := store.Forget(); err != nil {
+		t.Fatalf("Forget: %v", err)
+	}
+	if _, err := kc.Load(keychain.AccountForAccessToken("user-1")); err != keychain.ErrNotFound {
+		t.Errorf("access entry = %v after Forget; want ErrNotFound", err)
+	}
+}
+
+// TestSessionStore_PersistedAccessEntryShape locks the on-disk JSON
+// shape so a future engine version that reads back an older entry
+// doesn't silently break.
+func TestSessionStore_PersistedAccessEntryShape(t *testing.T) {
+	kc := keychain.NewMemory()
+	store := auth.NewSessionStore(kc)
+	exp := time.Date(2026, 5, 11, 12, 0, 0, 0, time.UTC)
+	store.SetTokens("user-1", "u@e.com", "access-tok", "refresh-tok", "active", exp)
+	if err := store.Persist(); err != nil {
+		t.Fatalf("Persist: %v", err)
+	}
+	raw, err := kc.Load(keychain.AccountForAccessToken("user-1"))
+	if err != nil {
+		t.Fatalf("Load access entry: %v", err)
+	}
+	var entry struct {
+		Token     string    `json:"token"`
+		ExpiresAt time.Time `json:"expiresAt"`
+	}
+	if err := json.Unmarshal(raw, &entry); err != nil {
+		t.Fatalf("unmarshal: %v (raw=%s)", err, raw)
+	}
+	if entry.Token != "access-tok" {
+		t.Errorf("token field = %q, want access-tok", entry.Token)
+	}
+	if !entry.ExpiresAt.Equal(exp) {
+		t.Errorf("expiresAt field = %v, want %v", entry.ExpiresAt, exp)
 	}
 }
 

--- a/go-engine/internal/backup/keychain/keychain.go
+++ b/go-engine/internal/backup/keychain/keychain.go
@@ -66,6 +66,20 @@ func AccountForWrappedDEK(userID string) string {
 	return "endstate-wdek-" + userID
 }
 
+// AccountForAccessToken returns the canonical account name for the cached
+// access token (and its parsed `exp`) of a given userId. Persisting the
+// access token alongside the refresh token lets fresh subprocesses skip
+// the 401-refresh round-trip while the cached token is still valid (15-min
+// TTL per contract §4), eliminating the per-call refresh that races with
+// substrate's refresh-token reuse-detection (contract §5, refresh.ts:71-110).
+//
+// Stored as a small JSON blob `{"token":"<jwt>","expiresAt":"<RFC3339>"}`.
+// Cleared on logout/account-delete via SessionStore.Forget alongside the
+// other userID-keyed entries.
+func AccountForAccessToken(userID string) string {
+	return "endstate-access-" + userID
+}
+
 // AccountForCurrentUser is the fixed account name holding the userID of
 // the currently-signed-in user. Without this pointer a fresh process has
 // no way to discover which userID-keyed entries (refresh, DEK, wrappedDEK)


### PR DESCRIPTION
## Summary

- Persists the access token + its parsed `exp` claim alongside the refresh token under a new `endstate-access-{userId}` keychain entry, so fresh subprocesses skip the per-call `/api/auth/refresh` round-trip.
- Eliminates the race that was tripping substrate's refresh-token reuse-detection (OWASP-style sliding window, `substrate refresh.ts:71-110`) and revoking the entire chain when two near-concurrent subprocesses presented the same RT.
- Retains the earlier fail-fast guardrail rejecting refresh responses with empty `accessToken`/`refreshToken` fields.

## Background

After `endstate backup login` succeeded, a second `endstate backup status --json` call ~20s later returned `AUTH_REQUIRED` with substrate's message `refresh token already used; chain revoked`. The root cause: every subprocess started with `accessToken=""` because login persisted only the refresh token, so every status call refreshed. The GUI's sign-in flow fires `backupStatus` twice in quick succession (post-auth handler + backup-pane mount `useEffect`); both subprocesses hydrated the same RT, both presented it, substrate detected the reuse and revoked the chain.

The diagnostic logging temporarily added earlier in the investigation captured the smoking gun:

```
BACKUP-DIAG refresh HTTP error code=AUTH_REQUIRED message="refresh token already used; chain revoked"
```

## Behavior change

- **Login / Signup / RecoverFinalize / Refresh** all now parse the JWT `exp` claim via `jwt.ParseUnverified` and pass it into `SetTokens` instead of `time.Time{}`. The signature isn't validated here — we trust the token substrate just minted us over TLS-validated HTTPS; we only need the `exp` for cache eviction.
- **`SessionStore.Persist()`** writes `endstate-access-{userId}` (JSON `{"token":"...","expiresAt":"..."}`) when an expiry is supplied. Back-compat: with a zero expiry the entry is not written, so pre-F4 tests / paths that pass `time.Time{}` continue to work unchanged.
- **`SessionStore.Hydrate()`** loads the access entry, skipping it if `expiresAt` is within a 30s skew buffer of now. Refresh token hydration is unchanged.
- **`SessionStore.AccessToken()`** returns `""` when the cached expiry has passed, so `client.go`'s one-shot 401-refresh hook fires the next time the token is genuinely needed.
- **`SessionStore.Forget()`** also deletes the new access entry on logout.

Result: refresh fires ~once every 15 min instead of every call, which removes the race in practice. No cross-process lock needed.

## What's NOT in this PR

- **No GUI changes.** App.tsx fires `backupStatus` at five call sites; two race on sign-in. With this fix they no longer race because refresh is rare, so GUI coalescing is a separate code-hygiene PR, not a correctness one.
- **No cross-process refresh lock.** Documented as a hardening follow-up if telemetry shows residual reuse-detection events; F4 alone is sufficient for the bug.
- **No contract change.** `hosted-backup-contract.md` already specifies 15-minute access-token TTL with sliding-window refresh-token rotation; we're just using more of what the contract gives us.

## Test plan

- [x] `go test ./...` clean across the whole engine.
- [x] 8 new `SessionStore` tests in `session_test.go` covering hydrate-when-unexpired, skip-when-expired, no-persist-when-zero-expiry, `AccessToken()` eviction behavior, `Forget` clears entry, and on-disk JSON shape.
- [x] 3 new authenticator tests in `authenticator_test.go`: `CompleteLogin_PersistsAccessTokenWithExpiry`, `Refresh_PersistsAccessTokenWithExpiry`, and the key behavioral test `Refresh_NotCalledWhenCachedAccessTokenIsValid` (asserts a second fresh-stack subprocess does NOT call `/api/auth/refresh` when a valid cached AT is in the keychain).
- [x] Existing `TestAuthenticator_RefreshRotatesRefreshToken` still passes — happy-path rotation is unaffected.
- [x] Live end-to-end against real substrate: fresh login → status #1 succeeds with empty stderr (no refresh) → status #2 after wait succeeds with empty stderr → two parallel status subprocesses both succeed with empty stderr (the previously-racy case).

## Recovery note for existing broken sessions

This PR fixes the bug going forward but does not unstick a keychain that already holds a substrate-revoked refresh token (a "tombstone"). Users in that state should run `endstate backup logout` then `endstate backup login` to start a fresh chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)