### PR TITLE
feat(engine): platform-aware backend selection foundation

### DIFF
--- a/docs/contracts/cli-json-contract.md
+++ b/docs/contracts/cli-json-contract.md
@@ -194,10 +194,12 @@ endstate capabilities --json
 | `supportedSchemaVersions` | object | Yes | Min/max supported schema versions |
 | `commands` | object | Yes | Supported commands with flags |
 | `features` | object | Yes | Feature flags |
-| `platform` | object | Yes | OS and driver information |
+| `platform` | object | Yes | Host OS and available package-manager drivers (host-dependent — see note) |
 | `gitCommit` | string\|null | Yes | Short git SHA of HEAD, or `null` if git unavailable |
 | `gitDirty` | boolean | Yes | `true` if working tree has uncommitted changes, `false` otherwise (defaults to `false` if git unavailable) |
 | `bootstrapTimestamp` | string\|null | Yes | ISO 8601 UTC timestamp of last bootstrap, or `null` if not bootstrapped |
+
+> **`platform` is host-dependent.** `platform.os` reflects the host operating system (`windows`, `linux`, `darwin`) and `platform.drivers` lists the package-manager backends available on that host. On Windows this is `{ "os": "windows", "drivers": ["winget"] }`. On a host with no implemented backend yet, `drivers` is an empty array (`[]`). This is additive: consumers MUST NOT assume a fixed `windows` / `winget` value.
 
 ---
 

--- a/go-engine/internal/bundle/collect.go
+++ b/go-engine/internal/bundle/collect.go
@@ -41,7 +41,7 @@ func CollectConfigFiles(module *modules.Module, stagingDir string) ([]string, er
 	var collected []string
 
 	for _, fileEntry := range module.Capture.Files {
-		sourcePath := config.ExpandWindowsEnvVars(fileEntry.Source)
+		sourcePath := config.ExpandEnvVars(fileEntry.Source)
 		sourcePath = os.ExpandEnv(sourcePath)
 
 		// Expand ~ to home directory.

--- a/go-engine/internal/commands/apply.go
+++ b/go-engine/internal/commands/apply.go
@@ -24,7 +24,7 @@ func stringPtr(s string) *string { return &s }
 // expandVerifyPath expands Windows-style %VAR% and Go-style $VAR environment
 // variables in a verify path. Uses the same expansion as the restore module.
 func expandVerifyPath(p string) string {
-	expanded := config.ExpandWindowsEnvVars(p)
+	expanded := config.ExpandEnvVars(p)
 	expanded = os.ExpandEnv(expanded)
 	return expanded
 }
@@ -177,7 +177,10 @@ func RunApply(flags ApplyFlags) (interface{}, *envelope.Error) {
 		}
 	}
 
-	d := newDriverFn()
+	d, derr := newDriverFn()
+	if derr != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, derr.Error())
+	}
 
 	// First event in stream MUST be a phase event per event-contract.md.
 	emitter.EmitPhase("plan")
