### PR TITLE
feat(backup): add `backup claim` subcommand for anonymous-buyer credential attachment

### DIFF
--- a/go-engine/cmd/endstate/main.go
+++ b/go-engine/cmd/endstate/main.go
@@ -119,6 +119,7 @@ type parsedArgs struct {
 
 	// Backup / account flags
 	email          string
+	token          string
 	backupID       string
 	versionID      string
 	to             string
@@ -233,6 +234,11 @@ func parseArgs(args []string) parsedArgs {
 				p.email = args[i+1]
 				i++
 			}
+		case "--token":
+			if i+1 < len(args) {
+				p.token = args[i+1]
+				i++
+			}
 		case "--backup-id":
 			if i+1 < len(args) {
 				p.backupID = args[i+1]
@@ -305,7 +311,7 @@ func commandUsage(cmd string) string {
 	case "profile":
 		return "Usage: endstate profile <subcommand> [args] [--json]\n\nSubcommands:\n  list              List discovered profiles\n  path <name>       Resolve profile path from name\n  validate <path>   Validate a profile manifest\n"
 	case "backup":
-		return "Usage: endstate backup <subcommand> [flags] [--json] [--events jsonl]\n\nSubcommands:\n  signup --email <addr> --save-recovery-to <path>\n                              Create account (passphrase + optional 24-word phrase via stdin)\n  login --email <addr>          Sign in (passphrase via stdin)\n  logout                        Clear local session\n  status                        Report current session state\n  subscribe                     Start a Hosted Backup subscription checkout (returns checkoutUrl for the GUI to open)\n  push --profile <path> [--backup-id <id>] [--name <label>]\n                              Encrypt and upload a profile\n  pull --backup-id <id> --to <path> [--version-id <id>] [--overwrite]\n                              Download and restore a profile\n  list                          List backups\n  versions --backup-id <id>     List versions of a backup\n  delete --backup-id <id> --confirm\n                              Permanently delete a backup\n  delete-version --backup-id <id> --version-id <id> --confirm\n                              Soft-delete a backup version\n  recover --email <addr>        Reset passphrase using recovery phrase (stdin: phrase, then new passphrase)\n\nEnv vars:\n  ENDSTATE_OIDC_ISSUER_URL    Backend issuer URL (default: https://substratesystems.io)\n  ENDSTATE_OIDC_AUDIENCE      JWT audience (default: endstate-backup)\n  ENDSTATE_BACKUP_CONCURRENCY Worker pool size for chunk transfer (default 4, clamp 1..16)\n"
+		return "Usage: endstate backup <subcommand> [flags] [--json] [--events jsonl]\n\nSubcommands:\n  signup --email <addr> --save-recovery-to <path>\n                              Create account (passphrase + optional 24-word phrase via stdin)\n  claim --token <token> --save-recovery-to <path>\n                              Attach credentials to a pre-account using the bearer claim token\n                              from the buyer's purchase email (passphrase via stdin).\n                              Replaces any existing local session on success.\n  login --email <addr>          Sign in (passphrase via stdin)\n  logout                        Clear local session\n  status                        Report current session state\n  subscribe                     Start a Hosted Backup subscription checkout (returns checkoutUrl for the GUI to open)\n  push --profile <path> [--backup-id <id>] [--name <label>]\n                              Encrypt and upload a profile\n  pull --backup-id <id> --to <path> [--version-id <id>] [--overwrite]\n                              Download and restore a profile\n  list                          List backups\n  versions --backup-id <id>     List versions of a backup\n  delete --backup-id <id> --confirm\n                              Permanently delete a backup\n  delete-version --backup-id <id> --version-id <id> --confirm\n                              Soft-delete a backup version\n  recover --email <addr>        Reset passphrase using recovery phrase (stdin: phrase, then new passphrase)\n\nEnv vars:\n  ENDSTATE_OIDC_ISSUER_URL    Backend issuer URL (default: https://substratesystems.io)\n  ENDSTATE_OIDC_AUDIENCE      JWT audience (default: endstate-backup)\n  ENDSTATE_BACKUP_CONCURRENCY Worker pool size for chunk transfer (default 4, clamp 1..16)\n"
 	case "account":
 		return "Usage: endstate account <subcommand> [flags] [--json]\n\nSubcommands:\n  delete --confirm  Delete the Hosted Backup account permanently\n"
 	case "bootstrap":
@@ -499,6 +505,7 @@ func dispatch(p parsedArgs) (interface{}, *envelope.Error) {
 			Subcommand:     subcommand,
 			Args:           subArgs,
 			Email:          p.email,
+			Token:          p.token,
 			BackupID:       p.backupID,
 			VersionID:      p.versionID,
 			Profile:        p.profile,

--- a/go-engine/internal/backup/auth/authenticator.go
+++ b/go-engine/internal/backup/auth/authenticator.go
@@ -104,8 +104,14 @@ type completeLoginRequest struct {
 }
 
 // CompleteLoginResponse matches the contract §5 step-2 response shape.
+//
+// Email is populated only by `/api/auth/claim` — substrate has the
+// canonical email from Paddle and returns it so the engine can display
+// the same identity the buyer purchased under. Other endpoints
+// (signup, login, recover-finalize, refresh) leave it empty.
 type CompleteLoginResponse struct {
 	UserID             string `json:"userId"`
+	Email              string `json:"email,omitempty"`
 	AccessToken        string `json:"accessToken"`
 	RefreshToken       string `json:"refreshToken"`
 	WrappedDEK         string `json:"wrappedDEK"`
@@ -251,6 +257,71 @@ func (a *Authenticator) Signup(ctx context.Context, body SignupBody) (*CompleteL
 	if perr := a.session.Persist(); perr != nil {
 		return &resp, envelope.NewError(envelope.ErrInternalError,
 			"signup succeeded but refresh token could not be saved to the OS keychain: "+perr.Error()).
+			WithRemediation("Re-run `endstate backup login` after addressing the keychain access issue.")
+	}
+	return &resp, nil
+}
+
+// ClaimBody is the POST /api/auth/claim request body. Structurally
+// identical to SignupBody minus Email — substrate identifies the user
+// from the claim-token row (keyed by the bearer token), so the email
+// on the wire would be ignored anyway and surfacing one in the GUI
+// would invite identity-mismatch confusion. The credential block is
+// byte-identical to signup's; the KDF floor check is enforced by
+// substrate on the receiving side.
+type ClaimBody struct {
+	ServerPassword        string           `json:"serverPassword"`
+	Salt                  string           `json:"salt"`
+	KDFParams             crypto.KDFParams `json:"kdfParams"`
+	WrappedDEK            string           `json:"wrappedDEK"`
+	RecoveryKeyVerifier   string           `json:"recoveryKeyVerifier"`
+	RecoveryKeyWrappedDEK string           `json:"recoveryKeyWrappedDEK"`
+}
+
+// Claim performs `POST /api/auth/claim` with `Authorization: Bearer
+// <claimToken>`. Mirrors Signup's success path: on 200 the session is
+// updated with the returned tokens (email is server-supplied) and the
+// refresh token is persisted to the keychain. The caller is
+// responsible for caching the unwrapped DEK via SessionStore.StoreDEK
+// separately — Claim does not see plaintext keys.
+//
+// SkipAuthRefresh is required: the bearer IS the claim token, not an
+// access token. A 401 here means the claim token is invalid, expired,
+// or already consumed; recursing into the refresh hook would loop
+// without progress AND risk clobbering the intended substrate
+// identity.
+//
+// URL: prefer discovery's `auth_claim_endpoint` when non-empty; fall
+// back to `<issuer>/api/auth/claim` otherwise (substrate v1 does not
+// advertise the discovery field — see `oidc.EndstateExtensions`).
+func (a *Authenticator) Claim(ctx context.Context, claimToken string, body ClaimBody) (*CompleteLoginResponse, *envelope.Error) {
+	if strings.TrimSpace(claimToken) == "" {
+		return nil, envelope.NewError(envelope.ErrInternalError,
+			"claim: empty claimToken — caller must pass the token from the buyer's claim link")
+	}
+	doc, err := a.oidc.Discovery(ctx)
+	if err != nil {
+		return nil, mapDiscoveryError(err)
+	}
+	url := doc.EndstateExtensions.AuthClaimEndpoint
+	if url == "" {
+		url = strings.TrimRight(a.issuer.URL, "/") + "/api/auth/claim"
+	}
+	var resp CompleteLoginResponse
+	if cerr := a.httpc.Do(ctx, client.Request{
+		Method:          "POST",
+		URL:             url,
+		Body:            body,
+		Headers:         http.Header{"Authorization": []string{"Bearer " + claimToken}},
+		ReadOnly:        false,
+		SkipAuthRefresh: true,
+	}, &resp); cerr != nil {
+		return nil, cerr
+	}
+	a.session.SetTokens(resp.UserID, strings.ToLower(resp.Email), resp.AccessToken, resp.RefreshToken, resp.SubscriptionStatus, parseAccessExpiry(resp.AccessToken))
+	if perr := a.session.Persist(); perr != nil {
+		return &resp, envelope.NewError(envelope.ErrInternalError,
+			"claim succeeded but refresh token could not be saved to the OS keychain: "+perr.Error()).
 			WithRemediation("Re-run `endstate backup login` after addressing the keychain access issue.")
 	}
 	return &resp, nil

--- a/go-engine/internal/backup/client/client.go
+++ b/go-engine/internal/backup/client/client.go
@@ -299,10 +299,21 @@ func parseAPIError(resp *http.Response, body []byte) *APIError {
 			ae.Detail = env.Error.Detail
 			ae.Remediation = env.Error.Remediation
 			ae.DocsKey = env.Error.DocsKey
-			// Substrate may surface STORAGE_QUOTA_EXCEEDED on a 409 (or 403).
-			// Honour their code when it's one we recognise.
-			if up := strings.ToUpper(env.Error.Code); up == "STORAGE_QUOTA_EXCEEDED" {
+			// Substrate may surface domain codes on the response body
+			// that warrant overriding the status-derived envelope code:
+			//   - STORAGE_QUOTA_EXCEEDED → mapped to a typed engine
+			//     constant (engine has a native semantic).
+			//   - CLAIM_TOKEN_INVALID / EXPIRED / CONSUMED, KDF_TOO_WEAK
+			//     → passed through verbatim. The engine does not own the
+			//     claim-flow error namespace; the GUI's friendly-error
+			//     map switches on the wire-string code. `envelope.ErrorCode`
+			//     is `type ErrorCode string`, so casting is sound.
+			switch up := strings.ToUpper(env.Error.Code); up {
+			case "STORAGE_QUOTA_EXCEEDED":
 				ae.Code = envelope.ErrStorageQuotaExceeded
+			case "CLAIM_TOKEN_INVALID", "CLAIM_TOKEN_EXPIRED",
+				"CLAIM_TOKEN_CONSUMED", "KDF_TOO_WEAK":
+				ae.Code = envelope.ErrorCode(up)
 			}
 		}
 	}

--- a/go-engine/internal/backup/oidc/oidc.go
+++ b/go-engine/internal/backup/oidc/oidc.go
@@ -62,6 +62,10 @@ type EndstateExtensions struct {
 	AuthRefreshEndpoint       string         `json:"auth_refresh_endpoint"`
 	AuthLogoutEndpoint        string         `json:"auth_logout_endpoint"`
 	AuthRecoverEndpoint       string         `json:"auth_recover_endpoint"`
+	// AuthClaimEndpoint is optional: substrate v1 does not yet advertise
+	// it. When absent, callers fall back to `<issuer>/api/auth/claim`.
+	// See `Authenticator.Claim`.
+	AuthClaimEndpoint         string         `json:"auth_claim_endpoint,omitempty"`
 	BackupAPIBase             string         `json:"backup_api_base"`
 	SupportedKDFAlgorithms    []string       `json:"supported_kdf_algorithms"`
 	SupportedEnvelopeVersions []int          `json:"supported_envelope_versions"`

--- a/go-engine/internal/commands/backup.go
+++ b/go-engine/internal/commands/backup.go
@@ -35,6 +35,10 @@ type BackupFlags struct {
 	// Email is the --email flag (login, recover).
 	Email string
 
+	// Token is the --token flag (claim), the 43-char URL-safe base64
+	// claim-token from the buyer's claim email.
+	Token string
+
 	// BackupID identifies an existing backup (versions, push, pull, delete).
 	BackupID string
 
@@ -75,6 +79,8 @@ func RunBackup(flags BackupFlags) (interface{}, *envelope.Error) {
 	switch flags.Subcommand {
 	case "signup":
 		return runBackupSignup(flags)
+	case "claim":
+		return runBackupClaim(flags)
 	case "login":
 		return runBackupLogin(flags)
 	case "logout":
@@ -85,7 +91,7 @@ func RunBackup(flags BackupFlags) (interface{}, *envelope.Error) {
 		return runBackupSubscribe(flags)
 	case "":
 		return nil, envelope.NewError(envelope.ErrInternalError,
-			"backup requires a subcommand (signup, login, logout, status, subscribe, push, pull, list, versions, delete, delete-version, recover)")
+			"backup requires a subcommand (signup, claim, login, logout, status, subscribe, push, pull, list, versions, delete, delete-version, recover)")
 	case "list":
 		return runBackupList(flags)
 	case "versions":

--- a/go-engine/internal/commands/backup_claim.go
+++ b/go-engine/internal/commands/backup_claim.go
@@ -1,0 +1,203 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"context"
+	"crypto/rand"
+	"os"
+	"strings"
+
+	"github.com/Artexis10/endstate/go-engine/internal/backup/auth"
+	"github.com/Artexis10/endstate/go-engine/internal/backup/crypto"
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// runBackupClaim attaches credentials to a Hosted Backup pre-account
+// using a single-use bearer claim token from the buyer's purchase
+// email. Structurally identical to runBackupSignup: the only deltas
+// are at the HTTP boundary (bearer header + no email in the body,
+// server-supplied email in the response).
+//
+// The token is validated client-side as a UX optimisation (length 43,
+// URL-safe base64 alphabet) so an obviously-malformed paste is
+// rejected before any network call. Substrate is the source of truth
+// for token validity — it returns CLAIM_TOKEN_INVALID for a
+// well-formed token that doesn't match a `claim_tokens` row.
+//
+// See `openspec/changes/add-backup-claim-subcommand/`.
+func runBackupClaim(flags BackupFlags) (interface{}, *envelope.Error) {
+	if strings.TrimSpace(flags.Token) == "" {
+		return nil, envelope.NewError(envelope.ErrInternalError,
+			"backup claim requires --token <claim-token>").
+			WithRemediation("Pass --token <43-char URL-safe base64 token>; the passphrase is read from stdin.")
+	}
+	if !validClaimToken(flags.Token) {
+		return nil, envelope.NewError(envelope.ErrInternalError,
+			"backup claim: --token must be 43 characters of URL-safe base64 (alphabet [A-Za-z0-9_-])").
+			WithRemediation("Re-copy the token from the link in your purchase claim email.")
+	}
+
+	passphrase, recoveryPhrase, ierr := signupReader(os.Stdin)
+	if ierr != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, "backup claim: read stdin: "+ierr.Error()).
+			WithRemediation("Pipe the passphrase to stdin (and optionally a recovery phrase on the next line).")
+	}
+	if strings.TrimSpace(passphrase) == "" {
+		return nil, envelope.NewError(envelope.ErrInternalError,
+			"backup claim: empty passphrase").
+			WithRemediation("Provide a non-empty passphrase via stdin.")
+	}
+
+	// Decide between supplied vs generated mnemonic. Same rule as
+	// signup: when not supplied, --save-recovery-to is mandatory.
+	mnemonicSupplied := strings.TrimSpace(recoveryPhrase) != ""
+	if !mnemonicSupplied && strings.TrimSpace(flags.SaveRecoveryTo) == "" {
+		return nil, envelope.NewError(envelope.ErrInternalError,
+			"backup claim: --save-recovery-to <path> is required when no recovery phrase is supplied on stdin").
+			WithRemediation("Either pipe a 24-word BIP39 mnemonic on the second stdin line, or pass --save-recovery-to <path> so the engine can write the freshly generated mnemonic.")
+	}
+
+	var rkBytes [32]byte
+	var mnemonic string
+
+	if mnemonicSupplied {
+		var perr error
+		rkBytes, perr = crypto.ParseRecoveryPhrase(recoveryPhrase)
+		if perr != nil {
+			return nil, envelope.NewError(envelope.ErrInternalError, "backup claim: parse recovery phrase: "+perr.Error()).
+				WithRemediation("Supply a valid 24-word BIP39 mnemonic on stdin (line 2). Order and spelling must match the standard wordlist.")
+		}
+		mnemonic = strings.TrimSpace(recoveryPhrase)
+	} else {
+		rk, gerr := crypto.GenerateRecoveryKey()
+		if gerr != nil {
+			return nil, envelope.NewError(envelope.ErrInternalError, "backup claim: generate recovery key: "+gerr.Error())
+		}
+		copy(rkBytes[:], rk.Bytes[:])
+		mnemonic = rk.Phrase
+	}
+
+	// Generate per-user salt + DEK.
+	salt := make([]byte, crypto.SaltSize)
+	if _, rerr := rand.Read(salt); rerr != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, "backup claim: generate salt: "+rerr.Error())
+	}
+	dek, derr := crypto.GenerateDEK()
+	if derr != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, "backup claim: generate DEK: "+derr.Error())
+	}
+
+	params := crypto.DefaultKDFParams()
+
+	derived, kerr := crypto.DeriveKeys(passphrase, salt, params)
+	if kerr != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, "backup claim: derive keys: "+kerr.Error())
+	}
+	defer zero32(&derived.MasterKey)
+	defer zero32(&derived.ServerPassword)
+
+	wrappedDEK, werr := crypto.WrapDEK(dek, derived.MasterKey)
+	if werr != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, "backup claim: wrap DEK: "+werr.Error())
+	}
+
+	recoveryKey, rderr := crypto.DeriveRecoveryKey(rkBytes, salt, params)
+	if rderr != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, "backup claim: derive recovery key: "+rderr.Error())
+	}
+	defer zero32(&recoveryKey)
+
+	recoveryKeyWrappedDEK, rwerr := crypto.WrapDEK(dek, recoveryKey)
+	if rwerr != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, "backup claim: wrap DEK with recovery key: "+rwerr.Error())
+	}
+
+	recoveryKeyVerifier, vverr := crypto.RecoveryKeyVerifier(recoveryKey, salt, params)
+	if vverr != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, "backup claim: compute recovery verifier: "+vverr.Error())
+	}
+
+	// Write the recovery file BEFORE the network call. Identical
+	// to signup — the contract requires the user has the recovery
+	// key on disk before the substrate-side credentials are written.
+	recoverySavedTo := ""
+	if strings.TrimSpace(flags.SaveRecoveryTo) != "" {
+		path, werr := writeRecoveryFile(flags.SaveRecoveryTo, mnemonic)
+		if werr != nil {
+			return nil, envelope.NewError(envelope.ErrInternalError,
+				"backup claim: write recovery file: "+werr.Error()).
+				WithRemediation("Choose a path you can write to, or pipe a recovery phrase on stdin to skip writing.")
+		}
+		recoverySavedTo = path
+	}
+
+	// Submit claim to substrate.
+	a := newBackupStack().Auth
+	ctx := context.Background()
+
+	body := auth.ClaimBody{
+		ServerPassword:        b64.EncodeToString(derived.ServerPassword[:]),
+		Salt:                  b64.EncodeToString(salt),
+		KDFParams:             params,
+		WrappedDEK:            b64.EncodeToString(wrappedDEK),
+		RecoveryKeyVerifier:   b64.EncodeToString(recoveryKeyVerifier),
+		RecoveryKeyWrappedDEK: b64.EncodeToString(recoveryKeyWrappedDEK),
+	}
+
+	resp, envErr := a.Claim(ctx, flags.Token, body)
+	if envErr != nil {
+		return nil, envErr
+	}
+
+	// Persist the unwrapped DEK + the masterKey-wrapped DEK alongside
+	// the refresh token. Identical to signup.
+	if serr := a.Session().StoreDEK(dek); serr != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError,
+			"claim succeeded but DEK could not be cached in the OS keychain: "+serr.Error()).
+			WithRemediation("Re-run `endstate backup login` after addressing the keychain access issue.")
+	}
+	if werr := a.Session().StoreWrappedDEK(body.WrappedDEK); werr != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError,
+			"claim succeeded but wrappedDEK could not be cached in the OS keychain: "+werr.Error()).
+			WithRemediation("Re-run `endstate backup login` after addressing the keychain access issue.")
+	}
+
+	// Best-effort wipe of the local DEK copy.
+	for i := range dek {
+		dek[i] = 0
+	}
+
+	return &SignupResult{
+		UserID:             resp.UserID,
+		Email:              strings.ToLower(resp.Email),
+		SubscriptionStatus: resp.SubscriptionStatus,
+		RecoveryKeySavedTo: recoverySavedTo,
+	}, nil
+}
+
+// validClaimToken returns true iff t is exactly 43 characters from the
+// URL-safe base64 alphabet (RFC 4648 §5, unpadded). Substrate mints
+// 32-byte random tokens encoded with base64url-no-padding → 43 chars.
+//
+// This is a UX gate — substrate is the source of truth for token
+// validity. A well-formed token that doesn't match a `claim_tokens`
+// row returns `CLAIM_TOKEN_INVALID` from the server side.
+func validClaimToken(t string) bool {
+	if len(t) != 43 {
+		return false
+	}
+	for _, r := range t {
+		switch {
+		case r >= 'A' && r <= 'Z',
+			r >= 'a' && r <= 'z',
+			r >= '0' && r <= '9',
+			r == '-', r == '_':
+			continue
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/go-engine/internal/commands/backup_claim_test.go
+++ b/go-engine/internal/commands/backup_claim_test.go
@@ -1,0 +1,312 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands_test
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/backup"
+	"github.com/Artexis10/endstate/go-engine/internal/backup/keychain"
+	"github.com/Artexis10/endstate/go-engine/internal/commands"
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+const validClaimTokenFixture = "AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIIIJJJJKKK" // 43 chars, URL-safe base64 alphabet
+
+// claimBackend is the test fixture for `/api/auth/claim`. Mounts the
+// auth-discovery routes (issuer, jwks, login, etc.) on a fresh mux +
+// httptest.Server so claim tests don't share mutable state with other
+// suites. The claim handler captures inbound requests so tests can
+// assert on the Authorization header, body shape, and hit count.
+type claimBackend struct {
+	srv       *httptest.Server
+	hits      int32
+	claimFn   http.HandlerFunc
+	lastAuth  string
+	lastBody  []byte
+	captureMu chan struct{} // single-slot mutex; tests don't need finer concurrency
+}
+
+func newClaimBackend(t *testing.T) *claimBackend {
+	t.Helper()
+	cb := &claimBackend{captureMu: make(chan struct{}, 1)}
+	mux := http.NewServeMux()
+	srv := httptest.NewServer(mux)
+	cb.srv = srv
+	t.Cleanup(srv.Close)
+	addAuthRoutes(mux, srv)
+	mux.HandleFunc("/api/auth/claim", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "2.0")
+		atomic.AddInt32(&cb.hits, 1)
+		body, _ := io.ReadAll(r.Body)
+		cb.captureMu <- struct{}{}
+		cb.lastAuth = r.Header.Get("Authorization")
+		cb.lastBody = body
+		<-cb.captureMu
+		if cb.claimFn != nil {
+			cb.claimFn(w, r)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"userId":             "user-claim-1",
+			"email":              "buyer@example.com",
+			"accessToken":        "access-claim",
+			"refreshToken":       "refresh-claim",
+			"subscriptionStatus": "active",
+		})
+	})
+	return cb
+}
+
+func TestBackupClaim_HappyPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Argon2id v1 floor parameters are heavy; skipped in short mode")
+	}
+	cb := newClaimBackend(t)
+	kc := keychain.NewMemory()
+	defer commands.ReplaceBackupStackFactoryForTest(func() *backup.Stack {
+		return stackForBackend(cb.srv, kc)
+	})()
+	defer commands.WithSignupReader(func(io.Reader) (string, string, error) {
+		return "secret-pass", "", nil
+	})()
+
+	tmp := t.TempDir()
+	recoveryPath := filepath.Join(tmp, "recovery.txt")
+
+	data, err := commands.RunBackup(commands.BackupFlags{
+		Subcommand:     "claim",
+		Token:          validClaimTokenFixture,
+		SaveRecoveryTo: recoveryPath,
+	})
+	if err != nil {
+		t.Fatalf("claim: %+v", err)
+	}
+	res, ok := data.(*commands.SignupResult)
+	if !ok {
+		t.Fatalf("data type = %T", data)
+	}
+	// Server-supplied email is what the engine surfaces, lowercased.
+	if res.Email != "buyer@example.com" {
+		t.Errorf("Email = %q, want buyer@example.com (server-supplied)", res.Email)
+	}
+	if res.UserID != "user-claim-1" {
+		t.Errorf("UserID = %q, want user-claim-1", res.UserID)
+	}
+	if res.SubscriptionStatus != "active" {
+		t.Errorf("SubscriptionStatus = %q, want active", res.SubscriptionStatus)
+	}
+	if res.RecoveryKeySavedTo != recoveryPath {
+		t.Errorf("RecoveryKeySavedTo = %q, want %q", res.RecoveryKeySavedTo, recoveryPath)
+	}
+	// Recovery file present, contains 24 BIP39 words.
+	body, statErr := os.ReadFile(recoveryPath)
+	if statErr != nil {
+		t.Fatalf("recovery file missing: %v", statErr)
+	}
+	mnemonicLine := lastNonHashLine(string(body))
+	if got := len(strings.Fields(mnemonicLine)); got != 24 {
+		t.Errorf("recovery file mnemonic word count = %d, want 24", got)
+	}
+	// Refresh token + DEK persisted in keychain under the server-supplied userId.
+	if _, kerr := kc.Load(keychain.AccountForUser("user-claim-1")); kerr != nil {
+		t.Errorf("refresh token not in keychain: %v", kerr)
+	}
+	if _, kerr := kc.Load(keychain.AccountForDEK("user-claim-1")); kerr != nil {
+		t.Errorf("DEK not in keychain: %v", kerr)
+	}
+	// Exactly one claim call, bearer header set, body has no email field.
+	if atomic.LoadInt32(&cb.hits) != 1 {
+		t.Errorf("claim hits = %d, want 1", cb.hits)
+	}
+	wantAuth := "Bearer " + validClaimTokenFixture
+	if cb.lastAuth != wantAuth {
+		t.Errorf("Authorization header = %q, want %q", cb.lastAuth, wantAuth)
+	}
+	var bodyMap map[string]interface{}
+	if jerr := json.Unmarshal(cb.lastBody, &bodyMap); jerr != nil {
+		t.Fatalf("request body decode: %v (body=%q)", jerr, cb.lastBody)
+	}
+	if _, present := bodyMap["email"]; present {
+		t.Errorf("request body should NOT include email; got: %v", bodyMap)
+	}
+	for _, want := range []string{"serverPassword", "salt", "kdfParams", "wrappedDEK", "recoveryKeyVerifier", "recoveryKeyWrappedDEK"} {
+		if _, present := bodyMap[want]; !present {
+			t.Errorf("request body missing %q (full body: %v)", want, bodyMap)
+		}
+	}
+}
+
+func TestBackupClaim_RequiresToken(t *testing.T) {
+	_, err := commands.RunBackup(commands.BackupFlags{Subcommand: "claim"})
+	if err == nil || err.Code != envelope.ErrInternalError {
+		t.Fatalf("got %+v, want INTERNAL_ERROR", err)
+	}
+	if !strings.Contains(err.Message, "--token") {
+		t.Errorf("error message %q should mention --token", err.Message)
+	}
+}
+
+func TestBackupClaim_RejectsMalformedToken(t *testing.T) {
+	_, err := commands.RunBackup(commands.BackupFlags{
+		Subcommand: "claim",
+		Token:      "too-short",
+	})
+	if err == nil || err.Code != envelope.ErrInternalError {
+		t.Fatalf("got %+v, want INTERNAL_ERROR", err)
+	}
+	if !strings.Contains(err.Message, "43 characters") {
+		t.Errorf("error message %q should mention '43 characters'", err.Message)
+	}
+}
+
+func TestBackupClaim_RejectsTokenWithBadAlphabet(t *testing.T) {
+	// Length 43 but includes '+' (not in the URL-safe alphabet).
+	bad := strings.Repeat("A", 42) + "+"
+	_, err := commands.RunBackup(commands.BackupFlags{
+		Subcommand: "claim",
+		Token:      bad,
+	})
+	if err == nil || err.Code != envelope.ErrInternalError {
+		t.Fatalf("got %+v, want INTERNAL_ERROR", err)
+	}
+	if !strings.Contains(err.Message, "URL-safe base64") {
+		t.Errorf("error message %q should mention URL-safe base64", err.Message)
+	}
+}
+
+func TestBackupClaim_RequiresSaveRecoveryToWhenGenerating(t *testing.T) {
+	defer commands.WithSignupReader(func(io.Reader) (string, string, error) {
+		return "secret-pass", "", nil
+	})()
+	_, err := commands.RunBackup(commands.BackupFlags{
+		Subcommand: "claim",
+		Token:      validClaimTokenFixture,
+		// SaveRecoveryTo deliberately empty
+	})
+	if err == nil || err.Code != envelope.ErrInternalError {
+		t.Fatalf("got %+v, want INTERNAL_ERROR", err)
+	}
+	if !strings.Contains(err.Message, "--save-recovery-to") {
+		t.Errorf("error message %q should mention --save-recovery-to", err.Message)
+	}
+}
+
+func TestBackupClaim_RequiresPassphrase(t *testing.T) {
+	defer commands.WithSignupReader(func(io.Reader) (string, string, error) {
+		return "", "", nil
+	})()
+	_, err := commands.RunBackup(commands.BackupFlags{
+		Subcommand:     "claim",
+		Token:          validClaimTokenFixture,
+		SaveRecoveryTo: filepath.Join(t.TempDir(), "r.txt"),
+	})
+	if err == nil || err.Code != envelope.ErrInternalError {
+		t.Fatalf("got %+v, want INTERNAL_ERROR", err)
+	}
+	if !strings.Contains(err.Message, "passphrase") {
+		t.Errorf("error message %q should mention passphrase", err.Message)
+	}
+}
+
+func TestBackupClaim_RecoveryFileWriteFailureNoNetworkCall(t *testing.T) {
+	if testing.Short() {
+		t.Skip("exercises real KDF before the failing write; heavy in short mode")
+	}
+	cb := newClaimBackend(t)
+	kc := keychain.NewMemory()
+	defer commands.ReplaceBackupStackFactoryForTest(func() *backup.Stack {
+		return stackForBackend(cb.srv, kc)
+	})()
+	defer commands.WithSignupReader(func(io.Reader) (string, string, error) {
+		return "secret-pass", "", nil
+	})()
+
+	// Make the parent path unwritable by pointing it at an existing
+	// file rather than a directory — writeRecoveryFile's MkdirAll
+	// will fail because the parent path component is a regular file.
+	tmp := t.TempDir()
+	regularFile := filepath.Join(tmp, "blocking-file")
+	if werr := os.WriteFile(regularFile, []byte("blocker"), 0o600); werr != nil {
+		t.Fatalf("seed blocker file: %v", werr)
+	}
+	recoveryPath := filepath.Join(regularFile, "child", "recovery.txt")
+
+	_, err := commands.RunBackup(commands.BackupFlags{
+		Subcommand:     "claim",
+		Token:          validClaimTokenFixture,
+		SaveRecoveryTo: recoveryPath,
+	})
+	if err == nil || err.Code != envelope.ErrInternalError {
+		t.Fatalf("got %+v, want INTERNAL_ERROR", err)
+	}
+	if atomic.LoadInt32(&cb.hits) != 0 {
+		t.Errorf("claim hits = %d, want 0 (write-before-network invariant)", cb.hits)
+	}
+}
+
+// errorCodePassthrough exercises the four substrate claim error codes
+// via the engine envelope. Each fixture sets the response status, the
+// body code, and asserts the engine surfaces the code verbatim in
+// envelope.error.code.
+func TestBackupClaim_SubstrateErrorCodesSurfaceVerbatim(t *testing.T) {
+	if testing.Short() {
+		t.Skip("heavy KDF runs precede the error path; skipped in short mode")
+	}
+	cases := []struct {
+		name     string
+		status   int
+		bodyCode string
+	}{
+		{"ClaimTokenInvalid_401", http.StatusUnauthorized, "CLAIM_TOKEN_INVALID"},
+		{"ClaimTokenExpired_401", http.StatusUnauthorized, "CLAIM_TOKEN_EXPIRED"},
+		{"ClaimTokenConsumed_409", http.StatusConflict, "CLAIM_TOKEN_CONSUMED"},
+		{"KdfTooWeak_400", http.StatusBadRequest, "KDF_TOO_WEAK"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			cb := newClaimBackend(t)
+			cb.claimFn = func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(tc.status)
+				_ = json.NewEncoder(w).Encode(map[string]interface{}{
+					"success": false,
+					"error": map[string]interface{}{
+						"code":    tc.bodyCode,
+						"message": "substrate raw: " + tc.bodyCode,
+					},
+				})
+			}
+			kc := keychain.NewMemory()
+			defer commands.ReplaceBackupStackFactoryForTest(func() *backup.Stack {
+				return stackForBackend(cb.srv, kc)
+			})()
+			defer commands.WithSignupReader(func(io.Reader) (string, string, error) {
+				return "secret-pass", "", nil
+			})()
+
+			tmp := t.TempDir()
+			_, err := commands.RunBackup(commands.BackupFlags{
+				Subcommand:     "claim",
+				Token:          validClaimTokenFixture,
+				SaveRecoveryTo: filepath.Join(tmp, "recovery.txt"),
+			})
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if string(err.Code) != tc.bodyCode {
+				t.Errorf("envelope.error.code = %q, want %q (status %d)", err.Code, tc.bodyCode, tc.status)
+			}
+		})
+	}
+}

