### PR TITLE
fix(backup): fail closed on Hydrate error inside refresh lock

### DIFF
--- a/go-engine/internal/backup/auth/authenticator.go
+++ b/go-engine/internal/backup/auth/authenticator.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/Artexis10/endstate/go-engine/internal/backup/client"
 	"github.com/Artexis10/endstate/go-engine/internal/backup/crypto"
+	"github.com/Artexis10/endstate/go-engine/internal/backup/keychain"
 	"github.com/Artexis10/endstate/go-engine/internal/backup/oidc"
 	"github.com/Artexis10/endstate/go-engine/internal/envelope"
 )
@@ -243,10 +244,18 @@ func (a *Authenticator) refreshAccessToken(ctx context.Context) (string, error) 
 	// Re-hydrate from the keychain so a sibling process's rotated RT
 	// becomes visible to this process. Without this, the in-memory snapshot
 	// here is the pre-wait copy and we'd POST a now-stale RT, defeating the
-	// lock entirely. Best-effort: a hydrate failure (e.g. fresh test
-	// keychain with no pointer) falls through to the original snapshot.
+	// lock entirely.
+	//
+	// ErrNotFound at the pointer is the expected signed-out shape and falls
+	// through to the original snapshot (no-op for fresh test keychains).
+	// Any other error means we cannot trust the in-memory snapshot to match
+	// what's in the keychain — proceeding would risk POSTing a stale RT,
+	// which substrate's reuse-detection would burn, re-introducing exactly
+	// the AUTH_REQUIRED symptom F5 is meant to eliminate. Fail closed.
 	if uid := a.session.Snapshot().UserID; uid != "" {
-		_ = a.session.Hydrate(uid)
+		if err := a.session.Hydrate(uid); err != nil && !errors.Is(err, keychain.ErrNotFound) {
+			return "", fmt.Errorf("auth: refresh: hydrate before rotation: %w", err)
+		}
 	}
 	snap := a.session.Snapshot()
 

--- a/go-engine/internal/backup/auth/authenticator_test.go
+++ b/go-engine/internal/backup/auth/authenticator_test.go
@@ -804,6 +804,45 @@ func TestAuthenticator_RefreshLock_CtxCancel(t *testing.T) {
 	}
 }
 
+// TestAuthenticator_RefreshLock_HydrateFailureFailsClosed verifies that when
+// the pre-rotation Hydrate returns a non-ErrNotFound error inside the refresh
+// critical section, RefreshAccessToken returns the error rather than
+// proceeding to POST a potentially-stale RT. Failing open would have the
+// process burn a refresh token that a sibling already rotated, re-introducing
+// exactly the AUTH_REQUIRED symptom F5 is meant to eliminate.
+func TestAuthenticator_RefreshLock_HydrateFailureFailsClosed(t *testing.T) {
+	fb := newFakeBackend(t)
+	fb.refreshFn = func(w http.ResponseWriter, r *http.Request) {
+		t.Fatal("substrate refresh endpoint must not be hit when Hydrate fails closed")
+	}
+
+	loadErr := errors.New("keychain temporarily unavailable")
+	kc := &faultyKeychain{loadErr: loadErr}
+	store := auth.NewSessionStore(kc)
+
+	// SetTokens populates in-memory state without writing to the keychain so
+	// the Snapshot has a non-empty UserID (which triggers the Hydrate path)
+	// without depending on Persist succeeding against the faulty keychain.
+	store.SetTokens("user-1", "user@example.com", "", "refresh-1", "active", time.Time{})
+
+	oc := oidc.NewClient(fb.URL(), fb.srv.Client())
+	rp := client.RetryPolicy{MaxRetries: 0, InitialWait: time.Millisecond, Multiplier: 1, MaxWait: time.Millisecond}
+	hc := client.New(client.Options{Tokens: store, Retry: &rp})
+	a := auth.NewAuthenticator(auth.IssuerFromOIDC(oc, "endstate-backup"), oc, hc, store).
+		WithRefreshLockDir(t.TempDir())
+
+	_, err := a.Session().RefreshAccessToken(context.Background())
+	if err == nil {
+		t.Fatal("RefreshAccessToken returned nil; want wrapped Hydrate error")
+	}
+	if !errors.Is(err, loadErr) {
+		t.Errorf("err = %v; want errors.Is(err, loadErr) so the underlying keychain failure is preserved", err)
+	}
+	if !strings.Contains(err.Error(), "hydrate before rotation") {
+		t.Errorf("err message = %q; want 'hydrate before rotation' phrase", err.Error())
+	}
+}
+
 func TestAuthenticator_PreHandshake_404MapsToNotFound(t *testing.T) {
 	fb := newFakeBackend(t)
 	fb.loginPreFn = func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

Follow-up to #45 (F5). The pre-rotation `Hydrate` call inside `refreshAccessToken` was a silent `_ = a.session.Hydrate(uid)`. If a sibling process had just rotated the RT and our `Hydrate` failed with a transient keychain error, we'd read the pre-wait snapshot and POST a now-stale RT — substrate's reuse-detection would burn it, and the next CLI call would surface `AUTH_REQUIRED`, which is the exact symptom F5 is meant to eliminate.

Now distinguishes:
- `errors.Is(err, keychain.ErrNotFound)` → signed-out, fall through (no change in behavior)
- Anything else → return wrapped error; do NOT POST a refresh

Adds `TestAuthenticator_RefreshLock_HydrateFailureFailsClosed`: asserts the substrate refresh endpoint is never hit when `Hydrate` fails with a non-ErrNotFound error.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/backup/auth/... -count=1` green (36 tests, +1 new)
- [x] No call-site changes — public `RefreshAccessToken` signature unchanged