@@ -193,7 +196,7 @@ func RunApply(flags ApplyFlags) (interface{}, *envelope.Error) {
 	// Batch-detect all winget apps in one call for performance.
 	var wingetRefs []string
 	for _, app := range mf.Apps {
-		ref := resolveWindowsRef(app)
+		ref := resolveAppRef(app)
 		if ref != "" {
 			wingetRefs = append(wingetRefs, ref)
 		}
@@ -210,7 +213,7 @@ func RunApply(flags ApplyFlags) (interface{}, *envelope.Error) {
 	toInstallCount := 0
 
 	for _, app := range mf.Apps {
-		ref := resolveWindowsRef(app)
+		ref := resolveAppRef(app)
 		isManual := ref == "" && app.Manual != nil && app.Manual.VerifyPath != ""
 
 		if ref == "" && !isManual {

--- a/go-engine/internal/commands/capabilities.go
+++ b/go-engine/internal/commands/capabilities.go
@@ -7,6 +7,8 @@
 package commands
 
 import (
+	"runtime"
+
 	"github.com/Artexis10/endstate/go-engine/internal/backup"
 	"github.com/Artexis10/endstate/go-engine/internal/envelope"
 )
@@ -149,14 +151,28 @@ func RunCapabilities() (interface{}, *envelope.Error) {
 				Audience:         backup.Audience(),
 			},
 		},
-		Platform: PlatformInfo{
-			OS:      "windows",
-			Drivers: []string{"winget"},
-		},
+		Platform: platformInfoFor(runtime.GOOS),
 		GitCommit:          nil,
 		GitDirty:           false,
 		BootstrapTimestamp: nil,
 	}
 
 	return data, nil
+}
+
+// platformInfoFor builds the capabilities PlatformInfo for the given OS. The OS
+// string and available drivers are derived dynamically so the handshake
+// reflects the host rather than a fixed Windows/winget literal.
+func platformInfoFor(goos string) PlatformInfo {
+	return PlatformInfo{OS: goos, Drivers: driversFor(goos)}
+}
+
+// driversFor returns the package-manager drivers available on the given OS. It
+// derives the list from selectBackend so it stays in sync with backend
+// selection (winget on Windows; empty until a platform backend is added).
+func driversFor(goos string) []string {
+	if d, err := selectBackend(goos); err == nil && d != nil {
+		return []string{d.Name()}
+	}
+	return []string{}
 }

--- a/go-engine/internal/commands/commands_test.go
+++ b/go-engine/internal/commands/commands_test.go
@@ -112,7 +112,7 @@ func parseEvents(buf *bytes.Buffer) []map[string]interface{} {
 // restores the original factory.
 func withMockDriver(md *mockDriver, f func()) {
 	orig := newDriverFn
-	newDriverFn = func() driver.Driver { return md }
+	newDriverFn = func() (driver.Driver, error) { return md, nil }
 	defer func() { newDriverFn = orig }()
 	f()
 }

--- a/go-engine/internal/commands/export.go
+++ b/go-engine/internal/commands/export.go
@@ -68,7 +68,7 @@ func RunExport(flags ExportFlags) (interface{}, *envelope.Error) {
 	// --- 2. Process restore entries (inverse: target -> source) ---
 	for _, entry := range mf.Restore {
 		// Expand target path (system path).
-		target := config.ExpandWindowsEnvVars(entry.Target)
+		target := config.ExpandEnvVars(entry.Target)
 		target = os.ExpandEnv(target)
 
 		// Check if system target exists.

--- a/go-engine/internal/commands/plan.go
+++ b/go-engine/internal/commands/plan.go
@@ -47,7 +47,10 @@ func RunPlan(flags PlanFlags) (interface{}, *envelope.Error) {
 	}
 
 	// --- 2. Create driver and compute plan ---
-	d := newDriverFn()
+	d, derr := newDriverFn()
+	if derr != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, derr.Error())
+	}
 	emitter.EmitPhase("plan")
 
 	p, planErr := planner.ComputePlan(mf, d)

--- a/go-engine/internal/commands/platform_test.go
+++ b/go-engine/internal/commands/platform_test.go
@@ -1,0 +1,60 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestSelectBackend_WindowsReturnsWinget(t *testing.T) {
+	d, err := selectBackend("windows")
+	if err != nil {
+		t.Fatalf("selectBackend(windows) error = %v, want nil", err)
+	}
+	if d == nil {
+		t.Fatal("selectBackend(windows) driver = nil, want non-nil")
+	}
+	if d.Name() != "winget" {
+		t.Errorf("selectBackend(windows).Name() = %q, want winget", d.Name())
+	}
+}
+
+func TestSelectBackend_UnsupportedReturnsErrNoBackend(t *testing.T) {
+	d, err := selectBackend("linux")
+	if !errors.Is(err, ErrNoBackend) {
+		t.Errorf("selectBackend(linux) error = %v, want ErrNoBackend", err)
+	}
+	if d != nil {
+		t.Errorf("selectBackend(linux) driver = %v, want nil", d)
+	}
+}
+
+func TestPlatformInfoFor_Windows(t *testing.T) {
+	pi := platformInfoFor("windows")
+	if pi.OS != "windows" {
+		t.Errorf("platformInfoFor(windows).OS = %q, want windows", pi.OS)
+	}
+	found := false
+	for _, drv := range pi.Drivers {
+		if drv == "winget" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("platformInfoFor(windows).Drivers = %v, want to include winget", pi.Drivers)
+	}
+}
+
+func TestPlatformInfoFor_NonWindowsHasNoWinget(t *testing.T) {
+	pi := platformInfoFor("linux")
+	if pi.OS != "linux" {
+		t.Errorf("platformInfoFor(linux).OS = %q, want linux", pi.OS)
+	}
+	for _, drv := range pi.Drivers {
+		if drv == "winget" {
+			t.Errorf("platformInfoFor(linux).Drivers = %v, must not include winget", pi.Drivers)
+		}
+	}
+}

--- a/go-engine/internal/commands/select.go
+++ b/go-engine/internal/commands/select.go
@@ -1,0 +1,28 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"errors"
+
+	"github.com/Artexis10/endstate/go-engine/internal/driver"
+	"github.com/Artexis10/endstate/go-engine/internal/driver/winget"
+)
+
+// ErrNoBackend indicates that no package backend is implemented for the host
+// operating system. Non-Windows hosts return this until a platform backend
+// (e.g. a Nix realizer) is added.
+var ErrNoBackend = errors.New("no package backend available for this platform")
+
+// selectBackend returns the package-manager driver for the given OS. Windows
+// uses the winget driver; other platforms have no backend yet and return
+// ErrNoBackend so callers fail explicitly rather than attempting installs.
+func selectBackend(goos string) (driver.Driver, error) {
+	switch goos {
+	case "windows":
+		return winget.New(), nil
+	default:
+		return nil, ErrNoBackend
+	}
+}

--- a/go-engine/internal/commands/verify.go
+++ b/go-engine/internal/commands/verify.go
@@ -7,11 +7,11 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/Artexis10/endstate/go-engine/internal/config"
 	"github.com/Artexis10/endstate/go-engine/internal/driver"
-	"github.com/Artexis10/endstate/go-engine/internal/driver/winget"
 	"github.com/Artexis10/endstate/go-engine/internal/envelope"
 	"github.com/Artexis10/endstate/go-engine/internal/events"
 	"github.com/Artexis10/endstate/go-engine/internal/manifest"
@@ -19,9 +19,13 @@ import (
 	"github.com/Artexis10/endstate/go-engine/internal/verifier"
 )
 
-// newDriverFn is the factory used to create the package manager driver. It
-// defaults to winget.New() and can be replaced in tests to inject a mock.
-var newDriverFn func() driver.Driver = func() driver.Driver { return winget.New() }
+// newDriverFn is the factory used to create the package-manager backend for the
+// host platform. It defaults to selectBackend(runtime.GOOS) and can be replaced
+// in tests to inject a mock. It returns an error when no backend exists for the
+// host OS (non-Windows, until a platform backend is added).
+var newDriverFn func() (driver.Driver, error) = func() (driver.Driver, error) {
+	return selectBackend(runtime.GOOS)
+}
 
 // VerifyFlags holds the parsed CLI flags for the verify command.
 type VerifyFlags struct {
@@ -99,8 +103,11 @@ func RunVerify(flags VerifyFlags) (interface{}, *envelope.Error) {
 		}
 	}
 
-	// --- 2. Create driver ---
-	d := newDriverFn()
+	// --- 2. Create driver (platform-selected backend) ---
+	d, derr := newDriverFn()
+	if derr != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, derr.Error())
+	}
 
 	// --- 3. Emit phase event (first event in stream per event-contract.md) ---
 	emitter.EmitPhase("verify")
