### PR TITLE
feat(backup): emit backup-chunk events with per-attempt retry visibility

### DIFF
--- a/docs/contracts/event-contract.md
+++ b/docs/contracts/event-contract.md
@@ -46,7 +46,7 @@ Every event **MUST** include:
 | `version` | integer | Event schema version (always `1` for this contract) |
 | `runId` | string | Run identifier (e.g., `"apply-20250101-120000-MACHINE"`) |
 | `timestamp` | string | RFC3339 UTC timestamp (informational; NDJSON line order is authoritative) |
-| `event` | string | Event type: `"phase"`, `"item"`, `"summary"`, `"error"`, `"artifact"` |
+| `event` | string | Event type: `"phase"`, `"item"`, `"summary"`, `"error"`, `"artifact"`, `"restore-item"`, `"backup-chunk"` |
 
 ### Event Types
 
@@ -249,6 +249,54 @@ Tracks progress of individual restore actions during apply with `--EnableRestore
 **Summary event extension:**
 When `phase` is `"restore"`, the summary event may include an additional optional field:
 - `backupLocation` (string | null): Root backup directory path
+
+---
+
+#### 7. Backup-Chunk Event
+
+Tracks per-chunk progress of a hosted-backup push or pull (added in engine v2.3.0). Non-breaking addition (new event type, no version bump).
+
+```json
+{
+  "version": 1,
+  "runId": "backup-push-20260526-120000-MACHINE",
+  "timestamp": "2026-05-26T12:00:01.456Z",
+  "event": "backup-chunk",
+  "chunkIndex": 46,
+  "totalChunks": 95,
+  "encryptedSize": 4194316,
+  "status": "uploading",
+  "current": 47,
+  "total": 95
+}
+```
+
+**Fields:**
+- `chunkIndex` (integer, required): 0-based chunk index, or `-1` for the manifest blob
+- `totalChunks` (integer, required): Count of data chunks (manifest excluded)
+- `encryptedSize` (integer, required): On-the-wire size of the chunk in bytes
+- `status` (string, required): One of:
+  - `"uploading"` — push: chunk in flight
+  - `"uploaded"` — push: chunk terminally succeeded
+  - `"downloading"` — pull: chunk in flight
+  - `"verified"` — pull: SHA-256 verified
+  - `"decrypted"` — pull: AEAD decrypt succeeded
+  - `"retrying"` — push: previous attempt failed with a retryable error; retry imminent (no pull-side retry today)
+  - `"failed"` — terminal failure after exhausting retries
+- `message` (string, optional): Non-fatal hint (e.g., error message before retry)
+- `attempt` (integer, optional): 1-based current attempt number; present only when `status === "retrying"`
+- `maxAttempts` (integer, optional): Inclusive upper bound on attempts; present only when `status === "retrying"`
+- `current` (integer, optional): 1-based chunk-of-total position (mirrors `chunkIndex + 1` for data chunks; omitted for the manifest chunk)
+- `total` (integer, optional): Mirrors `totalChunks` for forward-compat
+
+**Guarantees:**
+- Emitted during the `"backup-push"` and `"backup-pull"` phases (alongside existing item events for log continuity)
+- Per chunk, the status sequence is `uploading → (retrying* →) uploaded` for push and `downloading → verified → decrypted` for pull
+- A `retrying` event is emitted **before** the backoff sleep, so the GUI shows the retry tag during the sleep window rather than after
+
+**Consumer notes:**
+- The GUI MUST handle missing `attempt` / `maxAttempts` gracefully (treat as a generic retry indicator) so a GUI built against this event can still consume events from an older engine that doesn't yet emit them
+- `current` is omitted from the manifest chunk (chunkIndex == -1); the GUI should render "manifest" rather than a chunk number
 
 ---
 

--- a/go-engine/internal/backup/download/download.go
+++ b/go-engine/internal/backup/download/download.go
@@ -241,16 +241,30 @@ func getParallelChunks(ctx context.Context, hc *http.Client, urls []storage.Pres
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	totalChunks := len(chunks)
+	emitChunk := func(idx uint32, status, message string, encSize int) {
+		em.EmitBackupChunk(events.BackupChunkProgress{
+			ChunkIndex:    int(idx),
+			TotalChunks:   totalChunks,
+			EncryptedSize: encSize,
+			Status:        status,
+			Message:       message,
+		})
+	}
+
 	var wg sync.WaitGroup
 	for w := 0; w < concurrency; w++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			for j := range work {
+				encSize := int(j.meta.EncryptedSize)
 				em.EmitItem(fmt.Sprintf("chunk-%d", j.index), "hosted-backup", "downloading", "", "", "")
+				emitChunk(j.index, "downloading", "", encSize)
 				blob, gerr := getOnce(ctx, hc, j.url)
 				if gerr != nil {
 					em.EmitItem(fmt.Sprintf("chunk-%d", j.index), "hosted-backup", "failed", gerr.Error(), "", "")
+					emitChunk(j.index, "failed", gerr.Error(), encSize)
 					errCh <- envelope.NewError(envelope.ErrBackendUnreachable,
 						fmt.Sprintf("backup pull: download chunk %d: %s", j.index, gerr.Error()))
 					cancel()
@@ -259,6 +273,7 @@ func getParallelChunks(ctx context.Context, hc *http.Client, urls []storage.Pres
 				sum := sha256.Sum256(blob)
 				if hex.EncodeToString(sum[:]) != strings.ToLower(j.meta.SHA256) {
 					em.EmitItem(fmt.Sprintf("chunk-%d", j.index), "hosted-backup", "failed", "sha256 mismatch", "", "")
+					emitChunk(j.index, "failed", "sha256 mismatch", encSize)
 					errCh <- envelope.NewError(envelope.ErrInternalError,
 						fmt.Sprintf("backup pull: chunk %d SHA-256 mismatch — refusing to decrypt", j.index)).
 						WithRemediation("Re-run; if it persists, the chunk may be corrupted in storage.")
@@ -266,9 +281,11 @@ func getParallelChunks(ctx context.Context, hc *http.Client, urls []storage.Pres
 					return
 				}
 				em.EmitItem(fmt.Sprintf("chunk-%d", j.index), "hosted-backup", "verified", "", "", "")
+				emitChunk(j.index, "verified", "", encSize)
 				plain, derr := crypto.DecryptChunk(blob, j.index, dek)
 				if derr != nil {
 					em.EmitItem(fmt.Sprintf("chunk-%d", j.index), "hosted-backup", "failed", "decrypt failed", "", "")
+					emitChunk(j.index, "failed", "decrypt failed", encSize)
 					errCh <- envelope.NewError(envelope.ErrInternalError,
 						fmt.Sprintf("backup pull: decrypt chunk %d: %s", j.index, derr.Error()))
 					cancel()
@@ -276,6 +293,7 @@ func getParallelChunks(ctx context.Context, hc *http.Client, urls []storage.Pres
 				}
 				out[j.index] = plain
 				em.EmitItem(fmt.Sprintf("chunk-%d", j.index), "hosted-backup", "decrypted", "", "", "")
+				emitChunk(j.index, "decrypted", "", encSize)
 			}
 		}()
 	}

--- a/go-engine/internal/backup/upload/upload.go
+++ b/go-engine/internal/backup/upload/upload.go
@@ -192,7 +192,7 @@ func PushVersion(ctx context.Context, deps Dependencies, backupID, profilePath, 
 		work = append(work, uploadItem{index: i, url: u.PresignedURL, data: blob})
 	}
 
-	successCount, failedCount, perr := putParallel(ctx, httpClient, work, concurrency, retries, deps.Events)
+	successCount, failedCount, perr := putParallel(ctx, httpClient, work, concurrency, retries, chunkCount, deps.Events)
 	if perr != nil {
 		deps.Events.EmitSummary("backup-push", chunkCount+1, successCount, 0, failedCount)
 		return nil, envelope.NewError(envelope.ErrBackendUnreachable,
@@ -343,7 +343,9 @@ type uploadItem struct {
 // concurrency and limited 5xx retries. Returns (successCount,
 // failedCount, error). On any item failing past its retry budget, the
 // returned error is non-nil and ctx propagation cancels remaining work.
-func putParallel(ctx context.Context, hc *http.Client, items []uploadItem, concurrency, retries int, em *events.Emitter) (int, int, error) {
+// totalChunks is the count of data chunks (manifest excluded), forwarded
+// to per-chunk progress events for GUI rendering.
+func putParallel(ctx context.Context, hc *http.Client, items []uploadItem, concurrency, retries, totalChunks int, em *events.Emitter) (int, int, error) {
 	if concurrency < 1 {
 		concurrency = 1
 	}
@@ -365,7 +367,7 @@ func putParallel(ctx context.Context, hc *http.Client, items []uploadItem, concu
 		go func() {
 			defer wg.Done()
 			for it := range work {
-				if err := putWithRetry(ctx, hc, it, retries, em); err != nil {
+				if err := putWithRetry(ctx, hc, it, retries, totalChunks, em); err != nil {
 					counterMu.Lock()
 					failed++
 					counterMu.Unlock()
@@ -403,22 +405,59 @@ func putParallel(ctx context.Context, hc *http.Client, items []uploadItem, concu
 	return success, failed, firstErr
 }
 
-// putWithRetry PUTs one upload item, retrying once on 5xx. Emits item
-// events `uploading` → `uploaded` (or `failed`) for the GUI progress UI.
-func putWithRetry(ctx context.Context, hc *http.Client, it uploadItem, retries int, em *events.Emitter) error {
+// putWithRetry PUTs one upload item, retrying once on 5xx. Emits both
+// item events (for log continuity) and richer backup-chunk events (for the
+// GUI's per-chunk progress dialog, including retry visibility).
+//
+// totalChunks is the count of data chunks (manifest excluded). The
+// manifest item carries chunkIndex == storage.ManifestChunkIndex (-1);
+// data chunks carry their 0-based index.
+func putWithRetry(ctx context.Context, hc *http.Client, it uploadItem, retries, totalChunks int, em *events.Emitter) error {
 	em.EmitItem(itemID(it.index), "hosted-backup", "uploading", "", "", "")
+	em.EmitBackupChunk(events.BackupChunkProgress{
+		ChunkIndex:    it.index,
+		TotalChunks:   totalChunks,
+		EncryptedSize: len(it.data),
+		Status:        "uploading",
+	})
 	attempt := 0
+	maxAttempts := retries + 1
 	for {
 		err := putOnce(ctx, hc, it)
 		if err == nil {
 			em.EmitItem(itemID(it.index), "hosted-backup", "uploaded", "", "", "")
+			em.EmitBackupChunk(events.BackupChunkProgress{
+				ChunkIndex:    it.index,
+				TotalChunks:   totalChunks,
+				EncryptedSize: len(it.data),
+				Status:        "uploaded",
+			})
 			return nil
 		}
 		if !isRetryable(err) || attempt >= retries {
 			em.EmitItem(itemID(it.index), "hosted-backup", "failed", err.Error(), "", "")
+			em.EmitBackupChunk(events.BackupChunkProgress{
+				ChunkIndex:    it.index,
+				TotalChunks:   totalChunks,
+				EncryptedSize: len(it.data),
+				Status:        "failed",
+				Message:       err.Error(),
+			})
 			return err
 		}
 		attempt++
+		// Emit the retry event BEFORE the backoff sleep so the GUI shows
+		// "Retrying chunk N of M (attempt X of Y)" while the sleep runs,
+		// not after.
+		em.EmitBackupChunk(events.BackupChunkProgress{
+			ChunkIndex:    it.index,
+			TotalChunks:   totalChunks,
+			EncryptedSize: len(it.data),
+			Status:        "retrying",
+			Message:       err.Error(),
+			Attempt:       attempt + 1,
+			MaxAttempts:   maxAttempts,
+		})
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/go-engine/internal/events/emitter.go
+++ b/go-engine/internal/events/emitter.go
@@ -132,3 +132,45 @@ func (e *Emitter) EmitArtifact(phase, kind, path string) {
 		Path:      path,
 	})
 }
+
+// BackupChunkProgress carries the per-chunk fields emitted as a
+// `backup-chunk` event. Pass into EmitBackupChunk so future fields can be
+// added without breaking call sites.
+type BackupChunkProgress struct {
+	ChunkIndex    int
+	TotalChunks   int
+	EncryptedSize int
+	Status        string // "uploading"|"uploaded"|"downloading"|"verified"|"decrypted"|"retrying"|"failed"
+	Message       string
+	// Retry-specific. Both set only when Status == "retrying".
+	Attempt     int
+	MaxAttempts int
+}
+
+// EmitBackupChunk emits a hosted-backup per-chunk progress event. Used by
+// the upload and download pipelines so the GUI can render chunk-by-chunk
+// progress (and, for the upload path, retry attempts).
+func (e *Emitter) EmitBackupChunk(p BackupChunkProgress) {
+	if !e.enabled {
+		return
+	}
+	// Current/Total are convenience fields for GUI rendering. The manifest
+	// (chunkIndex == -1) reports current 0 — the GUI treats <=0 as "manifest"
+	// and shows a separate label.
+	current := 0
+	if p.ChunkIndex >= 0 {
+		current = p.ChunkIndex + 1
+	}
+	e.emit(BackupChunkEvent{
+		BaseEvent:     e.base("backup-chunk"),
+		ChunkIndex:    p.ChunkIndex,
+		TotalChunks:   p.TotalChunks,
+		EncryptedSize: p.EncryptedSize,
+		Status:        p.Status,
+		Message:       p.Message,
+		Attempt:       p.Attempt,
+		MaxAttempts:   p.MaxAttempts,
+		Current:       current,
+		Total:         p.TotalChunks,
+	})
+}

--- a/go-engine/internal/events/emitter_test.go
+++ b/go-engine/internal/events/emitter_test.go
@@ -594,3 +594,109 @@ func TestEmitMultipleEvents_SeparateLines(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// BackupChunk event (Wave 6 — hosted-backup per-chunk progress + retry)
+// ---------------------------------------------------------------------------
+
+func TestEmitBackupChunk_Uploading(t *testing.T) {
+	runID := "push-test"
+	em, buf := captureEmitter(runID)
+	em.EmitBackupChunk(BackupChunkProgress{
+		ChunkIndex:    46,
+		TotalChunks:   95,
+		EncryptedSize: 4194316,
+		Status:        "uploading",
+	})
+
+	ev := parseEvent(t, lastLine(buf))
+	assertBaseFields(t, ev, runID, "backup-chunk")
+
+	if ev["chunkIndex"] != float64(46) {
+		t.Errorf("chunkIndex = %v, want 46", ev["chunkIndex"])
+	}
+	if ev["totalChunks"] != float64(95) {
+		t.Errorf("totalChunks = %v, want 95", ev["totalChunks"])
+	}
+	if ev["encryptedSize"] != float64(4194316) {
+		t.Errorf("encryptedSize = %v, want 4194316", ev["encryptedSize"])
+	}
+	if ev["status"] != "uploading" {
+		t.Errorf("status = %v, want 'uploading'", ev["status"])
+	}
+	// current = chunkIndex + 1 for data chunks
+	if ev["current"] != float64(47) {
+		t.Errorf("current = %v, want 47", ev["current"])
+	}
+	if ev["total"] != float64(95) {
+		t.Errorf("total = %v, want 95", ev["total"])
+	}
+	// attempt / maxAttempts should be omitted on non-retry status
+	if _, ok := ev["attempt"]; ok {
+		t.Errorf("expected 'attempt' to be omitted for non-retry, got %v", ev["attempt"])
+	}
+	if _, ok := ev["maxAttempts"]; ok {
+		t.Errorf("expected 'maxAttempts' to be omitted for non-retry, got %v", ev["maxAttempts"])
+	}
+}
+
+func TestEmitBackupChunk_Retrying(t *testing.T) {
+	em, buf := captureEmitter("retry-test")
+	em.EmitBackupChunk(BackupChunkProgress{
+		ChunkIndex:    46,
+		TotalChunks:   95,
+		EncryptedSize: 4194316,
+		Status:        "retrying",
+		Message:       "upload: presigned PUT returned HTTP 503",
+		Attempt:       2,
+		MaxAttempts:   3,
+	})
+
+	ev := parseEvent(t, lastLine(buf))
+	if ev["status"] != "retrying" {
+		t.Errorf("status = %v, want 'retrying'", ev["status"])
+	}
+	if ev["attempt"] != float64(2) {
+		t.Errorf("attempt = %v, want 2", ev["attempt"])
+	}
+	if ev["maxAttempts"] != float64(3) {
+		t.Errorf("maxAttempts = %v, want 3", ev["maxAttempts"])
+	}
+	if ev["message"] != "upload: presigned PUT returned HTTP 503" {
+		t.Errorf("message = %v, want 'upload: presigned PUT returned HTTP 503'", ev["message"])
+	}
+}
+
+func TestEmitBackupChunk_ManifestChunk(t *testing.T) {
+	// Manifest carries ChunkIndex == -1; the emitter reports current == 0
+	// so the GUI can distinguish "manifest" from a regular chunk.
+	em, buf := captureEmitter("manifest-test")
+	em.EmitBackupChunk(BackupChunkProgress{
+		ChunkIndex:    -1,
+		TotalChunks:   95,
+		EncryptedSize: 2048,
+		Status:        "uploading",
+	})
+
+	ev := parseEvent(t, lastLine(buf))
+	if ev["chunkIndex"] != float64(-1) {
+		t.Errorf("chunkIndex = %v, want -1", ev["chunkIndex"])
+	}
+	// "current" is omitempty + value 0 → omitted from JSON
+	if _, ok := ev["current"]; ok {
+		t.Errorf("expected 'current' to be omitted for manifest chunk, got %v", ev["current"])
+	}
+}
+
+func TestEmitBackupChunk_DisabledEmitterProducesNoOutput(t *testing.T) {
+	buf := &bytes.Buffer{}
+	em := NewEmitterWithWriter("disabled-test", false, buf)
+	em.EmitBackupChunk(BackupChunkProgress{
+		ChunkIndex:  0,
+		TotalChunks: 1,
+		Status:      "uploading",
+	})
+	if buf.Len() != 0 {
+		t.Errorf("expected no output from disabled emitter, got %q", buf.String())
+	}
+}

--- a/go-engine/internal/events/types.go
+++ b/go-engine/internal/events/types.go
@@ -61,3 +61,41 @@ type ArtifactEvent struct {
 	Kind  string `json:"kind"`
 	Path  string `json:"path"`
 }
+
+// BackupChunkEvent tracks per-chunk progress of a hosted-backup push or pull.
+//
+// Status values:
+//   - Push (backup-push phase): "uploading" → "uploaded" (terminal-success),
+//     with "retrying" between attempts and "failed" on terminal error.
+//   - Pull (backup-pull phase): "downloading" → "verified" → "decrypted"
+//     (per-chunk pipeline), with "failed" on error. The pull path does not
+//     currently retry at the chunk level so "retrying" is push-only today.
+//
+// Retry fields (Attempt / MaxAttempts) are present when Status == "retrying".
+// Current / Total mirror ChunkIndex+1 / TotalChunks for forward-compat with
+// non-chunk-indexed progress sources; they are always populated.
+type BackupChunkEvent struct {
+	BaseEvent
+	// ChunkIndex is the 0-based chunk index, or storage.ManifestChunkIndex (-1)
+	// for the manifest blob itself.
+	ChunkIndex int `json:"chunkIndex"`
+	// TotalChunks is the count of data chunks (excluding the manifest).
+	TotalChunks int `json:"totalChunks"`
+	// EncryptedSize is the on-the-wire size of the chunk in bytes.
+	EncryptedSize int    `json:"encryptedSize"`
+	Status        string `json:"status"`
+	// Message carries a non-fatal hint (e.g. error message before retry).
+	// Omitted when empty.
+	Message string `json:"message,omitempty"`
+	// Attempt is the 1-based current attempt number; only set when
+	// Status == "retrying".
+	Attempt int `json:"attempt,omitempty"`
+	// MaxAttempts is the inclusive upper bound on attempts; only set when
+	// Status == "retrying".
+	MaxAttempts int `json:"maxAttempts,omitempty"`
+	// Current is the 1-based chunk-of-total position (mirrors ChunkIndex+1
+	// for data chunks). Always set.
+	Current int `json:"current,omitempty"`
+	// Total mirrors TotalChunks for forward-compat. Always set.
+	Total int `json:"total,omitempty"`
+}


### PR DESCRIPTION
## Summary

- Bridges a pre-existing gap: the GUI's `backup-chunk` event type was a paper contract the engine never honored — the push/pull progress dialogs spun without per-chunk progress.
- Adds `EmitBackupChunk(BackupChunkProgress)` + `BackupChunkEvent` type. Existing `EmitItem` arity unchanged (shared with capture/restore) — both events emitted so CLI/log readers keep working.
- `putWithRetry` (upload) now emits a `retrying` chunk event **before** the backoff sleep, carrying `attempt` + `maxAttempts` so the GUI can render `"Retrying chunk N of M (attempt X of Y)"`. Pull path emits `downloading` → `verified` → `decrypted`; pull has no chunk-level retry today so `retrying` is push-only.
- Documents the new event in `docs/contracts/event-contract.md` with consumer guidance for missing optional fields (older-engine compat).

Coordinates with [endstate-gui#48](https://github.com/Artexis10/endstate-gui/pull/48) (Wave 6 of the hosted-backup polish plan). The GUI handles missing `attempt` / `maxAttempts` gracefully so the GUI PR can land first; this engine PR enables the richer copy once the binary is re-pinned.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/events/... ./internal/backup/...\` passes (4 new emitter tests pin the JSON shape, retry-attempt fields, and manifest-chunk-index omission)
- [x] Built binary verified via \`endstate capabilities --json\` — hostedBackup feature reports supported
- [x] GUI-side parses both rich (attempt/maxAttempts populated) and sparse (older-engine fallback) retry events at runtime
- [ ] Live verification with an induced 503 against substrate to see a real retry event in the wild (deferred; mock'd at unit-test level)

🤖 Generated with [Claude Code](https://claude.com/claude-code)