### PR TITLE
fix(ci): auth release-please via GitHub App, drop dispatch shim

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -4,44 +4,28 @@ on:
   push:
     branches: [main]
 
+# Release-please runs under the endstate-release-bot GitHub App identity
+# (App ID + private key live as RELEASE_PLEASE_APP_* secrets). The minted
+# installation token is a non-GITHUB_TOKEN credential, so the PRs and
+# releases it creates fire `pull_request` and `release: published` events
+# normally — bypassing the recursion-protection rule that previously
+# silently swallowed every cascade from this workflow. The earlier
+# `dispatch-release` job (workflow_dispatch shim) is no longer needed.
+
 permissions:
-  contents: write
-  pull-requests: write
-  # Required for the dispatch-release job below — fires `gh workflow run` to
-  # kick the Release workflow once release-please has cut a new release.
-  actions: write
+  contents: read
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.rp.outputs.release_created }}
-      tag_name: ${{ steps.rp.outputs.tag_name }}
     steps:
-      # Config driven via release-please-config.json
-      - uses: googleapis/release-please-action@v4
-        id: rp
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_PLEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_PLEASE_APP_PRIVATE_KEY }}
 
-  # release-please creates the tag + GitHub Release via GITHUB_TOKEN. Per
-  # GitHub's recursion-protection rule, events triggered by GITHUB_TOKEN do
-  # NOT fire other workflows — with two documented exceptions:
-  # `workflow_dispatch` and `repository_dispatch`. So the `release: published`
-  # trigger in release.yml has never actually fired (see the workflow run
-  # history — every Release run is either a manual workflow_dispatch or a
-  # legacy push:tag from before release-please-action). This step closes the
-  # gap by explicitly dispatching release.yml with the just-cut tag.
-  dispatch-release:
-    needs: release-please
-    if: needs.release-please.outputs.release_created == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - name: Dispatch Release workflow to build + upload binaries
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          gh workflow run release.yml \
-            --repo "${{ github.repository }}" \
-            --ref main \
-            --field tag_name="${{ needs.release-please.outputs.tag_name }}"
+      - uses: googleapis/release-please-action@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,22 +2,14 @@ name: Release
 
 # Builds endstate.exe + .sha256 and attaches them to the GitHub Release.
 #
-# Trigger model: dispatched from release-please.yml via `gh workflow run`
-# once a new release is cut. The `release: published` trigger is kept as a
-# defensive backup in case the release is ever created by a non-
-# GITHUB_TOKEN identity (PAT, GitHub App) where the recursion-protection
-# rule doesn't apply — but the primary path is workflow_dispatch.
+# Trigger model: `release: published` fires naturally when release-please
+# cuts a release, because release-please.yml now mints its token from the
+# endstate-release-bot GitHub App (not GITHUB_TOKEN), and App-created
+# events DO cascade into other workflows.
 #
-# History: an earlier iteration relied on `release: published` firing for
-# releases created by release-please-action. That doesn't actually work —
-# GitHub blocks GITHUB_TOKEN-triggered events from cascading into other
-# workflows (with `workflow_dispatch` and `repository_dispatch` as the
-# documented exceptions). Releases v2.0.1 / v2.1.0 / v2.2.1 / v2.3.0
-# shipped without binaries as a result. See release-please.yml for the
-# dispatch fix.
-#
-# workflow_dispatch with `tag_name` input also doubles as the manual
-# backfill path for any release that pre-dates the fix.
+# workflow_dispatch with `tag_name` is kept for manual backfills (e.g.
+# re-running a build that failed for transient reasons, or attaching
+# assets to a pre-App-era release like v2.0.1 / v2.1.0 / v2.2.1).
 
 on:
   release:


### PR DESCRIPTION
## Summary

Replaces the GITHUB_TOKEN-based release-please flow with one authenticated via the **endstate-release-bot** GitHub App. App-minted installation tokens are not subject to GitHub's recursion-protection rule, so the releases this workflow creates fire \`release: published\` events naturally — meaning [release.yml](.github/workflows/release.yml) runs without any workflow_dispatch shim.

## Why

PR #39 worked around the recursion-protection rule by dispatching release.yml manually. That was duct-tape — the same class of bug then bit the GUI repo on the release-please PR side, requiring another shim. The proper fix is to authenticate release-please as a non-GITHUB_TOKEN identity. GitHub App is the recommended pattern for OSS:

- Ephemeral tokens (~1h), regenerated per workflow run
- No long-lived PAT sitting in repo secrets
- Isolated identity (\`endstate-release-bot[bot]\`) instead of acting as the maintainer's account
- Already standard across the OSS ecosystem (release-please's own docs recommend it)

## Changes

- \`release-please.yml\`: mint an installation token via \`actions/create-github-app-token@v1\` using the \`RELEASE_PLEASE_APP_ID\` + \`RELEASE_PLEASE_APP_PRIVATE_KEY\` secrets; pass it to release-please-action as \`token:\`. Drop the \`dispatch-release\` job (no longer needed). Reduce workflow's own GITHUB_TOKEN permissions to \`contents: read\` since the App token carries the write capability.
- \`release.yml\`: update the trigger-model comment to reflect that \`release: published\` is now the primary path. \`workflow_dispatch\` is kept for manual backfills.

## Prereqs (done)

- GitHub App \`endstate-release-bot\` created, installed on this repo, with Contents R/W + Pull requests R/W + Issues R/W permissions.
- Repository secrets set:
  - \`RELEASE_PLEASE_APP_ID\`
  - \`RELEASE_PLEASE_APP_PRIVATE_KEY\`

## Test plan

- [x] Workflow syntax valid (GitHub validates at parse time)
- [ ] After merge, the next conventional commit on main should trigger release-please normally; the resulting release PR should be opened by \`endstate-release-bot[bot]\` (not \`github-actions[bot]\`)
- [ ] Merging that release PR should publish a release AND fire release.yml from the \`release: published\` event without any manual dispatch
- [ ] Verify by watching \`gh run list --workflow=release.yml\` after the next release — should show \`release\` (not \`workflow_dispatch\`) as the triggering event

🤖 Generated with [Claude Code](https://claude.com/claude-code)