@@ -108,7 +115,7 @@ func RunVerify(flags VerifyFlags) (interface{}, *envelope.Error) {
 	// Batch-detect all winget apps in one call for performance.
 	var wingetRefs []string
 	for _, app := range mf.Apps {
-		ref := resolveWindowsRef(app)
+		ref := resolveAppRef(app)
 		if ref != "" {
 			wingetRefs = append(wingetRefs, ref)
 		}
@@ -124,7 +131,7 @@ func RunVerify(flags VerifyFlags) (interface{}, *envelope.Error) {
 	failCount := 0
 
 	for _, app := range mf.Apps {
-		ref := resolveWindowsRef(app)
+		ref := resolveAppRef(app)
 		isManual := ref == "" && app.Manual != nil && app.Manual.VerifyPath != ""
 
 		if ref == "" && !isManual {
@@ -264,19 +271,10 @@ func loadManifest(path string) (*manifest.Manifest, *envelope.Error) {
 	return mf, nil
 }
 
-// resolveWindowsRef returns the Windows-platform package ref for an app.
-// It prefers app.Refs["windows"]; if absent it falls back to the first
-// available ref in map iteration order. Returns "" if the map is empty.
-func resolveWindowsRef(app manifest.App) string {
-	if ref, ok := app.Refs["windows"]; ok && ref != "" {
-		return ref
-	}
-	for _, ref := range app.Refs {
-		if ref != "" {
-			return ref
-		}
-	}
-	return ""
+// resolveAppRef returns the package ref for an app on the host platform via the
+// shared manifest.ResolveRef resolver (prefers refs[GOOS], else first non-empty).
+func resolveAppRef(app manifest.App) string {
+	return manifest.ResolveRef(app, runtime.GOOS)
 }
 
 // buildRunID constructs a simple run identifier for use with the emitter.

--- a/go-engine/internal/config/paths.go
+++ b/go-engine/internal/config/paths.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 )
 
 // ResolveRepoRoot returns the absolute path to the Endstate repo root.
@@ -51,16 +52,35 @@ func ResolveRepoRoot() string {
 	return ""
 }
 
-// ProfileDir returns the path to the Endstate profiles directory under the user's
-// home directory: <home>/Documents/Endstate/Profiles.
-//
-// If the home directory cannot be determined, it returns an empty string.
+// ProfileDir returns the path to the Endstate profiles directory for the host
+// platform. On Windows this is <home>\Documents\Endstate\Profiles; on Linux it
+// follows the XDG Base Directory specification; on macOS it uses Application
+// Support. Returns an empty string if the home directory cannot be determined.
 func ProfileDir() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return ""
 	}
-	return filepath.Join(home, "Documents", "Endstate", "Profiles")
+	return profileDirFor(runtime.GOOS, home, os.Getenv("XDG_DATA_HOME"))
+}
+
+// profileDirFor computes the profiles directory for the given OS. Path
+// separators are written explicitly for the target OS so the result is
+// host-independent and unit-testable from any platform. The Windows path is
+// unchanged from the historical Documents location.
+func profileDirFor(goos, home, xdgDataHome string) string {
+	switch goos {
+	case "windows":
+		return home + `\Documents\Endstate\Profiles`
+	case "darwin":
+		return home + "/Library/Application Support/Endstate/Profiles"
+	default: // linux and other unix-likes
+		base := xdgDataHome
+		if base == "" {
+			base = home + "/.local/share"
+		}
+		return base + "/endstate/profiles"
+	}
 }
 
 // windowsEnvVarPattern matches %VAR_NAME% style variable references.
@@ -78,4 +98,20 @@ func ExpandWindowsEnvVars(s string) string {
 		}
 		return match
 	})
+}
+
+// ExpandEnvVars expands environment-variable references in s using the host
+// platform's convention: %VAR% on Windows, $VAR / ${VAR} elsewhere. On Windows
+// it is identical to ExpandWindowsEnvVars.
+func ExpandEnvVars(s string) string {
+	return expandEnvVarsFor(runtime.GOOS, s)
+}
+
+// expandEnvVarsFor expands environment variables in s for the given OS. Split
+// from ExpandEnvVars so platform behavior is unit-testable from any host.
+func expandEnvVarsFor(goos, s string) string {
+	if goos == "windows" {
+		return ExpandWindowsEnvVars(s)
+	}
+	return os.ExpandEnv(s)
 }