--- a/go-engine/internal/envelope/errors.go
+++ b/go-engine/internal/envelope/errors.go
@@ -35,6 +35,19 @@ const (
 	ErrBackendUnreachable   ErrorCode = "BACKEND_UNREACHABLE"
 	ErrBackendIncompatible  ErrorCode = "BACKEND_INCOMPATIBLE"
 	ErrStorageQuotaExceeded ErrorCode = "STORAGE_QUOTA_EXCEEDED"
+
+	// Substrate claim-flow domain codes. Surfaced verbatim by
+	// `client.parseAPIError` when substrate returns them on the
+	// response body of `/api/auth/claim`. NOT declared as constants
+	// because the engine is a transparent pipe for the substrate
+	// claim namespace — the GUI's `friendlyAuthError` map owns the
+	// user-facing copy. Valid `ErrorCode` values produced by this
+	// engine include (cast from the substrate response):
+	//
+	//   "CLAIM_TOKEN_INVALID"   (HTTP 401)
+	//   "CLAIM_TOKEN_EXPIRED"   (HTTP 401)
+	//   "CLAIM_TOKEN_CONSUMED"  (HTTP 409)
+	//   "KDF_TOO_WEAK"          (HTTP 400)
 )
 
 // Error is the structured error object included in the JSON envelope when success is false.

