### PR TITLE
feat(backup): cross-process refresh-token rotation lock (F5)

### DIFF
--- a/go-engine/go.mod
+++ b/go-engine/go.mod
@@ -9,3 +9,5 @@ require (
 	golang.org/x/crypto v0.32.0
 	golang.org/x/sys v0.29.0
 )
+
+require github.com/gofrs/flock v0.11.0 // indirect

--- a/go-engine/go.sum
+++ b/go-engine/go.sum
@@ -2,6 +2,8 @@ github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMF
 github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/gofrs/flock v0.11.0 h1:AGFQxrpWd8ezw60AvLWIPbxMydNfF8564pwH3FCty0g=
+github.com/gofrs/flock v0.11.0/go.mod h1:FirDy1Ing0mI2+kB6wk+vyyAH+e6xiE+EYA0jnzV9jc=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
 github.com/golang-jwt/jwt/v5 v5.3.1/go.mod h1:fxCRLWMO43lRc8nhHWY6LGqRcf+1gQWArsqaEUEa5bE=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -21,6 +23,8 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
+golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
+golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go-engine/internal/backup/auth/authenticator.go
+++ b/go-engine/internal/backup/auth/authenticator.go
@@ -9,9 +9,12 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/gofrs/flock"
 	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/Artexis10/endstate/go-engine/internal/backup/client"
@@ -28,10 +31,11 @@ var stdBase64 = stdBase64Pkg.StdEncoding
 // the SessionStore (for in-memory + keychain persistence), and the
 // crypto package (for KDF / DEK wrap, currently STUBS).
 type Authenticator struct {
-	issuer  Issuer
-	oidc    *oidc.Client
-	httpc   *client.Client
-	session *SessionStore
+	issuer       Issuer
+	oidc         *oidc.Client
+	httpc        *client.Client
+	session      *SessionStore
+	refreshLock  string // absolute path to the cross-process refresh lock file (F5)
 }
 
 // NewAuthenticator constructs an Authenticator. The supplied client.Client
