### PR TITLE
fix(modules): exclude PowerToys self-update installer from captures

### DIFF
--- a/go-engine/internal/modules/regression_test.go
+++ b/go-engine/internal/modules/regression_test.go
@@ -1,0 +1,54 @@
+// Copyright 2025 Substrate Systems OU
+// SPDX-License-Identifier: Apache-2.0
+
+package modules
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestPowerToysModule_ExcludesUpdatesDir is a regression guard for the
+// PowerToys self-update installer bloat.
+//
+// Background: substrate PR #15's hosted-backup e2e verification surfaced a
+// 377 MiB profile push. Inventory revealed a single 376 MiB file at
+// configs/powertoys/powertoys/Updates/powertoysusersetup-0.98.1-x64.exe —
+// PowerToys' downloaded self-update installer, captured as if it were
+// config. The PowerToys module's excludeGlobs covered
+// Logs/Temp/Cache/GPUCache/Crashpad but not the Updates/ dir where the
+// installer accumulates.
+//
+// This test asserts the PowerToys module excludes the Updates/ dir so the
+// same regression can't slip back in.
+func TestPowerToysModule_ExcludesUpdatesDir(t *testing.T) {
+	// Load the real production modules catalog (not testdata).
+	modulesRoot := filepath.Join("..", "..", "..", "modules", "apps")
+	catalog, err := LoadCatalog(modulesRoot)
+	if err != nil {
+		t.Fatalf("LoadCatalog: %v", err)
+	}
+	mod, ok := catalog["apps.powertoys"]
+	if !ok {
+		t.Fatal("apps.powertoys module not in catalog (did the module dir move?)")
+	}
+	if mod.Capture == nil {
+		t.Fatal("apps.powertoys has no Capture section")
+	}
+	found := false
+	for _, glob := range mod.Capture.ExcludeGlobs {
+		// Match either backslash- or forward-slash-style globs.
+		if glob == "**\\Updates\\**" || glob == "**/Updates/**" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf(
+			"apps.powertoys module excludeGlobs missing **\\Updates\\** (or forward-slash equivalent).\n"+
+				"got: %v\n"+
+				"PowerToys' Updates/ dir contains downloaded self-update installers (~400 MiB) — see substrate PR #15 regression notes.",
+			mod.Capture.ExcludeGlobs,
+		)
+	}
+}

--- a/modules/apps/powertoys/module.jsonc
+++ b/modules/apps/powertoys/module.jsonc
@@ -46,11 +46,12 @@
         "**\\Temp\\**",
         "**\\Cache\\**",
         "**\\GPUCache\\**",
-        "**\\Crashpad\\**"
+        "**\\Crashpad\\**",
+        "**\\Updates\\**"
       ]
     }
   ],
-  
+
   "capture": {
     "files": [
       { "source": "%LOCALAPPDATA%\\Microsoft\\PowerToys", "dest": "apps/powertoys", "optional": true }
@@ -60,9 +61,10 @@
       "**\\Temp\\**",
       "**\\Cache\\**",
       "**\\GPUCache\\**",
-      "**\\Crashpad\\**"
+      "**\\Crashpad\\**",
+      "**\\Updates\\**"
     ]
   },
-  
-  "notes": "Full PowerToys configuration including all enabled modules. Excludes runtime logs and volatile files."
+
+  "notes": "Full PowerToys configuration including all enabled modules. Excludes runtime logs, volatile files, and the Updates/ dir where PowerToys stages its ~400 MiB self-update installer (otherwise dominates the capture; see substrate PR #15 regression notes)."
 }


### PR DESCRIPTION
## Summary

PowerToys' \`Updates/\` dir under \`%LOCALAPPDATA%\Microsoft\PowerToys\` is where PowerToys stages its downloaded self-update installer (\`powertoysusersetup-*-x64.exe\`, currently **~400 MiB**). The module's \`excludeGlobs\` covered \`Logs/Temp/Cache/GPUCache/Crashpad\` — but **not** \`Updates/\`. Every capture that included PowerToys inflated by ~376 MiB.

This was surfaced via substrate PR #15's hosted-backup e2e: a \"default\" profile push to R2 produced **377 MiB of encrypted data per version** (754 MiB across 2 versions). Static inventory of the source profile zip pinned 97% of the bytes to a single \`configs/powertoys/powertoys/Updates/powertoysusersetup-0.98.1-x64.exe\` (394,468,640 bytes). At the default 1 GiB / 5-version hosted-backup quota, this gives users 2–3 pushes before hitting the cap.

## Changes

- \`modules/apps/powertoys/module.jsonc\` — add \`**\Updates\**\` to both \`capture.excludeGlobs\` and the \`restore\` step's \`exclude\` array (kept symmetric). Note added explaining the trap.
- \`go-engine/internal/modules/regression_test.go\` (new) — loads the production module catalog and asserts \`apps.powertoys\` excludes \`Updates/\`. Fails on current main; passes after the module edit.

## Not a code bug

\`matchesExcludeGlobs\` already supports \`**\Updates\**\` correctly — \`filepath.ToSlash\` normalizes the backslashes and the \`/Updates/\` substring check works. This was a module-config omission, not an engine bug. No code in \`internal/bundle\` changed.

## Test plan

- [x] \`go test ./internal/modules/ -run TestPowerToysModule_ExcludesUpdatesDir -v\` — fails on main (smoking-gun trace), passes after the module edit.
- [x] \`go test ./...\` — full engine suite green.
- [ ] After release (release-please will pick this up), regenerate a profile bundle on a PowerToys-using machine and confirm \`configs/powertoys/.../Updates/\` is absent from the zip.

## Follow-ups (out of scope; flagging for the radar)

1. **Other modules likely have similar leaks.** Any module that captures a whole appdata dir is at risk if the app stages installers/caches outside the named exclude dirs. A quick audit suggests \~40 modules don't exclude \`Updates/\`. Not all of them have an Updates dir, but worth a sweep.
2. **Engine-side defense in depth.** Consider a global filter (e.g., \`*.exe\` / \`*.msi\` / \`*.appx\` over some threshold) so a misconfigured module can't bloat captures unboundedly. Currently the engine trusts the module fully.
3. **GUI profile-selection UX.** Users pick a saved profile from disk to push; nothing in the GUI warns them when a profile is unreasonably large for cloud storage. A pre-push size check + warning would catch this before bytes hit the wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)