--- a/openspec/changes/add-backup-claim-subcommand/.openspec.yaml
+++ b/openspec/changes/add-backup-claim-subcommand/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-24

--- a/openspec/changes/add-backup-claim-subcommand/design.md
+++ b/openspec/changes/add-backup-claim-subcommand/design.md
@@ -1,0 +1,230 @@
+## Context
+
+`backup signup` is the canonical template for creating a Hosted Backup
+identity end-to-end: read passphrase from stdin, generate the 24-word
+BIP39 mnemonic, derive an Argon2id KDF (serverPassword + masterKey),
+wrap a fresh DEK with masterKey, derive a recoveryKey + verifier,
+wrap the DEK again with the recoveryKey, **write the recovery file to
+disk before any network call**, then `POST /api/auth/signup` with the
+full credential block. On success the engine persists the access +
+refresh tokens to the OS keychain and caches the unwrapped DEK and
+masterKey-wrapped DEK there too.
+
+Substrate's `POST /api/auth/claim` is structurally identical from a
+crypto standpoint: same KDF, same wrap, same verifier — substrate
+will reject a request that doesn't satisfy the KDF floor with
+`KDF_TOO_WEAK`. The two differences are at the HTTP layer:
+
+1. Authentication is bearer-borne via a single-use claim token instead
+   of the buyer-supplied email + serverPassword pair.
+2. The request body omits `email` and the response body includes
+   `email` — substrate has the canonical email from Paddle and
+   surfaces it back so the engine displays the same identity the
+   buyer purchased under.
+
+Everything between stdin and the HTTP boundary is identical to signup
+and is reused verbatim.
+
+## Goals / Non-Goals
+
+**Goals:**
+
+- Ship a CLI surface that lets the GUI's already-shipped
+  `backupClaim()` bridge complete the credential-attach round trip
+  against a real substrate backend.
+- Reuse `backup signup`'s code, helpers, and stdin protocol —
+  diverging only at the request body, the URL, the bearer header,
+  and the response email field.
+- Surface substrate's domain error codes
+  (`CLAIM_TOKEN_INVALID|EXPIRED|CONSUMED`, `KDF_TOO_WEAK`) verbatim
+  in `envelope.error.code` so the GUI's friendly-error map renders
+  the correct user-facing copy without further translation.
+- Add no substrate-side dependencies. Discovery-doc field is
+  optional with an issuer-relative fallback.
+
+**Non-Goals:**
+
+- A second crypto path for claim. Anything the engine would do
+  differently from signup is a smell.
+- A `--token-stdin` mode in v1. Token is single-use + 30-day
+  expiry; the modest `ps`-leak window is acceptable. Future change
+  can add stdin protocol coordinated with the GUI.
+- A claim-resend wrapper. Substrate's resend cron sends a nudge
+  email (the plaintext token is not re-derivable from the stored
+  hash), so there is no engine-side action.
+- An `endstate://claim?token=…` URL scheme handler. Deferred to the
+  GUI repo; engine has no role.
+
+## Decisions
+
+### Mirror file (`backup_claim.go`), not extend signup
+
+A new file `internal/commands/backup_claim.go` mirroring
+`backup_signup.go` is preferred over branching inside
+`runBackupSignup`. Reasons:
+
+- One-file-per-subcommand is the established convention
+  (`backup_login.go`, `backup_logout.go`, `backup_recover.go`, …).
+- The error-handling messages reference the subcommand by name
+  ("backup signup: …") and would have to fork inside a shared
+  function. Two separate functions is cleaner than threading a
+  subcommand label.
+- Shared helpers (`writeRecoveryFile`, `zero32`, `b64`,
+  `readSignupFromStdin`, `signupReader`, `WithSignupReader`) stay
+  exactly where they are — same package, no exports needed.
+
+The duplication is ~80% structural overlap. We accept it because the
+divergence at the HTTP layer (bearer header, no-email body,
+server-supplied email response) is exactly the load-bearing
+difference, and forcing it through a shared abstraction obscures
+where claim ≠ signup.
+
+**Alternative considered:** extract a shared `derivePassphraseAndDEK`
+helper inside `internal/backup/crypto`. Rejected because the helper
+would need to accept the recovery-file-write callback (must happen
+before the HTTP call) and the post-HTTP keychain persistence
+callback, which means six parameters and two callbacks — at that
+point the helper is harder to read than two parallel files.
+
+### Bearer header via `client.Request.Headers` + `SkipAuthRefresh: true`
+
+Direct precedent: `RecoverFinalize` (`authenticator.go:320-339`) uses
+this exact pattern for the recovery bearer. The HTTP client
+(`client.go:139-159`) explicitly preserves caller-supplied
+`Authorization` headers — copying it onto the request *before* the
+session's cached access token gets considered. The comment at
+line 145-149 is explicit: the recovery-finalize flow relies on this.
+Claim is the second caller of the same mechanism.
+
+`SkipAuthRefresh: true` is essential: a 401 from `/api/auth/claim`
+means the token is invalid, expired, or consumed. The default
+refresh hook would attempt to refresh a (possibly nonexistent)
+access token and retry, which (a) loops without progress and (b)
+risks the retry succeeding with a stale local session in a way that
+loses the intended substrate identity.
+
+### Discovery field optional with issuer-relative fallback
+
+Substrate's discovery doc (verified by reading substrate's
+`src/app/api/.well-known/openid-configuration/route.ts`) advertises
+six extension endpoints: signup, login, refresh, logout, recover,
+backup_api_base. It does **not** advertise `auth_claim_endpoint`.
+
+Two paths considered:
+
+1. Make `auth_claim_endpoint` required in `validateDocument` and
+   require a substrate companion PR. **Rejected**: this engine
+   change is meant to unblock the GUI immediately; coupling it to
+   another substrate PR delays the launch.
+2. Make `auth_claim_endpoint` optional with `<issuer>/api/auth/claim`
+   fallback when absent. **Chosen**: zero substrate dependency,
+   matches the precedent for `Me()` and `Subscribe()` which compute
+   their URLs from the issuer URL directly.
+
+The fallback only fires when the field is *empty/missing*, not when
+present-but-bogus. A future substrate version that advertises a
+typo'd value will cause the HTTP call to fail loudly with a clear
+error rather than silently routing to a fallback path.
+
+### Error-code passthrough widens existing whitelist
+
+`parseAPIError` (`client.go:296-307`) already passes
+`STORAGE_QUOTA_EXCEEDED` through as `envelope.ErrStorageQuotaExceeded`
+when substrate sets that in the response body. The same mechanism
+extends to the four substrate claim codes — except the engine does
+not define `ErrCLAIM_TOKEN_INVALID` etc. as constants. Two options:
+
+1. Define constants and add full `defaultRemediation` /
+   `defaultDocsKey` mappings. **Rejected**: the engine doesn't own
+   the claim error namespace; substrate's claim endpoint is the
+   source of truth. The GUI's `friendlyAuthError` map already owns
+   the user-facing copy for these codes.
+2. Cast the substrate code string into `envelope.ErrorCode` directly:
+   `ae.Code = envelope.ErrorCode(strings.ToUpper(env.Error.Code))`.
+   Allowed by the type — `envelope.ErrorCode` is `type ErrorCode
+   string`. **Chosen**: minimal engine surface, the substrate code
+   reaches `envelope.error.code` verbatim, and the GUI side switches
+   on the wire-string. A comment in `errors.go` documents the
+   passthrough so future readers don't expect a constant for these
+   codes.
+
+### `--token` on argv vs. on stdin
+
+The GUI already wires `--token` as a CLI flag (the bridge call shape
+is locked in `endstate-gui/src/lib/backup-bridge.ts`). Moving to a
+stdin protocol requires a coordinated GUI change and would block
+this PR. The token is:
+
+- Single-use — consumed on first successful claim. A `ps` snapshot
+  captured during the call window can replay only until the
+  legitimate buyer completes their claim, which is the immediately
+  following operation.
+- Short-lived — 30-day expiry from substrate's `claim_tokens` row.
+- Not a long-lived secret like an access token or recovery key.
+
+V1 accepts the leak. Future work can add `--token-stdin` (read line
+0 of stdin, then the existing passphrase on line 1) once both repos
+ship together.
+
+### `Email` field on `CompleteLoginResponse`
+
+Adding an `omitempty` field to the shared response struct is benign:
+the other endpoints (signup, login, recover-finalize, refresh) will
+serialize the same struct with the field absent because substrate
+doesn't return it in those flows. The alternative — a separate
+`ClaimResponse` struct — duplicates five identical fields for one
+extra and forces a bespoke `session.SetTokens` call site.
+
+## Risks / Trade-offs
+
+**[Discovery fallback silently masks a future substrate
+misconfiguration]** → Mitigation: the fallback only fires when the
+field is empty/missing. A bogus value reaches the HTTP layer
+unchanged, where the request fails with a clear status code. If we
+want louder feedback when substrate later advertises the field but
+disagrees with the engine on the path shape, that's a v2 concern.
+
+**[`SkipAuthRefresh: true` plus a successful claim overwrites any
+existing local session]** → This is correct behaviour. A user who
+invokes `backup claim` while already signed in is telling the
+engine to bind credentials to the pre-account substrate has for the
+claim token, which is *not* the current local session's user
+(otherwise no claim token would exist for them). The substrate
+session win is intentional.
+
+**[`envelope.ErrorCode` passthrough bypasses the constant set]** →
+Acceptable because substrate owns the claim error namespace. The
+engine is a transparent pipe. Mitigation: add a comment block in
+`internal/envelope/errors.go` documenting that the four substrate
+codes are valid `ErrorCode` values produced by this engine but NOT
+declared as constants, with a link to the GUI's friendly-error map
+for downstream behaviour.
+
+**[Test parity with signup means heavy Argon2id runs]** →
+`backup_signup_test.go` is already `testing.Short()`-aware; the
+claim suite mirrors that. CI default keeps short mode off; pre-push
+hook respects `-short`.
+
+## Migration Plan
+
+Purely additive. No schema migrations. No keychain layout changes.
+Rollback is `git revert` of the engine PR — `backup claim` simply
+disappears from the dispatch table; the GUI's `backupClaim()` will
+get "unknown backup subcommand: claim" until a new binary is built.
+
+The GUI side's PR description must reference this engine PR's commit
+SHA. After both merge:
+
+1. The GUI repo's `predev` rebuild script runs the next time `npm
+   run dev` / `tauri dev` fires and produces a new binary containing
+   `backup claim`.
+2. CI for the GUI PR re-runs against that binary and passes.
+3. The GUI PR unblocks for merge.
+
+## Open Questions
+
+None at this time. The discovery-doc question is resolved
+(optional + fallback). The error-code passthrough mechanism has a
+direct precedent (`STORAGE_QUOTA_EXCEEDED`). The bearer header
+mechanism has a direct precedent (`RecoverFinalize`). The shape of
+the request body is fixed by substrate's contract.

--- a/openspec/changes/add-backup-claim-subcommand/proposal.md
+++ b/openspec/changes/add-backup-claim-subcommand/proposal.md
@@ -1,0 +1,102 @@
+## Why
+
+Substrate's `wire-anonymous-buyer-account-linking` change (substrate PR
+#12, archived 2026-05-24) shipped `POST /api/auth/claim` so buyers who
+purchase Hosted Backup anonymously — via the `/endstate` storefront,
+without a pre-existing session — can attach credentials to the
+*pre-account* substrate created for them at Paddle webhook time.
+
+The buyer receives an email containing a single-use 43-char URL-safe
+base64 claim token (`endstate://claim?token=…`). Until the engine can
+spawn a CLI surface for this flow, the GUI side (already shipped in
+`endstate-gui#add-hosted-backup-claim-input`) has nothing to call:
+`backupClaim()` spawns `endstate backup claim --token <t>
+--save-recovery-to <p>` and that subcommand does not exist yet.
+
+This change adds that subcommand. The whole flow is structurally
+identical to `backup signup`: same passphrase-on-stdin, same Argon2id
+KDF, same 24-word BIP39 mnemonic generation, same wrappedDEK and
+recovery-key derivation, same write-recovery-file-before-network
+ordering. The only deltas are: bearer-token authentication, an
+empty-email request body (substrate has the email from Paddle), and
+four substrate-specific error codes that must reach the GUI verbatim
+so its `friendlyAuthError` map can render the right copy.
+
+## What Changes
+
+- New `endstate backup claim --token <43-char-base64url>
+  --save-recovery-to <path>` subcommand. Passphrase via stdin (line 1),
+  optional 24-word BIP39 recovery mnemonic on line 2 — exactly mirrors
+  `backup signup`.
+- New `auth.ClaimBody` request struct (= `SignupBody` minus `Email`)
+  and `Authenticator.Claim(ctx, claimToken, body)` HTTP method.
+  `Authorization: Bearer <claimToken>` carries auth; `SkipAuthRefresh:
+  true` prevents the access-token refresh hook from interfering.
+  Existing precedent: `RecoverFinalize` uses the identical pattern for
+  the recovery bearer.
+- Optional `EndstateExtensions.AuthClaimEndpoint` discovery field
+  (`json:"auth_claim_endpoint,omitempty"`). Substrate does **not** yet
+  advertise it, so this field is non-required and the engine falls
+  back to `<issuer>/api/auth/claim` when absent — same pattern as
+  `Me()` and `Subscribe()` use for endpoints not in
+  `endstate_extensions`. A future substrate change can advertise the
+  field without engine changes.
+- Optional `Email` field on `auth.CompleteLoginResponse` (`omitempty`).
+  Populated only by claim — other endpoints (signup, login, recover,
+  refresh) carry on as before.
+- `client.parseAPIError` body-code passthrough widens to surface
+  substrate's domain codes (`CLAIM_TOKEN_INVALID`,
+  `CLAIM_TOKEN_EXPIRED`, `CLAIM_TOKEN_CONSUMED`, `KDF_TOO_WEAK`) on
+  `envelope.error.code` verbatim. The GUI's friendly-error map
+  switches on the wire-string. `envelope.ErrorCode` is `type
+  ErrorCode string`, so passing arbitrary substrate codes through
+  without defining new constants is type-safe.
+
+Explicitly out of scope:
+
+- `endstate://claim?token=…` deep-link handler (deferred — paste in
+  the GUI works fine for v1).
+- `--token-stdin` mode (defers a `ps`-leak mitigation; the token is
+  single-use and expires in 30 days, so v1 accepts the modest leak).
+- `/api/auth/claim/resend` engine wrapper. Substrate's resend cron
+  sends a nudge email rather than re-issuing the token (plaintext is
+  not stored server-side), so there is no engine-side action.
+- Cross-repo livewire e2e. Add once both engine and GUI ship if
+  regression risk warrants it.
+
+## Capabilities
+
+### Modified Capabilities
+
+- `hosted-backup-auth-client`: gains the claim-token credential-attach
+  flow, including the new request body, the new auth method, the
+  discovery-field fallback, and the substrate-domain error-code
+  passthrough.
+
+## Impact
+
+- **New file**:
+  - `internal/commands/backup_claim.go` (~170 LOC; ~80% structural
+    duplicate of `backup_signup.go`).
+  - `internal/commands/backup_claim_test.go` (~250 LOC; mirrors
+    `backup_signup_test.go` with a `newClaimBackend` fixture and the
+    four error-code scenarios).
+- **Modified files**:
+  - `internal/backup/oidc/oidc.go` (+1 line: optional discovery
+    field).
+  - `internal/backup/auth/authenticator.go` (~+50 lines: `ClaimBody`,
+    `Claim()`, `Email` field on `CompleteLoginResponse`).
+  - `internal/backup/client/client.go` (+5 lines: extended body-code
+    switch in `parseAPIError`).
+  - `internal/commands/backup.go` (+3 lines: dispatch case + `Token`
+    field on `BackupFlags`).
+  - `cmd/endstate/main.go` (~+10 lines: `--token` parser, dispatch
+    passthrough, usage blurb append).
+- **No substrate dependency.** Substrate's `/api/auth/claim` is live.
+  We do **not** require a substrate discovery-doc PR — the engine
+  falls back to issuer-relative URL when the optional field is
+  absent.
+- **GUI unblocks on merge.** `endstate-gui`'s
+  `add-hosted-backup-claim-input` change waits on this engine PR; the
+  predev rebuild script will pick up the new subcommand once a binary
+  with `backup claim` is built into the GUI repo's bundled engine.

