### PR TITLE
fix(ci): dispatch Release workflow from release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -7,10 +7,41 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  # Required for the dispatch-release job below — fires `gh workflow run` to
+  # kick the Release workflow once release-please has cut a new release.
+  actions: write
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.rp.outputs.release_created }}
+      tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
       # Config driven via release-please-config.json
       - uses: googleapis/release-please-action@v4
+        id: rp
+
+  # release-please creates the tag + GitHub Release via GITHUB_TOKEN. Per
+  # GitHub's recursion-protection rule, events triggered by GITHUB_TOKEN do
+  # NOT fire other workflows — with two documented exceptions:
+  # `workflow_dispatch` and `repository_dispatch`. So the `release: published`
+  # trigger in release.yml has never actually fired (see the workflow run
+  # history — every Release run is either a manual workflow_dispatch or a
+  # legacy push:tag from before release-please-action). This step closes the
+  # gap by explicitly dispatching release.yml with the just-cut tag.
+  dispatch-release:
+    needs: release-please
+    if: needs.release-please.outputs.release_created == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Dispatch Release workflow to build + upload binaries
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh workflow run release.yml \
+            --repo "${{ github.repository }}" \
+            --ref main \
+            --field tag_name="${{ needs.release-please.outputs.tag_name }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,16 +2,22 @@ name: Release
 
 # Builds endstate.exe + .sha256 and attaches them to the GitHub Release.
 #
-# Triggers on `release: published` rather than `push: tags` because the tag is
-# created by release-please-action via GITHUB_TOKEN — and per GitHub's
-# recursion-protection rule, GITHUB_TOKEN-created tags do NOT fire
-# `push: tags` workflows. `release: published` does fire for releases created
-# via GITHUB_TOKEN, which is what release-please does (creates tag + release
-# in one step).
+# Trigger model: dispatched from release-please.yml via `gh workflow run`
+# once a new release is cut. The `release: published` trigger is kept as a
+# defensive backup in case the release is ever created by a non-
+# GITHUB_TOKEN identity (PAT, GitHub App) where the recursion-protection
+# rule doesn't apply — but the primary path is workflow_dispatch.
 #
-# workflow_dispatch with `tag_name` input remains the manual override for
-# backfilling assets onto an older release (e.g. one created before this
-# trigger was fixed).
+# History: an earlier iteration relied on `release: published` firing for
+# releases created by release-please-action. That doesn't actually work —
+# GitHub blocks GITHUB_TOKEN-triggered events from cascading into other
+# workflows (with `workflow_dispatch` and `repository_dispatch` as the
+# documented exceptions). Releases v2.0.1 / v2.1.0 / v2.2.1 / v2.3.0
+# shipped without binaries as a result. See release-please.yml for the
+# dispatch fix.
+#
+# workflow_dispatch with `tag_name` input also doubles as the manual
+# backfill path for any release that pre-dates the fix.
 
 on:
   release:


### PR DESCRIPTION
## Summary

The Release workflow has never auto-fired from a release-please-created release. Every binary upload in this repo's history is either a manual `workflow_dispatch` or a legacy `push:tags` from before release-please-action. As a result, v2.0.1 / v2.1.0 / v2.2.1 / v2.3.0 all shipped without \`endstate.exe\` and \`endstate.exe.sha256\` — blocking the endstate-gui pin from advancing past v2.2.0.

**Root cause:** GitHub blocks events triggered by \`GITHUB_TOKEN\` from cascading into other workflows (recursion protection). \`workflow_dispatch\` and \`repository_dispatch\` are the documented exceptions; \`release: published\` is **not**. The current trigger in \`release.yml\` was wishful thinking.

**Fix:** add a \`dispatch-release\` job to \`release-please.yml\` that fires \`gh workflow run release.yml --field tag_name=\$TAG\` after a release is cut. \`workflow_dispatch\` IS allowed from \`GITHUB_TOKEN\`, so the cascade actually fires this time. The \`release: published\` trigger stays as a defensive backup for any future non-\`GITHUB_TOKEN\` release-creation path (PAT/App).

## Backfill

v2.3.0 has been manually triggered via \`workflow_dispatch\` in parallel with this PR so [endstate-gui#48](https://github.com/Artexis10/endstate-gui/pull/48) can bump \`ENGINE_VERSION\` to 2.3.0 without waiting for this fix to merge.

## Test plan

- [x] Branch off latest \`main\` (includes #37)
- [x] Workflow YAML edits are isolated to .github/workflows/
- [ ] Merge this PR → next release-please-cut release (next \`feat:\`/\`fix:\` on main) should auto-fire the Release workflow, attaching endstate.exe + endstate.exe.sha256 with no manual intervention
- [ ] Verify by watching the next release: \`gh run list --workflow=release.yml\` should show a \`workflow_dispatch\` run kicked by \`release-please\` (look at \`triggering_actor\` / event payload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)