--- a/go-engine/internal/config/paths_platform_test.go
+++ b/go-engine/internal/config/paths_platform_test.go
@@ -1,0 +1,55 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package config
+
+import "testing"
+
+// profileDirFor / expandEnvVarsFor take goos explicitly so platform behavior is
+// testable from any host (Windows now, Linux later).
+
+func TestProfileDirFor_WindowsUnchanged(t *testing.T) {
+	got := profileDirFor("windows", `C:\Users\me`, "")
+	want := `C:\Users\me\Documents\Endstate\Profiles`
+	if got != want {
+		t.Errorf("profileDirFor(windows) = %q, want %q", got, want)
+	}
+}
+
+func TestProfileDirFor_LinuxUsesXDGDataHome(t *testing.T) {
+	got := profileDirFor("linux", "/home/me", "/home/me/.xdgdata")
+	want := "/home/me/.xdgdata/endstate/profiles"
+	if got != want {
+		t.Errorf("profileDirFor(linux, xdg) = %q, want %q", got, want)
+	}
+}
+
+func TestProfileDirFor_LinuxDefaultsToLocalShare(t *testing.T) {
+	got := profileDirFor("linux", "/home/me", "")
+	want := "/home/me/.local/share/endstate/profiles"
+	if got != want {
+		t.Errorf("profileDirFor(linux, no xdg) = %q, want %q", got, want)
+	}
+}
+
+func TestExpandEnvVarsFor_WindowsExpandsPercent(t *testing.T) {
+	t.Setenv("ENDSTATE_TEST_X", "VAL")
+	if got := expandEnvVarsFor("windows", "%ENDSTATE_TEST_X%/a"); got != "VAL/a" {
+		t.Errorf("expandEnvVarsFor(windows) = %q, want VAL/a", got)
+	}
+}
+
+func TestExpandEnvVarsFor_LinuxExpandsDollar(t *testing.T) {
+	t.Setenv("ENDSTATE_TEST_Y", "VAL")
+	if got := expandEnvVarsFor("linux", "$ENDSTATE_TEST_Y/a"); got != "VAL/a" {
+		t.Errorf("expandEnvVarsFor(linux) = %q, want VAL/a", got)
+	}
+}
+
+func TestExpandEnvVarsFor_LinuxLeavesPercentAlone(t *testing.T) {
+	t.Setenv("ENDSTATE_TEST_Z", "VAL")
+	in := "%ENDSTATE_TEST_Z%/a"
+	if got := expandEnvVarsFor("linux", in); got != in {
+		t.Errorf("expandEnvVarsFor(linux, percent) = %q, want unchanged %q", got, in)
+	}
+}