--- a/openspec/changes/add-backup-claim-subcommand/specs/hosted-backup-auth-client/spec.md
+++ b/openspec/changes/add-backup-claim-subcommand/specs/hosted-backup-auth-client/spec.md
@@ -1,0 +1,182 @@
+## ADDED Requirements
+
+### Requirement: Anonymous-buyer credential claim subcommand
+
+The engine SHALL provide an `endstate backup claim --token <token>
+--save-recovery-to <path>` subcommand that attaches passphrase-derived
+credentials to a Hosted Backup pre-account identified by a single-use
+bearer claim token. The passphrase MUST be read from stdin (line 1).
+An optional caller-supplied 24-word BIP39 recovery mnemonic MAY be
+provided on line 2 of stdin, in which case the engine SHALL use it
+instead of generating one; this mirrors `backup signup`'s stdin
+protocol exactly.
+
+The HTTP call SHALL be `POST <claim-endpoint>` with
+`Authorization: Bearer <token>` and a request body equal to the
+`backup signup` request body MINUS the `email` field — substrate
+identifies the user from the bearer's claim-token row.
+
+The credentials block (`serverPassword`, `salt`, `kdfParams`,
+`wrappedDEK`, `recoveryKeyVerifier`, `recoveryKeyWrappedDEK`) SHALL
+be derived using the same primitives `backup signup` uses
+(`crypto.DeriveKeys`, `crypto.WrapDEK`, `crypto.DeriveRecoveryKey`,
+`crypto.RecoveryKeyVerifier`) with the same `crypto.DefaultKDFParams`.
+
+The recovery file at `--save-recovery-to` SHALL be written before any
+network call (contract §1 — load-bearing for the user-has-the-key
+guarantee). If the write fails, the engine SHALL return
+`INTERNAL_ERROR` and SHALL NOT issue the HTTP request.
+
+On a successful 200 response, the engine SHALL:
+
+1. Update the session via `session.SetTokens(userID, lower(email),
+   accessToken, refreshToken, subscriptionStatus, accessExpiry)`,
+   where `email` is the server-supplied value from the response body
+   (NOT a value the engine constructed locally).
+2. Persist the refresh token to the OS keychain via
+   `session.Persist()`.
+3. Cache the unwrapped DEK and the masterKey-wrapped DEK in the
+   keychain via `session.StoreDEK(dek)` and
+   `session.StoreWrappedDEK(wrappedDEK)`.
+4. Best-effort zero the local DEK copy.
+5. Emit a `SignupResult` envelope with the server-supplied email
+   lowercased.
+
+#### Scenario: Successful claim attaches credentials and returns a session
+
+- **GIVEN** substrate has a `claim_tokens` row for the supplied
+  43-char URL-safe base64 token, and a passphrase is piped to stdin
+- **WHEN** the user runs `endstate backup claim --token <t>
+  --save-recovery-to <p>`
+- **THEN** the engine SHALL derive serverPassword, masterKey,
+  recoveryKey, and wrappedDEK from the passphrase exactly as
+  `backup signup` does
+- **AND** SHALL write the 24-word recovery mnemonic to `<p>` BEFORE
+  any network call
+- **AND** SHALL `POST <claim-endpoint>` with `Authorization: Bearer
+  <t>` and a body that omits the `email` field
+- **AND** on HTTP 200 SHALL persist the refresh token + DEK +
+  wrappedDEK to the OS keychain
+- **AND** SHALL return `{ userId, email, subscriptionStatus,
+  recoveryKeySavedTo }` where `email` is the value substrate
+  returned, lowercased
+
+#### Scenario: Recovery file write failure aborts before the network call
+
+- **GIVEN** the path supplied to `--save-recovery-to` cannot be
+  written (parent directory missing on a read-only filesystem, or
+  permissions deny)
+- **WHEN** the user runs `endstate backup claim`
+- **THEN** the engine SHALL return `INTERNAL_ERROR` with a
+  remediation that suggests choosing a writable path
+- **AND** SHALL NOT call `POST <claim-endpoint>`
+
+#### Scenario: Malformed token rejected before the network call
+
+- **WHEN** `--token` is empty, has a length other than 43
+  characters, or contains any character outside `[A-Za-z0-9_-]`
+- **THEN** the engine SHALL return `INTERNAL_ERROR` with a
+  remediation pointing the user back to the claim link in their
+  email
+- **AND** SHALL NOT call `POST <claim-endpoint>`
+
+### Requirement: Substrate claim error codes surface verbatim
+
+The engine SHALL surface substrate's claim-flow error codes —
+`CLAIM_TOKEN_INVALID`, `CLAIM_TOKEN_EXPIRED`, `CLAIM_TOKEN_CONSUMED`,
+and `KDF_TOO_WEAK` — in `envelope.error.code` verbatim (uppercased).
+The engine SHALL NOT translate or replace these codes with a generic
+engine-native code such as `BACKEND_ERROR` or `AUTH_REQUIRED`. The
+GUI's `friendlyAuthError` map switches on the wire-string code, so
+verbatim passthrough is the contract.
+
+#### Scenario: 401 with CLAIM_TOKEN_INVALID surfaces verbatim
+
+- **GIVEN** substrate returns HTTP 401 with body `{"error":{"code":
+  "CLAIM_TOKEN_INVALID","message":"..."}}`
+- **WHEN** the engine processes the response
+- **THEN** the returned envelope error's `code` field SHALL equal
+  the string `"CLAIM_TOKEN_INVALID"`
+
+#### Scenario: 401 with CLAIM_TOKEN_EXPIRED surfaces verbatim
+
+- **GIVEN** substrate returns HTTP 401 with body `{"error":{"code":
+  "CLAIM_TOKEN_EXPIRED","message":"..."}}`
+- **WHEN** the engine processes the response
+- **THEN** the returned envelope error's `code` field SHALL equal
+  the string `"CLAIM_TOKEN_EXPIRED"`
+
+#### Scenario: 409 with CLAIM_TOKEN_CONSUMED surfaces verbatim
+
+- **GIVEN** substrate returns HTTP 409 with body `{"error":{"code":
+  "CLAIM_TOKEN_CONSUMED","message":"..."}}`
+- **WHEN** the engine processes the response
+- **THEN** the returned envelope error's `code` field SHALL equal
+  the string `"CLAIM_TOKEN_CONSUMED"`
+
+#### Scenario: 400 with KDF_TOO_WEAK surfaces verbatim
+
+- **GIVEN** substrate returns HTTP 400 with body `{"error":{"code":
+  "KDF_TOO_WEAK","message":"..."}}`
+- **WHEN** the engine processes the response
+- **THEN** the returned envelope error's `code` field SHALL equal
+  the string `"KDF_TOO_WEAK"`
+
+### Requirement: Optional discovery field for the claim endpoint
+
+The engine SHALL prefer
+`endstate_extensions.auth_claim_endpoint` from the OIDC discovery
+document when the field is present and non-empty, and SHALL fall
+back to `<issuer>/api/auth/claim` when the field is absent or
+empty. The field's absence MUST NOT cause discovery validation to
+fail — substrate v1 does not advertise this field, so making it
+required would break the discovery handshake.
+
+#### Scenario: Issuer-relative fallback when discovery omits the field
+
+- **GIVEN** substrate's discovery document does not include
+  `auth_claim_endpoint`
+- **WHEN** the engine invokes `Authenticator.Claim`
+- **THEN** the engine SHALL POST to `<issuer>/api/auth/claim`,
+  using the configured issuer URL with any trailing slash trimmed
+
+#### Scenario: Discovery field preferred when present
+
+- **GIVEN** substrate's discovery document includes
+  `auth_claim_endpoint = "https://substratesystems.io/api/auth/claim"`
+- **WHEN** the engine invokes `Authenticator.Claim`
+- **THEN** the engine SHALL POST to the advertised URL verbatim,
+  not to the issuer-relative fallback
+
+### Requirement: Bearer authentication isolates the claim request
+
+The engine SHALL set `Authorization: Bearer <claimToken>` on the
+claim request via `client.Request.Headers` and SHALL set
+`SkipAuthRefresh: true` to prevent the HTTP client's 401 → refresh
+→ retry hop from interfering with the bearer-borne claim. The
+existing access token (if any) for a logged-in session SHALL NOT
+be attached to the claim request — the bearer in `Headers` takes
+precedence per the existing
+`Authorization`-header-wins rule in
+`internal/backup/client/client.go`.
+
+#### Scenario: Bearer header set; no session access token attached
+
+- **GIVEN** the engine has an active local session with a cached
+  access token for `user-old@example.com`
+- **WHEN** the user runs `endstate backup claim --token <t>`
+- **THEN** the outgoing request SHALL carry exactly one
+  `Authorization` header equal to `"Bearer " + <t>`
+- **AND** the cached access token SHALL NOT appear anywhere in the
+  request headers
+
+#### Scenario: Existing session is replaced on successful claim
+
+- **GIVEN** the engine has an active local session for
+  `user-old@example.com`
+- **WHEN** a claim succeeds and substrate returns
+  `userId = "user-new-1"`, `email = "new-buyer@example.com"`
+- **THEN** the keychain refresh-token entry SHALL be for
+  `"user-new-1"`
+- **AND** the session's current-user pointer SHALL be
+  `"user-new-1"`

