### PR TITLE
ci(release): trigger on release:published so release-please tags auto-build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,21 @@
 name: Release
 
+# Builds endstate.exe + .sha256 and attaches them to the GitHub Release.
+#
+# Triggers on `release: published` rather than `push: tags` because the tag is
+# created by release-please-action via GITHUB_TOKEN — and per GitHub's
+# recursion-protection rule, GITHUB_TOKEN-created tags do NOT fire
+# `push: tags` workflows. `release: published` does fire for releases created
+# via GITHUB_TOKEN, which is what release-please does (creates tag + release
+# in one step).
+#
+# workflow_dispatch with `tag_name` input remains the manual override for
+# backfilling assets onto an older release (e.g. one created before this
+# trigger was fixed).
+
 on:
-  push:
-    tags:
-      - 'v*'
+  release:
+    types: [published]
   workflow_dispatch:
     inputs:
       tag_name:
@@ -11,29 +23,7 @@ on:
         required: true
 
 jobs:
-  release:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v5
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@v3
-        with:
-          name: ${{ github.event.inputs.tag_name || github.ref_name }}
-          tag_name: ${{ github.event.inputs.tag_name || github.ref_name }}
-          generate_release_notes: true
-          draft: false
-          prerelease: false
-          make_latest: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
   publish-artifacts:
-    needs: release
     runs-on: windows-latest
     permissions:
       contents: write
@@ -42,7 +32,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
-          ref: ${{ github.event.inputs.tag_name || github.ref_name }}
+          ref: ${{ github.event.inputs.tag_name || github.event.release.tag_name }}
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -53,7 +43,7 @@ jobs:
       - name: Build endstate.exe
         shell: pwsh
         run: |
-          $tag = "${{ github.event.inputs.tag_name || github.ref_name }}"
+          $tag = "${{ github.event.inputs.tag_name || github.event.release.tag_name }}"
           $version = $tag.TrimStart('v')
           $schemaVersion = (Get-Content SCHEMA_VERSION -Raw).Trim()
           Set-Location go-engine
@@ -71,7 +61,7 @@ jobs:
       - name: Upload release assets
         uses: softprops/action-gh-release@v3
         with:
-          tag_name: ${{ github.event.inputs.tag_name || github.ref_name }}
+          tag_name: ${{ github.event.inputs.tag_name || github.event.release.tag_name }}
           files: |
             endstate.exe
             endstate.exe.sha256
@@ -83,7 +73,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          $tag = "${{ github.event.inputs.tag_name || github.ref_name }}"
+          $tag = "${{ github.event.inputs.tag_name || github.event.release.tag_name }}"
           $release = gh release view "$tag" --json assets | ConvertFrom-Json
           $names = $release.assets | ForEach-Object { $_.name }
           $missing = @()


### PR DESCRIPTION
## Summary
- Switch `release.yml` trigger from `push: tags: ['v*']` to `release: types: [published]`
- Drop the now-redundant create-release job (release-please-action already creates the release object on PR merge)
- Rewire `github.ref_name` → `github.event.release.tag_name`; keep `workflow_dispatch` with `tag_name` input as manual override

## Why

The release workflow listened on `push: tags: ['v*']`, but release-please-action creates tags via `GITHUB_TOKEN`. Per GitHub's recursion-protection rule, **GITHUB_TOKEN-created tags do NOT fire `push: tags` workflows**. Result: v1.9.0, v2.0.1, v2.1.0, and v2.2.0 all shipped without `endstate.exe` / `.sha256` binaries because the build workflow never fired. Each release needed someone to remember to manually `gh workflow run release.yml --field tag_name=...` — and the ones nobody remembered (v2.1.0, v2.2.0) sit there asset-less, which **broke the downstream endstate-gui build pipeline** that downloads these binaries during its Tauri installer build (gui-v2.5.0 currently ships with only source archives, no `.msi`/`.exe`).

`release: published` fires for releases created via `GITHUB_TOKEN`, which is what release-please does (creates tag + release in one step). Once this lands, every future release-please-cut release auto-builds binaries — no human in the loop.

## One-time backfill after merge

The fix doesn't retro-fire for releases that already published. To backfill v2.2.0's missing binaries:

```bash
gh workflow run release.yml --repo Artexis10/endstate --field tag_name=v2.2.0
```

Same for v2.1.0 / v2.0.1 / v1.9.0 if you want those releases installable too (only v2.2.0 is currently blocking endstate-gui).

## Test plan
- [ ] Merge this PR
- [ ] Run `gh workflow run release.yml --repo Artexis10/endstate --field tag_name=v2.2.0` to backfill v2.2.0 binaries
- [ ] Confirm `gh release view v2.2.0 --json assets --jq '.assets[].name'` lists both `endstate.exe` and `endstate.exe.sha256`
- [ ] Cut next engine release via release-please — confirm `release.yml` fires automatically on PR merge (no manual dispatch needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)