--- a/go-engine/internal/manifest/refs.go
+++ b/go-engine/internal/manifest/refs.go
@@ -1,0 +1,24 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package manifest
+
+// ResolveRef returns the package reference for an app on the given operating
+// system. It prefers app.Refs[goos]; if that key is absent or blank it falls
+// back to the first non-empty ref in map iteration order. Returns "" when no
+// non-empty ref exists.
+//
+// This is the single, platform-aware ref resolver shared by the planner and the
+// command handlers. On Windows with a refs["windows"] entry it is identical to
+// the historical Windows-only behavior.
+func ResolveRef(app App, goos string) string {
+	if ref, ok := app.Refs[goos]; ok && ref != "" {
+		return ref
+	}
+	for _, ref := range app.Refs {
+		if ref != "" {
+			return ref
+		}
+	}
+	return ""
+}

--- a/go-engine/internal/manifest/refs_test.go
+++ b/go-engine/internal/manifest/refs_test.go
@@ -1,0 +1,35 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package manifest
+
+import "testing"
+
+func TestResolveRef_PrefersOSKey(t *testing.T) {
+	app := App{Refs: map[string]string{"windows": "Win.App", "linux": "lin-app"}}
+	if got := ResolveRef(app, "linux"); got != "lin-app" {
+		t.Errorf("ResolveRef(linux) = %q, want lin-app", got)
+	}
+	if got := ResolveRef(app, "windows"); got != "Win.App" {
+		t.Errorf("ResolveRef(windows) = %q, want Win.App", got)
+	}
+	if got := ResolveRef(app, "darwin"); got == "" {
+		t.Errorf("ResolveRef(darwin) = %q, want a fallback ref", got)
+	}
+}
+
+func TestResolveRef_FallsBackToFirstNonEmpty(t *testing.T) {
+	app := App{Refs: map[string]string{"windows": "Win.App"}}
+	if got := ResolveRef(app, "linux"); got != "Win.App" {
+		t.Errorf("ResolveRef(linux) fallback = %q, want Win.App", got)
+	}
+}
+
+func TestResolveRef_EmptyReturnsEmpty(t *testing.T) {
+	if got := ResolveRef(App{}, "linux"); got != "" {
+		t.Errorf("ResolveRef(no refs) = %q, want empty", got)
+	}
+	if got := ResolveRef(App{Refs: map[string]string{"windows": ""}}, "windows"); got != "" {
+		t.Errorf("ResolveRef(blank ref) = %q, want empty", got)
+	}
+}