--- a/openspec/changes/add-backup-claim-subcommand/tasks.md
+++ b/openspec/changes/add-backup-claim-subcommand/tasks.md
@@ -1,0 +1,51 @@
+## 1. Discovery + auth types
+
+- [ ] 1.1 Add optional `AuthClaimEndpoint string \`json:"auth_claim_endpoint,omitempty"\`` field to `oidc.EndstateExtensions` in `internal/backup/oidc/oidc.go`. Do NOT add to `validateDocument` required-fields check.
+- [ ] 1.2 Add optional `Email string \`json:"email,omitempty"\`` field to `auth.CompleteLoginResponse` in `internal/backup/auth/authenticator.go`.
+- [ ] 1.3 Add `auth.ClaimBody` struct (= `SignupBody` minus `Email`) immediately after `SignupBody` in `internal/backup/auth/authenticator.go`.
+- [ ] 1.4 Add `Authenticator.Claim(ctx, claimToken, body) (*CompleteLoginResponse, *envelope.Error)` mirroring `Signup` with `Headers: http.Header{"Authorization": []string{"Bearer " + claimToken}}` + `SkipAuthRefresh: true` + issuer-relative URL fallback.
+
+## 2. Error code passthrough
+
+- [ ] 2.1 Extend the post-decode switch in `parseAPIError` (`internal/backup/client/client.go`) to passthrough `CLAIM_TOKEN_INVALID`, `CLAIM_TOKEN_EXPIRED`, `CLAIM_TOKEN_CONSUMED`, and `KDF_TOO_WEAK` as `envelope.ErrorCode(strings.ToUpper(env.Error.Code))`.
+- [ ] 2.2 Add a short comment in `internal/envelope/errors.go` documenting that the four substrate claim codes are passed through as valid `ErrorCode` values without being declared as Go constants (engine is a transparent pipe for substrate's domain codes).
+
+## 3. CLI flag plumbing
+
+- [ ] 3.1 Add `Token string` field to `commands.BackupFlags` in `internal/commands/backup.go`.
+- [ ] 3.2 Add `--token` parser case in `cmd/endstate/main.go` (mirror the `--email` block at ~line 231-235).
+- [ ] 3.3 Add `Token: p.token` field to the `commands.RunBackup` flag passthrough in `cmd/endstate/main.go` (~line 498-511).
+- [ ] 3.4 Add `token string` field to `parsedArgs` struct in `cmd/endstate/main.go`.
+- [ ] 3.5 Append `claim --token <token> --save-recovery-to <path>` line to the `backup` subcommand usage blurb in `cmd/endstate/main.go` (`commandUsage("backup")`).
+
+## 4. Claim handler
+
+- [ ] 4.1 Create `internal/commands/backup_claim.go` with `runBackupClaim(flags BackupFlags) (interface{}, *envelope.Error)`.
+- [ ] 4.2 Validate `--token`: non-empty, length 43, charset `[A-Za-z0-9_-]`. Fail with `ErrInternalError` + remediation before any network call.
+- [ ] 4.3 Reuse `signupReader(os.Stdin)`, mnemonic gen/parse, salt + DEK gen, `crypto.DeriveKeys`, `crypto.WrapDEK`, recovery key + verifier + wrapping, `writeRecoveryFile` — identical to `runBackupSignup` lines 56-150.
+- [ ] 4.4 Build `auth.ClaimBody` (no email field), call `a.Claim(ctx, flags.Token, body)`.
+- [ ] 4.5 On success, populate `SignupResult.Email` from `strings.ToLower(resp.Email)` (server-supplied), persist DEK + wrappedDEK + zero local DEK identical to signup.
+- [ ] 4.6 Add `case "claim": return runBackupClaim(flags)` to the dispatch in `internal/commands/backup.go`. Add `claim` to the empty-subcommand error message.
+
+## 5. Tests
+
+- [ ] 5.1 Create `internal/commands/backup_claim_test.go` with a `newClaimBackend(t)` fixture mounting `/api/auth/claim` on a fresh mux + `httptest.Server` (reuse `addAuthRoutes`).
+- [ ] 5.2 `TestBackupClaim_HappyPath`: 200 + `{userId, email, accessToken, refreshToken, subscriptionStatus}`. Assert: result has server-supplied email, recovery file written, refresh + DEK in keychain, request had `Authorization: Bearer <token>` header, request body has NO `email` field.
+- [ ] 5.3 `TestBackupClaim_RequiresToken`: omit `--token` → `ErrInternalError` mentioning `--token`.
+- [ ] 5.4 `TestBackupClaim_RejectsMalformedToken`: `--token=too-short` → `ErrInternalError` mentioning "43 characters".
+- [ ] 5.5 `TestBackupClaim_RequiresSaveRecoveryToWhenGenerating`: empty mnemonic + empty `--save-recovery-to` → `ErrInternalError`.
+- [ ] 5.6 `TestBackupClaim_RequiresPassphrase`: empty passphrase → `ErrInternalError`.
+- [ ] 5.7 `TestBackupClaim_ClaimTokenInvalid_401`: 401 + body code `CLAIM_TOKEN_INVALID` → envelope `Code == "CLAIM_TOKEN_INVALID"`.
+- [ ] 5.8 `TestBackupClaim_ClaimTokenExpired_401`: 401 + body code `CLAIM_TOKEN_EXPIRED` → `Code == "CLAIM_TOKEN_EXPIRED"`.
+- [ ] 5.9 `TestBackupClaim_ClaimTokenConsumed_409`: 409 + body code `CLAIM_TOKEN_CONSUMED` → `Code == "CLAIM_TOKEN_CONSUMED"`.
+- [ ] 5.10 `TestBackupClaim_KdfTooWeak_400`: 400 + body code `KDF_TOO_WEAK` → `Code == "KDF_TOO_WEAK"`.
+- [ ] 5.11 `TestBackupClaim_RecoveryFileWriteFailureNoNetworkCall`: unwritable `--save-recovery-to` → `ErrInternalError`, claim hits == 0.
+- [ ] 5.12 Mark heavy-KDF scenarios as `testing.Short()`-aware, mirroring `backup_signup_test.go`.
+
+## 6. Verify
+
+- [ ] 6.1 `go test ./internal/commands/... ./internal/backup/...` — full pass on the engine repo.
+- [ ] 6.2 `go test ./internal/commands/ -run TestBackupClaim` — every new scenario green.
+- [ ] 6.3 `go build ./...` — clean compile.
+- [ ] 6.4 `openspec validate add-backup-claim-subcommand --strict` — passes.
+- [ ] 6.5 Manual smoke (post-merge, both engine + GUI ready): build engine, drop into GUI repo via predev rebuild, run `npm run tauri dev`, paste a real claim code, confirm credential attachment + backup pane lands signed in.


### PR DESCRIPTION
## Summary

- Adds `endstate backup claim --token <43-char-base64url> --save-recovery-to <path>` (passphrase on stdin), structurally mirroring `backup signup` except for the HTTP boundary: `Authorization: Bearer <claimToken>`, request body without `email`, response carrying server-supplied `email`.
- Surfaces the four substrate claim error codes (`CLAIM_TOKEN_INVALID|EXPIRED|CONSUMED`, `KDF_TOO_WEAK`) verbatim in `envelope.error.code` so the GUI's `friendlyAuthError` map can switch on them.
- Optional `auth_claim_endpoint` discovery field with `<issuer>/api/auth/claim` fallback — no substrate dependency required.

## Why

Substrate's [`wire-anonymous-buyer-account-linking`](https://github.com/Artexis10/substrate) (substrate PR #12, archived 2026-05-24) shipped `POST /api/auth/claim` so Hosted Backup buyers who purchased anonymously via the `/endstate` storefront can attach credentials to the pre-account substrate created for them at Paddle webhook time. Until the engine has a CLI surface, the GUI's `backupClaim()` bridge has nothing to call and the buyer is stranded.

This change unblocks the companion GUI PR ([endstate-gui `add-hosted-backup-claim-input`](https://github.com/Artexis10/endstate-gui)) which calls `endstate backup claim` from a new claim-mode branch on the sign-up form.

## Design notes

- **Bearer header via `client.Request.Headers` + `SkipAuthRefresh: true`** — direct precedent: `RecoverFinalize` uses the identical pattern for the recovery bearer.
- **Body-code passthrough** widens the existing `STORAGE_QUOTA_EXCEEDED` precedent in `parseAPIError`. `envelope.ErrorCode` is `type ErrorCode string`, so substrate's claim codes pass through verbatim without engine-side constants — the engine is a transparent pipe for the substrate claim namespace.
- **Discovery field optional** — substrate v1 doesn't advertise `auth_claim_endpoint`. Issuer-relative fallback mirrors `Me()` and `Subscribe()`. A future substrate change can advertise the field without engine changes.
- **`--token` on argv** — single-use + 30d expiry justifies the modest `ps`-leak window for v1; GUI is already wired this way. Future option: `--token-stdin` mode coordinated with the GUI.

OpenSpec change at `openspec/changes/add-backup-claim-subcommand/` extends the `hosted-backup-auth-client` capability.

## Test plan

- [x] `go test ./internal/commands/ -run TestBackupClaim` — 8 tests + 4 error-code subtests, all green
- [x] `go test ./internal/commands/... ./internal/backup/...` — full pass, no regressions
- [x] `go test ./...` — full engine suite green
- [x] `go build ./...` — clean compile
- [x] `openspec validate add-backup-claim-subcommand --strict` — passes
- [ ] Manual smoke (post-merge): build engine, drop into endstate-gui via predev, run \`npm run tauri dev\`, paste a real claim code against a substrate dev instance, confirm credential attachment + backup pane lands signed in

🤖 Generated with [Claude Code](https://claude.com/claude-code)