@@ -39,10 +43,53 @@ type Authenticator struct {
 // auth.MakeTokenProvider helper.
 func NewAuthenticator(issuer Issuer, o *oidc.Client, c *client.Client, s *SessionStore) *Authenticator {
 	a := &Authenticator{issuer: issuer, oidc: o, httpc: c, session: s}
+	a.refreshLock = defaultRefreshLockPath()
 	// Wire the refresh callback so the HTTP client's 401-refresh hook
 	// reaches into our /api/auth/refresh handler instead of looping.
 	s.WithRefreshFn(a.refreshAccessToken)
 	return a
+}
+
+// WithRefreshLockDir overrides the directory used for the cross-process
+// refresh lock file (F5). The lock file is created at `<dir>/refresh.lock`.
+// Primarily a test seam — production callers should leave this at the
+// default (per-user config dir) so all subprocesses for the same user
+// converge on the same lock. Returns the receiver for chaining.
+func (a *Authenticator) WithRefreshLockDir(dir string) *Authenticator {
+	if dir == "" {
+		return a
+	}
+	a.refreshLock = filepath.Join(dir, "refresh.lock")
+	return a
+}
+
+// refreshLockPath returns the absolute path to the cross-process refresh
+// lock file. Falls back to a process-scoped temp path if construction
+// fails (which degrades to per-process serialization — strictly worse
+// than cross-process but still safe).
+func (a *Authenticator) refreshLockPath() string {
+	if a.refreshLock != "" {
+		return a.refreshLock
+	}
+	return defaultRefreshLockPath()
+}
+
+// defaultRefreshLockPath returns the absolute path to the canonical
+// refresh lock file under the per-user OS config dir
+// (`%APPDATA%/Endstate/refresh.lock` on Windows, `~/.config/endstate/refresh.lock`
+// on Unix). Ensures the parent directory exists. Falls back to the OS
+// temp dir on environments where UserConfigDir fails (CI sandboxes, etc).
+func defaultRefreshLockPath() string {
+	base, err := os.UserConfigDir()
+	if err != nil || base == "" {
+		base = os.TempDir()
+	}
+	dir := filepath.Join(base, "Endstate")
+	// Best-effort: if MkdirAll fails the flock TryLock below will surface
+	// the underlying error and the caller treats it as a transient
+	// refresh failure (the existing 401-refresh path retries on next call).
+	_ = os.MkdirAll(dir, 0o700)
+	return filepath.Join(dir, "refresh.lock")
 }
 
 // Issuer returns the configured issuer.
@@ -152,12 +199,65 @@ func (a *Authenticator) CompleteLogin(ctx context.Context, email string, serverP
 
 // refreshAccessToken implements the client.TokenProvider refresh hook.
 // Returns the new access token on success.
+//
+// F5: serialized cross-process via a file lock at refreshLockPath().
+// Sliding-window refresh-token rotation (contract §5.3) means two
+// concurrent processes that read the same persisted RT and both POST it
+// will race — substrate burns the RT after the first call and the
+// second persists a now-stale RT to the keychain, surfacing as
+// AUTH_REQUIRED on the next subprocess. The lock collapses the
+// read-rotate-persist window into a single critical section across
+// every process for the user.
+//
+// After acquiring the lock, we re-read the session snapshot: another
+// process may have completed a refresh while we were waiting, in which
+// case the in-memory access token is now fresh and we return it
+// without hitting substrate. This is the optimisation that keeps a
+// burst of N concurrent subprocesses to 1 substrate round-trip rather
+// than N serial ones.
 func (a *Authenticator) refreshAccessToken(ctx context.Context) (string, error) {
 	doc, err := a.oidc.Discovery(ctx)
 	if err != nil {
 		return "", err
 	}
+
+	// Acquire the cross-process refresh lock before reading the RT. The
+	// 50ms poll is generous enough not to thrash; the wait is bounded by
+	// ctx so cancellation propagates.
+	lock := flock.New(a.refreshLockPath())
+	locked, lerr := lock.TryLockContext(ctx, 50*time.Millisecond)
+	if lerr != nil {
+		return "", fmt.Errorf("auth: refresh: acquire lock %q: %w", a.refreshLockPath(), lerr)
+	}
+	if !locked {
+		// ctx expired before we could acquire — propagate as a transient
+		// error. The 401-refresh hook surfaces this to the user as a
+		// retryable failure rather than burning the cached RT.
+		if cerr := ctx.Err(); cerr != nil {
+			return "", fmt.Errorf("auth: refresh: %w", cerr)
+		}
+		return "", errors.New("auth: refresh: could not acquire refresh lock")
+	}
+	defer func() { _ = lock.Unlock() }()
+
+	// Re-hydrate from the keychain so a sibling process's rotated RT
+	// becomes visible to this process. Without this, the in-memory snapshot
+	// here is the pre-wait copy and we'd POST a now-stale RT, defeating the
+	// lock entirely. Best-effort: a hydrate failure (e.g. fresh test
+	// keychain with no pointer) falls through to the original snapshot.
+	if uid := a.session.Snapshot().UserID; uid != "" {
+		_ = a.session.Hydrate(uid)
+	}
 	snap := a.session.Snapshot()
+
+	// Second-waiter optimisation: if a sibling process already rotated
+	// the access token while we were waiting, the AccessToken() check
+	// will see a still-valid cached token and short-circuit. This drops
+	// N-way concurrent refreshes to a single substrate round-trip.
+	if cached, _ := a.session.AccessToken(ctx); cached != "" {
+		return cached, nil
+	}
+
 	if snap.RefreshToken == "" {
 		return "", errors.New("auth: no refresh token in session")
 	}

--- a/go-engine/internal/backup/auth/authenticator_test.go
+++ b/go-engine/internal/backup/auth/authenticator_test.go
@@ -11,10 +11,13 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
+	"sync"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/gofrs/flock"
 	"github.com/golang-jwt/jwt/v5"
 
 	"github.com/Artexis10/endstate/go-engine/internal/backup/auth"
@@ -148,6 +151,11 @@ func (fb *fakeBackend) URL() string { return fb.srv.URL }
 // newAuthForTest wires a fresh Authenticator + memory keychain bound to
 // the supplied fakeBackend. Returns the authenticator and the underlying
 // keychain so the caller can assert keychain state.
+//
+// The refresh lock (F5) is pointed at t.TempDir() so each test gets an
+// isolated lock file — without this two parallel tests would serialize
+// through the real `%APPDATA%/Endstate/refresh.lock` and the second
+// test would block on the first.
 func newAuthForTest(t *testing.T, fb *fakeBackend) (*auth.Authenticator, keychain.Keychain) {
 	t.Helper()
 	kc := keychain.NewMemory()
@@ -158,7 +166,8 @@ func newAuthForTest(t *testing.T, fb *fakeBackend) (*auth.Authenticator, keychai
 		Tokens: store,
 		Retry:  &rp,
 	})
-	a := auth.NewAuthenticator(auth.IssuerFromOIDC(oc, "endstate-backup"), oc, hc, store)
+	a := auth.NewAuthenticator(auth.IssuerFromOIDC(oc, "endstate-backup"), oc, hc, store).
+		WithRefreshLockDir(t.TempDir())
 	return a, kc
 }
 
@@ -476,7 +485,8 @@ func TestAuthenticator_Refresh_NotCalledWhenCachedAccessTokenIsValid(t *testing.
 	oc := oidc.NewClient(fb.URL(), fb.srv.Client())
 	rp := client.RetryPolicy{MaxRetries: 0, InitialWait: time.Millisecond, Multiplier: 1, MaxWait: time.Millisecond}
 	hc := client.New(client.Options{Tokens: storeB, Retry: &rp})
-	a2 := auth.NewAuthenticator(auth.IssuerFromOIDC(oc, "endstate-backup"), oc, hc, storeB)
+	a2 := auth.NewAuthenticator(auth.IssuerFromOIDC(oc, "endstate-backup"), oc, hc, storeB).
+		WithRefreshLockDir(t.TempDir())
 	if err := storeB.HydrateFromCurrent(); err != nil {
 		t.Fatalf("HydrateFromCurrent: %v", err)
 	}
@@ -529,6 +539,268 @@ func TestAuthenticator_Me_ReturnsAccountInfo(t *testing.T) {
 	}
 	if me.SubscriptionStatus != "active" {
 		t.Errorf("subscription = %q", me.SubscriptionStatus)
+	}
+}
+
+// newAuthOnSharedKeychain builds a second Authenticator backed by the
+// supplied keychain (simulating a second process) and points its refresh
+// lock at the same directory as the first. Together with newAuthForTest
+// these compose the "two processes, one user" topology that the F5 lock
+// guards.
+func newAuthOnSharedKeychain(t *testing.T, fb *fakeBackend, kc keychain.Keychain, lockDir string) *auth.Authenticator {
+	t.Helper()
+	storeB := auth.NewSessionStore(kc)
+	oc := oidc.NewClient(fb.URL(), fb.srv.Client())
+	rp := client.RetryPolicy{MaxRetries: 0, InitialWait: time.Millisecond, Multiplier: 1, MaxWait: time.Millisecond}
+	hc := client.New(client.Options{Tokens: storeB, Retry: &rp})
+	a := auth.NewAuthenticator(auth.IssuerFromOIDC(oc, "endstate-backup"), oc, hc, storeB).
+		WithRefreshLockDir(lockDir)
+	// Hydrate so the new "process" sees the persisted RT.
+	if err := storeB.HydrateFromCurrent(); err != nil {
+		t.Fatalf("HydrateFromCurrent: %v", err)
+	}
+	return a
+}
+
+// TestAuthenticator_RefreshLock_SerializesConcurrentRotations is the
+// F5 root assertion: two processes that both think it's time to refresh
+// must converge on a single substrate round-trip, not race each other.
+// Without the lock both POST the same RT, substrate burns it after the
+// first call, the second persists a now-stale RT to the keychain, and
+// the next subprocess surfaces AUTH_REQUIRED.
+//
+// Topology: two Authenticator instances backed by the same keychain
+// (simulating two processes), pointing at the same refresh lock file
+// (simulating shared per-user state on disk). Both goroutines call
+// RefreshAccessToken concurrently against a mock substrate that
+// counts hits.
+func TestAuthenticator_RefreshLock_SerializesConcurrentRotations(t *testing.T) {
+	fb := newFakeBackend(t)
+	// Mint a JWT with future exp so the second waiter's
+	// `session.AccessToken()` check sees a valid cached token after
+	// the first goroutine persists. Without a parseable exp the F4
+	// path can't trust the cached AT and falls through to a network
+	// call, defeating the second-waiter short-circuit.
+	_, priv, kerr := ed25519.GenerateKey(rand.Reader)
+	if kerr != nil {
+		t.Fatalf("GenerateKey: %v", kerr)
+	}
+	futureExp := time.Now().Add(10 * time.Minute).UTC().Truncate(time.Second)
+	rotatedAT := signTestToken(t, "kid-1", priv, func(c *auth.Claims) {
+		c.ExpiresAt = jwt.NewNumericDate(futureExp)
+	})
+	// Slow down the refresh handler so the second goroutine reliably
+	// contends for the lock while the first holds it. Without this the
+	// first call can return before the second even tries to acquire,
+	// which would pass for the wrong reason.
+	fb.refreshFn = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "2.0")
+		time.Sleep(100 * time.Millisecond)
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"accessToken":  rotatedAT,
+			"refreshToken": "refresh-2",
+		})
+	}
+
+	lockDir := t.TempDir()
+	kc := keychain.NewMemory()
+	storeA := auth.NewSessionStore(kc)
+	oc := oidc.NewClient(fb.URL(), fb.srv.Client())
+	rp := client.RetryPolicy{MaxRetries: 0, InitialWait: time.Millisecond, Multiplier: 1, MaxWait: time.Millisecond}
+	hcA := client.New(client.Options{Tokens: storeA, Retry: &rp})
+	a1 := auth.NewAuthenticator(auth.IssuerFromOIDC(oc, "endstate-backup"), oc, hcA, storeA).
+		WithRefreshLockDir(lockDir)
+	if _, err := a1.CompleteLogin(context.Background(), "user@example.com", []byte("pw")); err != nil {
+		t.Fatalf("CompleteLogin: %v", err)
+	}
+
+	// Sibling "process": separate Authenticator + SessionStore on the
+	// same keychain and lock dir.
+	a2 := newAuthOnSharedKeychain(t, fb, kc, lockDir)
+
+	beforeRefresh := atomic.LoadInt32(&fb.refreshHits)
+
+	var wg sync.WaitGroup
+	type res struct {
+		at  string
+		err error
+	}
+	results := make([]res, 2)
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		at, err := a1.Session().RefreshAccessToken(context.Background())
+		results[0] = res{at, err}
+	}()
+	go func() {
+		defer wg.Done()
+		// Tiny stagger so both goroutines enter the lock-acquire window
+		// without the second sneaking in first on a fast scheduler.
+		time.Sleep(5 * time.Millisecond)
+		at, err := a2.Session().RefreshAccessToken(context.Background())
+		results[1] = res{at, err}
+	}()
+	wg.Wait()
+
+	// Both calls succeeded.
+	for i, r := range results {
+		if r.err != nil {
+			t.Fatalf("goroutine %d returned err: %v", i, r.err)
+		}
+		if r.at != rotatedAT {
+			t.Errorf("goroutine %d: access token = %q, want the rotated JWT", i, r.at)
+		}
+	}
+
+	// Only one substrate hit — the lock collapsed the race.
+	hits := atomic.LoadInt32(&fb.refreshHits) - beforeRefresh
+	if hits != 1 {
+		t.Errorf("substrate refresh hits = %d, want 1 (lock should have serialised and second waiter should have short-circuited)", hits)
+	}
+
+	// Keychain holds the rotated RT — not a stale "second writer wrote
+	// the old refresh-1 back" footgun.
+	stored, kerr := kc.Load(keychain.AccountForUser("user-1"))
+	if kerr != nil {
+		t.Fatalf("keychain.Load: %v", kerr)
+	}
+	if string(stored) != "refresh-2" {
+		t.Errorf("keychain RT = %q, want refresh-2 (rotated)", stored)
+	}
+}
+
+// TestAuthenticator_RefreshLock_SecondWaiterUsesFreshAccessToken locks
+// in the second-waiter optimisation: when goroutine B blocks on the
+// lock while goroutine A's refresh completes, B should re-hydrate,
+// observe the now-valid cached access token, and return without
+// hitting substrate. Otherwise N concurrent subprocesses would still
+// produce N serial substrate round-trips even though the lock prevents
+// the rotation race.
+func TestAuthenticator_RefreshLock_SecondWaiterUsesFreshAccessToken(t *testing.T) {
+	fb := newFakeBackend(t)
+	// Mint a JWT with a long-into-the-future exp so the cached AT
+	// passes the AccessToken() expiry check inside refreshAccessToken's
+	// second-waiter short-circuit.
+	_, priv, kerr := ed25519.GenerateKey(rand.Reader)
+	if kerr != nil {
+		t.Fatalf("GenerateKey: %v", kerr)
+	}
+	futureExp := time.Now().Add(10 * time.Minute).UTC().Truncate(time.Second)
+	rotatedAT := signTestToken(t, "kid-1", priv, func(c *auth.Claims) {
+		c.ExpiresAt = jwt.NewNumericDate(futureExp)
+	})
+
+	gateOpen := make(chan struct{})
+	gateClose := make(chan struct{})
+	fb.refreshFn = func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-Endstate-API-Version", "2.0")
+		close(gateOpen)
+		<-gateClose
+		_ = json.NewEncoder(w).Encode(map[string]string{
+			"accessToken":  rotatedAT,
+			"refreshToken": "refresh-2",
+		})
+	}
+
+	lockDir := t.TempDir()
+	kc := keychain.NewMemory()
+	storeA := auth.NewSessionStore(kc)
+	oc := oidc.NewClient(fb.URL(), fb.srv.Client())
+	rp := client.RetryPolicy{MaxRetries: 0, InitialWait: time.Millisecond, Multiplier: 1, MaxWait: time.Millisecond}
+	hcA := client.New(client.Options{Tokens: storeA, Retry: &rp})
+	a1 := auth.NewAuthenticator(auth.IssuerFromOIDC(oc, "endstate-backup"), oc, hcA, storeA).
+		WithRefreshLockDir(lockDir)
+	if _, err := a1.CompleteLogin(context.Background(), "user@example.com", []byte("pw")); err != nil {
+		t.Fatalf("CompleteLogin: %v", err)
+	}
+	a2 := newAuthOnSharedKeychain(t, fb, kc, lockDir)
+
+	beforeRefresh := atomic.LoadInt32(&fb.refreshHits)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	var atA, atB string
+	var errA, errB error
+	go func() {
+		defer wg.Done()
+		atA, errA = a1.Session().RefreshAccessToken(context.Background())
+	}()
+	go func() {
+		defer wg.Done()
+		// Wait until A is mid-refresh before B starts so B is
+		// guaranteed to block on the lock rather than win the race.
+		<-gateOpen
+		atB, errB = a2.Session().RefreshAccessToken(context.Background())
+		// B should not be the one to release A's gate — only A is
+		// waiting on it. So close it from here once B has acquired
+		// the lock (which it can't until A releases). Wait... B
+		// blocks on the lock until A finishes. So we need to release
+		// A's gate first, then let B run.
+	}()
+	// Release A so it can complete the network call, persist, and
+	// drop the lock. Then B unblocks and short-circuits on the cached AT.
+	close(gateClose)
+	wg.Wait()
+
+	if errA != nil {
+		t.Fatalf("goroutine A err: %v", errA)
+	}
+	if errB != nil {
+		t.Fatalf("goroutine B err: %v", errB)
+	}
+	if atA != rotatedAT {
+		t.Errorf("A access token mismatch")
+	}
+	if atB != rotatedAT {
+		t.Errorf("B access token = %q, want the rotated JWT (second waiter must reuse the cached value)", atB)
+	}
+
+	hits := atomic.LoadInt32(&fb.refreshHits) - beforeRefresh
+	if hits != 1 {
+		t.Errorf("substrate refresh hits = %d, want exactly 1 (second waiter must short-circuit on the cached AT)", hits)
+	}
+}
+
+// TestAuthenticator_RefreshLock_CtxCancel asserts that a ctx deadline
+// expiring while the lock is held by an external holder produces a
+// clean, wrapped error rather than panicking or blocking forever.
+// This is the "transient" failure mode the 401-refresh hook can retry.
+func TestAuthenticator_RefreshLock_CtxCancel(t *testing.T) {
+	fb := newFakeBackend(t)
+	a, _ := newAuthForTest(t, fb)
+	if _, err := a.CompleteLogin(context.Background(), "user@example.com", []byte("pw")); err != nil {
+		t.Fatalf("CompleteLogin: %v", err)
+	}
+
+	// Grab the lock file path that the test helper wired up via
+	// WithRefreshLockDir, then hold it from outside the Authenticator
+	// for the duration of the cancel window.
+	//
+	// newAuthForTest passes a per-test t.TempDir() to WithRefreshLockDir;
+	// we don't have a getter for that path here, so reproduce the
+	// directory inference via a second WithRefreshLockDir call into a
+	// fresh temp dir and have the Authenticator + the foreign holder
+	// share it.
+	lockDir := t.TempDir()
+	a.WithRefreshLockDir(lockDir)
+	foreign := flock.New(lockDir + "/refresh.lock")
+	if _, ferr := foreign.TryLock(); ferr != nil {
+		t.Fatalf("foreign TryLock setup: %v", ferr)
+	}
+	t.Cleanup(func() { _ = foreign.Unlock() })
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+
+	_, err := a.Session().RefreshAccessToken(ctx)
+	if err == nil {
+		t.Fatal("RefreshAccessToken returned nil; want ctx-cancel-wrapped error while foreign holder pins the lock")
+	}
+	// Acceptable failure modes: wrapped context.DeadlineExceeded or our
+	// "could not acquire" sentinel. The exact wording is not what we
+	// guard — we guard that it returns rather than panics/blocks.
+	if !errors.Is(err, context.DeadlineExceeded) && !strings.Contains(err.Error(), "refresh") {
+		t.Errorf("err = %v; want one that references ctx deadline or refresh lock", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Closes the F5 gap from the hosted-backup session-persistence work: eliminates intermittent `AUTH_REQUIRED` after sign-in when two engine subprocesses concurrently rotate the same refresh token and Substrate's reuse-detection invalidates the RT after the first POST.
- Wraps the read-refresh-persist window in `Authenticator.refreshAccessToken()` with a `gofrs/flock` file lock at `<session-dir>/refresh.lock`, so only one process performs the network rotation at a time.
- Second waiter re-reads the cached access token after acquiring the lock and short-circuits without a network call when a peer already refreshed — no wasted RTs, no stale-RT writeback.
- Adds unit coverage in `authenticator_test.go` for both the single-flight short-circuit and the serialized-rotation paths.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] `go test ./... -count=1` full suite green (race detector skipped locally — CGO/gcc unavailable on this Windows host; CI runs the same `go test ./...` invocation on `windows-latest`)
- [x] `go test ./internal/backup/auth/... -count=10` stable across 10 iterations (stress-flush for flakes in the new lock paths)
- [ ] CI green on `windows-latest`
- [ ] Manual: two concurrent `endstate session refresh` invocations against a freshly-signed-in profile both succeed; neither surfaces `AUTH_REQUIRED` on the follow-up call
- [ ] Manual: lock file `<session-dir>/refresh.lock` is created on first refresh and is reused (no growth, no leftover after process exit)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>