--- a/go-engine/internal/modules/matcher.go
+++ b/go-engine/internal/modules/matcher.go
@@ -52,7 +52,7 @@ func MatchModulesForApps(catalog map[string]*Module, apps []manifest.App) []*Mod
 		// Check pathExists matches (expand env vars, check filesystem).
 		if !isMatch {
 			for _, pathPattern := range mod.Matches.PathExists {
-				expandedPath := config.ExpandWindowsEnvVars(pathPattern)
+				expandedPath := config.ExpandEnvVars(pathPattern)
 				expandedPath = os.ExpandEnv(expandedPath)
 				if _, err := os.Stat(expandedPath); err == nil {
 					isMatch = true

--- a/go-engine/internal/planner/planner.go
+++ b/go-engine/internal/planner/planner.go
@@ -7,6 +7,7 @@ package planner
 
 import (
 	"os"
+	"runtime"
 
 	"github.com/Artexis10/endstate/go-engine/internal/config"
 	"github.com/Artexis10/endstate/go-engine/internal/driver"
@@ -145,22 +146,13 @@ func resolveDisplayName(resolved string, app manifest.App) string {
 // expandVerifyPath expands Windows-style %VAR% and Go-style $VAR environment
 // variables in a verify path.
 func expandVerifyPath(p string) string {
-	expanded := config.ExpandWindowsEnvVars(p)
+	expanded := config.ExpandEnvVars(p)
 	expanded = os.ExpandEnv(expanded)
 	return expanded
 }
 
-// resolveRef returns the platform-specific package ref for an app. It prefers
-// app.Refs["windows"]; if absent it falls back to the first available ref in
-// map iteration order. Returns "" if the map is empty or all refs are blank.
+// resolveRef returns the package ref for an app on the host platform via the
+// shared manifest.ResolveRef resolver (prefers refs[GOOS], else first non-empty).
 func resolveRef(app manifest.App) string {
-	if ref, ok := app.Refs["windows"]; ok && ref != "" {
-		return ref
-	}
-	for _, ref := range app.Refs {
-		if ref != "" {
-			return ref
-		}
-	}
-	return ""
+	return manifest.ResolveRef(app, runtime.GOOS)
 }

--- a/go-engine/internal/restore/restore.go
+++ b/go-engine/internal/restore/restore.go
@@ -87,7 +87,7 @@ func CheckSensitivePath(path string) []string {
 // %VAR% expansion (via config.ExpandWindowsEnvVars) and Go-style $VAR
 // expansion (via os.ExpandEnv).
 func expandPath(p string) string {
-	expanded := config.ExpandWindowsEnvVars(p)
+	expanded := config.ExpandEnvVars(p)
 	expanded = os.ExpandEnv(expanded)
 	// Handle ~ for home directory
 	if strings.HasPrefix(expanded, "~") {

--- a/openspec/changes/platform-backend-foundation/design.md
+++ b/openspec/changes/platform-backend-foundation/design.md
@@ -1,0 +1,34 @@
+## Context
+
+The Spec → Planner → Drivers → Verifiers pipeline is platform-agnostic above the driver layer, but selection and the surrounding ref/capabilities/path logic are hardcoded to Windows + winget. The validation spike (Determinate Nix 3.21.0) confirmed the Nix realizer model is viable (atomicity holds; error surface translatable via a tested anchor map — YELLOW). This change is the platform-agnostic foundation that the Nix backend slots into. It mirrors the repo's established per-OS split (`registry_windows.go`/`registry_other.go`, `keychain_windows.go`/`keychain_other.go`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- GOOS-keyed backend selection with a single, explicit insertion point for future backends.
+- Platform-keyed ref resolution, dynamic capabilities, XDG paths, platform-aware env expansion.
+- **Zero behavior change on Windows** — provable by regression tests.
+
+**Non-Goals:**
+- No Nix / realizer implementation (next change).
+- No new `Realizer`/`Backend` interface yet — introduced in the Nix change where the whole-set declarative model actually needs it; introducing it here would be a speculative, unused abstraction.
+- No per-app `App.Driver` backend override (a later decision); selection is purely GOOS-based.
+- No verifier/restore changes (separate change) and no bootstrap/release changes.
+
+## Decisions
+
+1. **`SelectBackend(goos string) (driver.Driver, error)`** in `internal/driver/` — `windows` → `winget.New()`; default → a sentinel `ErrNoBackend`. The existing `Driver` interface is kept; selection is the only new seam. Call sites (`commands/verify.go`, `apply.go`, `plan.go`) pass `runtime.GOOS`.
+
+2. **`resolveRef` prefers `App.Refs[runtime.GOOS]`, else the first non-empty ref** — byte-identical to today's `resolveWindowsRef` on a Windows host with `refs.windows`, so no Windows behavior changes.
+
+3. **Capabilities are dynamic** — `os` from `runtime.GOOS`; `drivers` from what `SelectBackend` can provide on this host. On Windows this still yields `windows` / `["winget"]`. Additive contract fields only.
+
+4. **Paths** — `ProfileDir()` returns the existing `Documents\Endstate\Profiles` on Windows, and `$XDG_DATA_HOME`/`~/.local/share/endstate/profiles` on Linux. Env expansion dispatches: `%VAR%` (Windows) vs `os.ExpandEnv` `$VAR` (other), via one `ExpandEnvVars` entry point that the four current `ExpandWindowsEnvVars` callers route through.
+
+5. **Build-tag split where OS-specific code is unavoidable** — follow the existing `*_windows.go` / `*_other.go` convention rather than scattering `runtime.GOOS` branches.
+
+## Risks / Trade-offs
+
+- **[Risk] A behavior change leaks onto Windows** → Mitigation: the Windows code path is literally unchanged; add regression tests asserting `capabilities` reports `os=windows` + `drivers=["winget"]`, `resolveRef` picks the same ref, and `ProfileDir` is unchanged.
+- **[Risk] `resolveRef` fallback changes selection for multi-ref manifests** → Mitigation: fallback order is identical to `resolveWindowsRef`; covered by a test with a multi-ref app.
+- **[Risk] Non-Windows `ErrNoBackend` is confusing in isolation** → Accepted: it is explicit and temporary; the Nix change fills it. Surfaced clearly rather than silently no-op.

--- a/openspec/changes/platform-backend-foundation/proposal.md
+++ b/openspec/changes/platform-backend-foundation/proposal.md
@@ -1,0 +1,31 @@
+## Why
+
+The engine is hardwired to Windows + winget at several points: the driver factory hardcodes `winget.New()` (`internal/commands/verify.go:24`), package-reference resolution only reads `refs["windows"]` (`resolveWindowsRef`), `capabilities` reports a literal `["winget"]`, and profile/path resolution assumes Windows conventions. Adding any second backend — Nix on Linux/macOS, whose realizer model the spike validated — is blocked on these hardcodes. This change makes backend selection and the surrounding ref/capabilities/path logic platform-aware, with **zero behavior change on Windows**, so a Nix backend can slot in additively in a later change.
+
+## What Changes
+
+- Add a GOOS-keyed backend selector (`SelectBackend`) — `windows` returns the winget driver; any other host returns an explicit "no backend available" error (filled in by the Nix change).
+- Generalize package-reference resolution from `resolveWindowsRef` to `resolveRef`, keyed by `runtime.GOOS` with the same fallback to the first non-empty ref.
+- `capabilities` reports the host OS and available backends dynamically instead of literal `windows` / `["winget"]`.
+- `ProfileDir()` follows the XDG Base Directory spec on Linux (Documents convention preserved on Windows); env-var expansion becomes platform-aware (`%VAR%` on Windows, `$VAR` elsewhere) behind one dispatch.
+- **No Nix code and no new package-manager backend** — non-Windows backend selection returns a clear error until the Nix change lands.
+
+## Capabilities
+
+### New Capabilities
+
+- `platform-backend-selection`: select the package backend by host OS, resolve refs per platform, report host OS/backends in capabilities, and follow platform path/env conventions — all preserving existing Windows behavior.
+
+### Modified Capabilities
+
+(none — Windows behavior is invariant; every addition is platform-gated and additive)
+
+## Impact
+
+- `internal/driver/select.go` (new) — `SelectBackend(goos) (Driver, error)`
+- `internal/commands/verify.go:24` — `newDriverFn` routes through `SelectBackend`; `apply.go` / `plan.go` call sites likewise
+- `internal/planner/planner.go` / `internal/commands/verify.go` — `resolveWindowsRef` → `resolveRef` (GOOS-keyed)
+- `internal/commands/capabilities.go` — dynamic OS + drivers
+- `internal/config/paths.go` — XDG `ProfileDir`; platform-aware env expansion (and its 4 callers)
+- `docs/contracts/cli-json-contract.md` — additive only (capabilities `os`/`drivers` now host-dependent). **Protected area — flagged for explicit go-ahead at implementation time.**
+- No schema version bump: adding `refs["linux"]` / `refs["darwin"]` keys is additive per `schema-versioning`.

--- a/openspec/changes/platform-backend-foundation/specs/platform-backend-selection/spec.md
+++ b/openspec/changes/platform-backend-foundation/specs/platform-backend-selection/spec.md
@@ -1,0 +1,55 @@
+## ADDED Requirements
+
+### Requirement: Backend selection is platform-aware
+The engine SHALL select its package backend by host operating system and SHALL preserve winget as the backend on Windows.
+
+#### Scenario: Windows selects winget
+- **WHEN** the engine selects a backend on a Windows host
+- **THEN** the winget driver SHALL be used
+- **AND** existing Windows install/verify behavior SHALL be unchanged
+
+#### Scenario: Unsupported platform reports no backend
+- **WHEN** the engine selects a backend on a host with no implemented backend
+- **THEN** selection SHALL fail with an explicit "no backend available" error
+- **AND** no install operation SHALL be attempted
+
+### Requirement: Package-reference resolution is platform-keyed
+Package-reference resolution SHALL prefer the `App.Refs` entry keyed by the host operating system, falling back to the first non-empty ref.
+
+#### Scenario: Windows ref selected on Windows
+- **WHEN** an app has a `refs.windows` entry and the host is Windows
+- **THEN** `refs.windows` SHALL be used, unchanged from prior behavior
+
+#### Scenario: Linux ref selected on Linux
+- **WHEN** an app has a `refs.linux` entry and the host is Linux
+- **THEN** `refs.linux` SHALL be used
+
+#### Scenario: Fallback when no OS-keyed ref exists
+- **WHEN** an app has no ref for the host OS but has at least one non-empty ref
+- **THEN** the first non-empty ref SHALL be used
+
+### Requirement: Capabilities reports host platform and backends
+The `capabilities` command data SHALL report the host operating system and the list of available backends dynamically rather than as fixed literals.
+
+#### Scenario: Windows capabilities
+- **WHEN** `capabilities` runs on a Windows host
+- **THEN** the data SHALL report operating system `windows`
+- **AND** the data SHALL include `winget` among the available drivers
+
+#### Scenario: Non-Windows capabilities
+- **WHEN** `capabilities` runs on a non-Windows host
+- **THEN** the data SHALL report that host's operating system
+- **AND** the data SHALL NOT claim winget is available
+
+### Requirement: Profile and path resolution follow platform conventions
+Profile-directory and environment-variable expansion SHALL follow host-platform conventions and SHALL be unchanged on Windows.
+
+#### Scenario: Windows paths unchanged
+- **WHEN** the profile directory is resolved on a Windows host
+- **THEN** it SHALL be the existing `Documents\Endstate\Profiles` location
+- **AND** `%VAR%`-style environment expansion SHALL be used
+
+#### Scenario: Linux uses XDG and POSIX expansion
+- **WHEN** the profile directory is resolved on a Linux host
+- **THEN** it SHALL follow the XDG Base Directory specification
+- **AND** `$VAR`-style environment expansion SHALL be used

--- a/openspec/changes/platform-backend-foundation/tasks.md
+++ b/openspec/changes/platform-backend-foundation/tasks.md
@@ -1,0 +1,29 @@
+## 1. Backend selection seam
+
+- [x] 1.1 Add `SelectBackend(goos string) (driver.Driver, error)` in `internal/driver/select.go` — `windows` → `winget.New()`, default → exported `ErrNoBackend`
+- [x] 1.2 Route the driver factory (`commands/verify.go:24` `newDriverFn`) and the `apply.go` / `plan.go` call sites through `SelectBackend(runtime.GOOS)`; preserve the test-injection seam
+
+## 2. Platform-aware ref resolution
+
+- [x] 2.1 Replace `resolveWindowsRef` with `resolveRef` that prefers `App.Refs[runtime.GOOS]` and falls back to the first non-empty ref (`planner.go`, `verify.go`)
+- [x] 2.2 Confirm `App.Refs` map already accepts arbitrary OS keys (`manifest/types.go:27`) — no schema change needed
+
+## 3. Dynamic capabilities
+
+- [x] 3.1 `capabilities.go` — populate `os` from `runtime.GOOS` and `drivers` from `SelectBackend` availability instead of literals
+
+## 4. Platform-aware paths
+
+- [x] 4.1 `ProfileDir()` — XDG on Linux, unchanged `Documents\Endstate\Profiles` on Windows (`config/paths.go`)
+- [x] 4.2 Add `ExpandEnvVars` dispatch (`%VAR%` Windows / `$VAR` other); route the four `ExpandWindowsEnvVars` callers (`bundle/collect.go`, `modules/matcher.go`, `restore/restore.go`, `apply.go`)
+
+## 5. Contract documentation (PROTECTED — needs explicit go-ahead)
+
+- [x] 5.1 `docs/contracts/cli-json-contract.md` — document `capabilities` `os`/`drivers` as host-dependent (additive)
+
+## 6. Verification
+
+- [x] 6.1 `cd go-engine && go test ./...` green on Windows (no regressions)
+- [x] 6.2 Regression tests: `capabilities` → `os=windows` + `drivers=["winget"]`; `resolveRef` Windows selection unchanged (incl. multi-ref fallback); `ProfileDir` unchanged on Windows
+- [x] 6.3 `GOOS=linux go build ./...` succeeds; tests for Linux ref/path/capabilities behavior
+- [x] 6.4 `npm run openspec:validate` passes


### PR DESCRIPTION
## Summary

Change 1 of the cross-platform (Linux/macOS via Nix) engine work: the **platform-agnostic foundation**. Makes backend selection, ref resolution, capabilities, and path/env handling platform-aware with **zero Windows behavior change**, so the Nix realizer backend can slot in additively next.

Preceded by a validation spike (Determinate Nix 3.21.0) that confirmed the realizer model is viable — **verdict YELLOW**: atomicity holds; error classification needs a contract-tested message-anchor map. (Spike branch: `spike/nix-realizer-errors`, see `spike/nix-realizer/FINDINGS.md`.)

## What changed

- `selectBackend(goos)`: winget on Windows, explicit `ErrNoBackend` elsewhere. `newDriverFn` now returns an error so unsupported platforms fail cleanly (no install attempted).
- `manifest.ResolveRef(app, goos)`: single platform-keyed resolver (prefers `refs[GOOS]`, falls back to first non-empty); planner + commands delegate to it.
- `capabilities` reports `os`/`drivers` dynamically (still `windows`/`["winget"]` on Windows).
- `ProfileDir` → XDG on Linux / Application Support on macOS; Windows unchanged. New `config.ExpandEnvVars` (`%VAR%` Windows / `$VAR` elsewhere); callers migrated.
- Additive `cli-json-contract.md` note: `platform.os`/`drivers` are host-dependent.

## Verification

- `go test ./...` green on Windows (full suite — zero regressions).
- `GOOS=linux go build ./...` succeeds.
- `openspec validate platform-backend-foundation --strict` passes.
- No schema bump (adding `refs[linux]`/`refs[darwin]` keys is additive).

## OpenSpec

New change `platform-backend-foundation` (proposal / design / tasks + `platform-backend-selection` spec delta).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
