### PR TITLE
feat(engine): Nix package realizer backend for Linux/macOS

### DIFF
--- a/docs/contracts/cli-json-contract.md
+++ b/docs/contracts/cli-json-contract.md
@@ -86,6 +86,7 @@ When `success` is `false`, the `error` field contains:
 | `PLAN_NOT_FOUND` | Plan file does not exist |
 | `PLAN_PARSE_ERROR` | Plan file is invalid |
 | `WINGET_NOT_AVAILABLE` | winget is not installed or accessible |
+| `REALIZER_UNAVAILABLE` | The package realizer is unavailable (e.g. the Nix daemon/store is unreachable, or `nix` is not installed) |
 | `ENGINE_CLI_NOT_FOUND` | Engine CLI not found (repo root not configured) |
 | `CAPTURE_FAILED` | Capture operation failed |
 | `CAPTURE_BLOCKED` | Capture blocked by guardrail |
@@ -199,7 +200,7 @@ endstate capabilities --json
 | `gitDirty` | boolean | Yes | `true` if working tree has uncommitted changes, `false` otherwise (defaults to `false` if git unavailable) |
 | `bootstrapTimestamp` | string\|null | Yes | ISO 8601 UTC timestamp of last bootstrap, or `null` if not bootstrapped |
 
-> **`platform` is host-dependent.** `platform.os` reflects the host operating system (`windows`, `linux`, `darwin`) and `platform.drivers` lists the package-manager backends available on that host. On Windows this is `{ "os": "windows", "drivers": ["winget"] }`. On a host with no implemented backend yet, `drivers` is an empty array (`[]`). This is additive: consumers MUST NOT assume a fixed `windows` / `winget` value.
+> **`platform` is host-dependent.** `platform.os` reflects the host operating system (`windows`, `linux`, `darwin`) and `platform.drivers` lists the package-manager backends available on that host. On Windows this is `{ "os": "windows", "drivers": ["winget"] }`. On Linux and macOS with Nix available this is `["nix"]`. On a host with no implemented backend yet, `drivers` is an empty array (`[]`). This is additive: consumers MUST NOT assume a fixed `windows` / `winget` value.
 
 ---
 

--- a/go-engine/internal/commands/apply.go
+++ b/go-engine/internal/commands/apply.go
@@ -177,6 +177,15 @@ func RunApply(flags ApplyFlags) (interface{}, *envelope.Error) {
 		}
 	}
 
+	// Platform realizer path (whole-set, e.g. Nix on linux/darwin). When a
+	// realizer backend is available, take the whole-set apply path that fans one
+	// atomic generation switch into the per-item event stream. On Windows
+	// newRealizerFn returns ErrNoRealizer, so control falls through to the winget
+	// driver loop below, byte-identical to prior behavior.
+	if rz, rerr := newRealizerFn(); rerr == nil {
+		return runApplyRealizer(flags, mf, rz, emitter, runID, configModuleMap, restoreModulesAvailable)
+	}
+
 	d, derr := newDriverFn()
 	if derr != nil {
 		return nil, envelope.NewError(envelope.ErrInternalError, derr.Error())

--- a/go-engine/internal/commands/apply_realizer.go
+++ b/go-engine/internal/commands/apply_realizer.go
@@ -1,0 +1,272 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"fmt"
+	"runtime"
+	"strings"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/events"
+	"github.com/Artexis10/endstate/go-engine/internal/manifest"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+// realizerEntry is one planned manifest app on the realizer path.
+type realizerEntry struct {
+	app      manifest.App
+	ins      realizer.Installable
+	isNix    bool
+	isManual bool
+	name     string
+}
+
+// realizerItemName returns a stable display name for a realizer item.
+func realizerItemName(app manifest.App) string {
+	if app.DisplayName != "" {
+		return app.DisplayName
+	}
+	return app.ID
+}
+
+// isSystemic reports whether a realizer error is a whole-run infrastructure
+// failure that should surface as a top-level envelope error (truncating the
+// per-item stream) rather than a per-item install failure.
+func isSystemic(code envelope.ErrorCode) bool {
+	return code == envelope.ErrRealizerUnavailable || code == envelope.ErrPermissionDenied
+}
+
+// realizerEnvelopeError builds the top-level envelope error for a systemic
+// realizer failure. Raw Nix text lands ONLY in error.detail (the moat).
+func realizerEnvelopeError(rerr *realizer.Error) *envelope.Error {
+	msg := "The package backend is unavailable."
+	rem := "Ensure the Nix daemon is running and 'nix' is on PATH."
+	if rerr.Code == envelope.ErrPermissionDenied {
+		msg = "Insufficient permissions to realize the package set."
+		rem = "Check write permissions on the Endstate Nix profile directory."
+	}
+	return envelope.NewError(rerr.Code, msg).
+		WithDetail(map[string]string{"subcode": rerr.Subcode, "stage": rerr.Stage, "raw": rerr.Raw}).
+		WithRemediation(rem)
+}
+
+// leafAttr returns the trailing attribute of an installable ref (after the last
+// '#', then the last '.'), for matching against installed element names.
+func leafAttr(s string) string {
+	if i := strings.LastIndex(s, "#"); i >= 0 {
+		s = s[i+1:]
+	}
+	if i := strings.LastIndex(s, "."); i >= 0 {
+		s = s[i+1:]
+	}
+	return s
+}
+
+// presentInSet reports whether ref's leaf attribute matches an installed element.
+func presentInSet(set realizer.Set, ref string) bool {
+	leaf := leafAttr(ref)
+	if leaf == "" {
+		return false
+	}
+	if _, ok := set.Elements[leaf]; ok {
+		return true
+	}
+	for _, e := range set.Elements {
+		if e.Name == leaf || leafAttr(e.AttrPath) == leaf {
+			return true
+		}
+	}
+	return false
+}
+
+// runApplyRealizer is the whole-set apply path for a realizer backend (Nix). It
+// computes one plan over the declared package set, performs ONE atomic
+// generation switch, and fans the single result back into the per-item event
+// stream so the event contract is preserved. Package install ONLY — config and
+// verify stages keep their own concerns. Raw backend text is confined to
+// error.detail.
+func runApplyRealizer(flags ApplyFlags, mf *manifest.Manifest, r realizer.Realizer, emitter *events.Emitter, runID string, configModuleMap map[string]string, restoreModulesAvailable []RestoreModuleRef) (interface{}, *envelope.Error) {
+	driverName := r.Name()
+
+	// --- Phase 1: Plan ---
+	emitter.EmitPhase("plan")
+
+	var entries []realizerEntry
+	var desired []realizer.Installable
+	names := map[string]string{}
+	for _, app := range mf.Apps {
+		ref := app.Refs[runtime.GOOS] // STRICT: no fallback to a non-host (e.g. winget) ref
+		name := realizerItemName(app)
+		names[app.ID] = name
+		switch {
+		case ref != "":
+			ins := realizer.Installable{ID: app.ID, Ref: ref}
+			entries = append(entries, realizerEntry{app: app, ins: ins, isNix: true, name: name})
+			desired = append(desired, ins)
+		case app.Manual != nil && app.Manual.VerifyPath != "":
+			entries = append(entries, realizerEntry{app: app, isManual: true, name: name})
+		default:
+			// No host package ref and not a manual app: skip (never pass a
+			// foreign ref to the realizer).
+			emitter.EmitItem(app.ID, driverName, "skipped", "filtered", "No linux/darwin package ref", name)
+		}
+	}
+
+	diff, planErr := r.Plan(desired)
+	if planErr != nil {
+		if rerr, ok := planErr.(*realizer.Error); ok && isSystemic(rerr.Code) {
+			return nil, realizerEnvelopeError(rerr)
+		}
+		return nil, envelope.NewError(envelope.ErrInternalError, "Failed to plan the package set.")
+	}
+
+	present := map[string]bool{} // app.ID -> already present
+	for _, ins := range diff.Present {
+		present[ins.ID] = true
+	}
+
+	actions := make([]ApplyAction, 0, len(entries))
+	idx := map[string]int{}
+	presentCount, toInstallCount := 0, 0
+	for _, e := range entries {
+		switch {
+		case e.isManual:
+			expanded, exists := checkVerifyPath(e.app.Manual.VerifyPath)
+			a := ApplyAction{ID: e.app.ID, Driver: "manual", Name: e.name}
+			if exists {
+				a.Status, a.Reason, a.Message = "present", "already_installed", fmt.Sprintf("Verified at %s", expanded)
+				emitter.EmitItem(e.app.ID, "manual", "present", "already_installed", a.Message, e.name)
+				presentCount++
+			} else {
+				a.Status, a.Reason, a.Message = "to_install", "manual_required", fmt.Sprintf("Not found at %s", expanded)
+				a.Manual = e.app.Manual
+				emitter.EmitItem(e.app.ID, "manual", "to_install", "manual_required", a.Message, e.name)
+				toInstallCount++
+			}
+			idx[e.app.ID] = len(actions)
+			actions = append(actions, a)
+		case e.isNix:
+			ref := e.ins.Ref
+			a := ApplyAction{ID: e.app.ID, Ref: stringPtr(ref), Driver: driverName, Name: e.name}
+			if present[e.app.ID] {
+				a.Status, a.Reason = "present", "already_installed"
+				emitter.EmitItem(ref, driverName, "present", "already_installed", "Already installed", e.name)
+				presentCount++
+			} else {
+				a.Status, a.Reason = "to_install", "missing"
+				emitter.EmitItem(ref, driverName, "to_install", "missing", "Will be installed", e.name)
+				toInstallCount++
+			}
+			idx[e.app.ID] = len(actions)
+			actions = append(actions, a)
+		}
+	}
+
+	totalApps := len(actions)
+	emitter.EmitSummary("plan", totalApps, presentCount, 0, toInstallCount)
+
+	if flags.DryRun {
+		return &ApplyResult{
+			DryRun:                  true,
+			Manifest:                ApplyManifestRef{Path: flags.Manifest, Name: mf.Name},
+			Summary:                 ApplySummary{Total: totalApps, Skipped: presentCount},
+			Actions:                 actions,
+			ConfigModuleMap:         configModuleMap,
+			RestoreModulesAvailable: restoreModulesAvailable,
+		}, nil
+	}
+
+	// --- Phase 2: Apply (one atomic generation switch over diff.ToAdd) ---
+	emitter.EmitPhase("apply")
+	successCount, skippedCount, failedCount := 0, 0, 0
+
+	// Manual apps: present -> success; otherwise skipped (manual_required).
+	for _, e := range entries {
+		if !e.isManual {
+			continue
+		}
+		if actions[idx[e.app.ID]].Status == "present" {
+			successCount++
+		} else {
+			actions[idx[e.app.ID]].Status = "skipped"
+			actions[idx[e.app.ID]].Reason = "manual_required"
+			emitter.EmitItem(e.app.ID, "manual", "skipped", "manual_required", actions[idx[e.app.ID]].Message, e.name)
+			skippedCount++
+		}
+	}
+
+	if len(diff.ToAdd) > 0 {
+		for _, ins := range diff.ToAdd {
+			emitter.EmitItem(ins.Ref, driverName, "installing", "", fmt.Sprintf("Installing %s", ins.Ref), names[ins.ID])
+		}
+		res, _ := r.Realize(diff.ToAdd)
+		if res.Err != nil {
+			if isSystemic(res.Err.Code) {
+				// Whole-run infra failure: top-level error, stream truncates here.
+				return nil, realizerEnvelopeError(res.Err)
+			}
+			// Atomic install failure: nothing was installed; every to-add fails.
+			msg := "Install failed"
+			if res.Err.Subcode != "" {
+				msg = fmt.Sprintf("Install failed (%s)", res.Err.Subcode)
+			}
+			for _, ins := range diff.ToAdd {
+				emitter.EmitItem(ins.Ref, driverName, "failed", "install_failed", msg, names[ins.ID])
+				if i, ok := idx[ins.ID]; ok {
+					actions[i].Status, actions[i].Reason, actions[i].Message = "failed", "install_failed", msg
+				}
+				failedCount++
+			}
+		} else {
+			for _, ins := range diff.ToAdd {
+				emitter.EmitItem(ins.Ref, driverName, "installed", "", "Installed", names[ins.ID])
+				if i, ok := idx[ins.ID]; ok {
+					actions[i].Status, actions[i].Reason = "installed", ""
+				}
+				successCount++
+			}
+		}
+	}
+	// Already-present nix packages count as skipped in the apply phase.
+	skippedCount += len(diff.Present)
+
+	emitter.EmitSummary("apply", successCount+skippedCount+failedCount, successCount, skippedCount, failedCount)
+
+	// --- Phase 3: Verify (read current generation) ---
+	emitter.EmitPhase("verify")
+	cur, _ := r.Current()
+	verifyPass, verifyFail := 0, 0
+	for _, e := range entries {
+		switch {
+		case e.isManual:
+			expanded, exists := checkVerifyPath(e.app.Manual.VerifyPath)
+			if exists {
+				emitter.EmitItem(e.app.ID, "manual", "present", "", fmt.Sprintf("Verified at %s", expanded), e.name)
+				verifyPass++
+			} else {
+				emitter.EmitItem(e.app.ID, "manual", "failed", "missing", fmt.Sprintf("Missing at %s", expanded), e.name)
+				verifyFail++
+			}
+		case e.isNix:
+			if presentInSet(cur, e.ins.Ref) {
+				emitter.EmitItem(e.ins.Ref, driverName, "present", "", "Verified installed", e.name)
+				verifyPass++
+			} else {
+				emitter.EmitItem(e.ins.Ref, driverName, "failed", "missing", "Missing after apply", e.name)
+				verifyFail++
+			}
+		}
+	}
+	emitter.EmitSummary("verify", verifyPass+verifyFail, verifyPass, 0, verifyFail)
+
+	return &ApplyResult{
+		DryRun:                  false,
+		Manifest:                ApplyManifestRef{Path: flags.Manifest, Name: mf.Name},
+		Summary:                 ApplySummary{Total: totalApps, Success: successCount, Skipped: skippedCount, Failed: failedCount},
+		Actions:                 actions,
+		ConfigModuleMap:         configModuleMap,
+		RestoreModulesAvailable: restoreModulesAvailable,
+	}, nil
+}

--- a/go-engine/internal/commands/apply_realizer_test.go
+++ b/go-engine/internal/commands/apply_realizer_test.go
@@ -64,17 +64,28 @@ func (f *fakeRealizer) Realize(toAdd []realizer.Installable) (realizer.Result, e
 // Test helpers
 // ---------------------------------------------------------------------------
 
-// nixApp returns an App with refs set for both linux and darwin, using the
-// same flakeref for each — typical for unit tests.
+// nixApp returns an App whose package ref is keyed by the CURRENT host OS
+// (runtime.GOOS). The realizer path resolves app.Refs[runtime.GOOS] strictly,
+// so keying by the host makes these fixtures exercise the nix path on whatever
+// OS the test runs on — linux, darwin, OR windows CI (where the realizer
+// functions are still invoked directly by these unit tests).
 func nixApp(id, ref string) manifest.App {
 	return manifest.App{
 		ID:          id,
 		DisplayName: id,
-		Refs: map[string]string{
-			"linux":  ref,
-			"darwin": ref,
-		},
+		Refs:        map[string]string{runtime.GOOS: ref},
 	}
+}
+
+// foreignRefApp returns an App whose only ref is for an OS that is NOT the
+// current host, so the realizer path always SKIPS it. Used to test the
+// no-host-ref skip behavior deterministically on any OS.
+func foreignRefApp(id, ref string) manifest.App {
+	foreign := "windows"
+	if runtime.GOOS == "windows" {
+		foreign = "linux"
+	}
+	return manifest.App{ID: id, Refs: map[string]string{foreign: ref}}
 }
 
 // hostRef returns the flakeref for the current GOOS from an app, matching
@@ -83,8 +94,8 @@ func hostRef(app manifest.App) string {
 	return app.Refs[runtime.GOOS]
 }
 
-// nixManifest builds an in-memory Manifest whose apps each carry refs for
-// both linux and darwin so tests work on any POSIX host.
+// nixManifest builds an in-memory Manifest from the given apps (each typically
+// built with nixApp, so they carry a ref for the current host OS).
 func nixManifest(apps ...manifest.App) *manifest.Manifest {
 	return &manifest.Manifest{
 		Version: 1,

--- a/go-engine/internal/commands/apply_realizer_test.go
+++ b/go-engine/internal/commands/apply_realizer_test.go
@@ -1,0 +1,417 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/events"
+	"github.com/Artexis10/endstate/go-engine/internal/manifest"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+// ---------------------------------------------------------------------------
+// fakeRealizer — configurable stub implementing realizer.Realizer
+// ---------------------------------------------------------------------------
+
+// fakeRealizer is a scriptable test double for realizer.Realizer. Fields that
+// hold return values are used directly by the interface methods; counter fields
+// let assertions verify call counts and captured arguments without depending on
+// emitter output.
+type fakeRealizer struct {
+	// --- scripted returns ---
+	currentSet realizer.Set
+	currentErr error
+
+	planDiff realizer.Diff
+	planErr  error
+
+	realizeResult realizer.Result
+
+	// --- observation ---
+	currentCalls    int
+	planCalls       int
+	realizeCalls    int
+	lastPlanArgs    []realizer.Installable
+	lastRealizeArgs []realizer.Installable
+}
+
+func (f *fakeRealizer) Name() string { return "nix" }
+
+func (f *fakeRealizer) Current() (realizer.Set, error) {
+	f.currentCalls++
+	return f.currentSet, f.currentErr
+}
+
+func (f *fakeRealizer) Plan(desired []realizer.Installable) (realizer.Diff, error) {
+	f.planCalls++
+	f.lastPlanArgs = desired
+	return f.planDiff, f.planErr
+}
+
+func (f *fakeRealizer) Realize(toAdd []realizer.Installable) (realizer.Result, error) {
+	f.realizeCalls++
+	f.lastRealizeArgs = toAdd
+	return f.realizeResult, nil
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// nixApp returns an App with refs set for both linux and darwin, using the
+// same flakeref for each — typical for unit tests.
+func nixApp(id, ref string) manifest.App {
+	return manifest.App{
+		ID:          id,
+		DisplayName: id,
+		Refs: map[string]string{
+			"linux":  ref,
+			"darwin": ref,
+		},
+	}
+}
+
+// hostRef returns the flakeref for the current GOOS from an app, matching
+// the strict host-only lookup in apply_realizer.go (app.Refs[runtime.GOOS]).
+func hostRef(app manifest.App) string {
+	return app.Refs[runtime.GOOS]
+}
+
+// nixManifest builds an in-memory Manifest whose apps each carry refs for
+// both linux and darwin so tests work on any POSIX host.
+func nixManifest(apps ...manifest.App) *manifest.Manifest {
+	return &manifest.Manifest{
+		Version: 1,
+		Name:    "nix-test",
+		Apps:    apps,
+	}
+}
+
+// withFakeRealizer replaces newRealizerFn with one that returns fr, calls f,
+// then restores the original factory.
+func withFakeRealizer(fr *fakeRealizer, f func()) {
+	orig := newRealizerFn
+	newRealizerFn = func() (realizer.Realizer, error) { return fr, nil }
+	defer func() { newRealizerFn = orig }()
+	f()
+}
+
+// noopEmitter returns a no-op emitter (streaming=false, discards all events).
+func noopEmitter() *events.Emitter {
+	return events.NewEmitter("test-run", false)
+}
+
+// ---------------------------------------------------------------------------
+// runApplyRealizer tests
+// ---------------------------------------------------------------------------
+
+// TestRunApplyRealizer_AllToAdd_Success: Plan returns all packages as ToAdd,
+// Realize returns Advanced:true with no error.
+// Expected: Summary.Success==2, both actions status "installed".
+func TestRunApplyRealizer_AllToAdd_Success(t *testing.T) {
+	app1 := nixApp("ripgrep", "nixpkgs#ripgrep")
+	app2 := nixApp("jq", "nixpkgs#jq")
+	mf := nixManifest(app1, app2)
+
+	ins1 := realizer.Installable{ID: "ripgrep", Ref: hostRef(app1)}
+	ins2 := realizer.Installable{ID: "jq", Ref: hostRef(app2)}
+
+	fr := &fakeRealizer{
+		planDiff: realizer.Diff{
+			ToAdd:   []realizer.Installable{ins1, ins2},
+			Present: nil,
+		},
+		realizeResult: realizer.Result{
+			Advanced:       true,
+			FromGeneration: 1,
+			ToGeneration:   2,
+			After: realizer.Set{
+				Generation: 2,
+				Elements: map[string]realizer.Element{
+					"ripgrep": {Name: "ripgrep", AttrPath: "ripgrep"},
+					"jq":      {Name: "jq", AttrPath: "jq"},
+				},
+			},
+		},
+	}
+
+	flags := ApplyFlags{Manifest: "nix-test", DryRun: false}
+	raw, envelopeErr := runApplyRealizer(flags, mf, fr, noopEmitter(), "run-1", nil, nil)
+
+	if envelopeErr != nil {
+		t.Fatalf("runApplyRealizer returned envelope error: %v", envelopeErr)
+	}
+	result, ok := raw.(*ApplyResult)
+	if !ok {
+		t.Fatalf("expected *ApplyResult, got %T", raw)
+	}
+
+	if result.Summary.Success != 2 {
+		t.Errorf("Summary.Success = %d, want 2", result.Summary.Success)
+	}
+	if result.Summary.Failed != 0 {
+		t.Errorf("Summary.Failed = %d, want 0", result.Summary.Failed)
+	}
+	for _, action := range result.Actions {
+		if action.Status != "installed" {
+			t.Errorf("action %q: Status = %q, want installed", action.ID, action.Status)
+		}
+	}
+	if fr.realizeCalls != 1 {
+		t.Errorf("Realize called %d times, want 1", fr.realizeCalls)
+	}
+}
+
+// TestRunApplyRealizer_SystemicError: Realize returns a systemic error
+// (ErrRealizerUnavailable).
+// Expected: non-nil envelope.Error with code REALIZER_UNAVAILABLE, nil data,
+// and raw Nix text confined to Detail (not Message).
+func TestRunApplyRealizer_SystemicError(t *testing.T) {
+	app1 := nixApp("ripgrep", "nixpkgs#ripgrep")
+	app2 := nixApp("jq", "nixpkgs#jq")
+	mf := nixManifest(app1, app2)
+
+	ins1 := realizer.Installable{ID: "ripgrep", Ref: hostRef(app1)}
+	ins2 := realizer.Installable{ID: "jq", Ref: hostRef(app2)}
+
+	rawText := "nix daemon error: connection refused"
+	fr := &fakeRealizer{
+		planDiff: realizer.Diff{
+			ToAdd:   []realizer.Installable{ins1, ins2},
+			Present: nil,
+		},
+		realizeResult: realizer.Result{
+			Err: &realizer.Error{
+				Code:    envelope.ErrRealizerUnavailable,
+				Subcode: "daemon",
+				Stage:   "spawn",
+				Raw:     rawText,
+			},
+		},
+	}
+
+	flags := ApplyFlags{Manifest: "nix-test", DryRun: false}
+	raw, envelopeErr := runApplyRealizer(flags, mf, fr, noopEmitter(), "run-2", nil, nil)
+
+	if envelopeErr == nil {
+		t.Fatal("expected envelope error for systemic realizer failure, got nil")
+	}
+	if raw != nil {
+		t.Errorf("expected nil data on systemic error, got %T", raw)
+	}
+	if envelopeErr.Code != envelope.ErrRealizerUnavailable {
+		t.Errorf("envelope error code = %q, want REALIZER_UNAVAILABLE", envelopeErr.Code)
+	}
+	// Raw Nix text must NOT appear in the user-facing message (the moat).
+	if strings.Contains(envelopeErr.Message, rawText) {
+		t.Errorf("raw nix text leaked into envelope Message: %q", envelopeErr.Message)
+	}
+	// Raw text should be confined to Detail.
+	detailMap, ok := envelopeErr.Detail.(map[string]string)
+	if !ok {
+		t.Fatalf("expected detail to be map[string]string, got %T", envelopeErr.Detail)
+	}
+	if detailMap["raw"] != rawText {
+		t.Errorf("detail.raw = %q, want %q", detailMap["raw"], rawText)
+	}
+}
+
+// TestRunApplyRealizer_InstallError: Realize returns a non-systemic install
+// error (ErrInstallFailed, subcode "eval").
+// Expected: nil envelope.Error, result.Summary.Failed==2, actions status
+// "failed"/reason "install_failed", raw Nix text NOT in any action Message.
+func TestRunApplyRealizer_InstallError(t *testing.T) {
+	app1 := nixApp("ripgrep", "nixpkgs#ripgrep")
+	app2 := nixApp("jq", "nixpkgs#jq")
+	mf := nixManifest(app1, app2)
+
+	ins1 := realizer.Installable{ID: "ripgrep", Ref: hostRef(app1)}
+	ins2 := realizer.Installable{ID: "jq", Ref: hostRef(app2)}
+
+	rawNixText := "error: attribute 'ripgrep' missing in flake output"
+	fr := &fakeRealizer{
+		planDiff: realizer.Diff{
+			ToAdd:   []realizer.Installable{ins1, ins2},
+			Present: nil,
+		},
+		realizeResult: realizer.Result{
+			Err: &realizer.Error{
+				Code:    envelope.ErrInstallFailed,
+				Subcode: "eval",
+				Stage:   "eval",
+				Raw:     rawNixText,
+			},
+		},
+	}
+
+	flags := ApplyFlags{Manifest: "nix-test", DryRun: false}
+	raw, envelopeErr := runApplyRealizer(flags, mf, fr, noopEmitter(), "run-3", nil, nil)
+
+	// Non-systemic: envelope error must be nil.
+	if envelopeErr != nil {
+		t.Fatalf("expected nil envelope error for per-item install failure, got: %v", envelopeErr)
+	}
+	if raw == nil {
+		t.Fatal("expected non-nil result for per-item install failure")
+	}
+	result, ok := raw.(*ApplyResult)
+	if !ok {
+		t.Fatalf("expected *ApplyResult, got %T", raw)
+	}
+
+	if result.Summary.Failed != 2 {
+		t.Errorf("Summary.Failed = %d, want 2", result.Summary.Failed)
+	}
+	if result.Summary.Success != 0 {
+		t.Errorf("Summary.Success = %d, want 0", result.Summary.Success)
+	}
+	for _, action := range result.Actions {
+		if action.Status != "failed" {
+			t.Errorf("action %q: Status = %q, want failed", action.ID, action.Status)
+		}
+		if action.Reason != "install_failed" {
+			t.Errorf("action %q: Reason = %q, want install_failed", action.ID, action.Reason)
+		}
+		// Raw Nix text must NOT appear in per-item message (the moat).
+		if strings.Contains(action.Message, rawNixText) {
+			t.Errorf("action %q: raw nix text leaked into Message: %q", action.ID, action.Message)
+		}
+	}
+}
+
+// TestRunApplyRealizer_AllPresent_NoRealize: Plan returns all packages as
+// Present (already installed).
+// Expected: Summary.Skipped==2, Realize is never called.
+func TestRunApplyRealizer_AllPresent_NoRealize(t *testing.T) {
+	app1 := nixApp("ripgrep", "nixpkgs#ripgrep")
+	app2 := nixApp("jq", "nixpkgs#jq")
+	mf := nixManifest(app1, app2)
+
+	ins1 := realizer.Installable{ID: "ripgrep", Ref: hostRef(app1)}
+	ins2 := realizer.Installable{ID: "jq", Ref: hostRef(app2)}
+
+	fr := &fakeRealizer{
+		planDiff: realizer.Diff{
+			Present: []realizer.Installable{ins1, ins2},
+			ToAdd:   nil,
+		},
+	}
+
+	flags := ApplyFlags{Manifest: "nix-test", DryRun: false}
+	raw, envelopeErr := runApplyRealizer(flags, mf, fr, noopEmitter(), "run-4", nil, nil)
+
+	if envelopeErr != nil {
+		t.Fatalf("runApplyRealizer returned envelope error: %v", envelopeErr)
+	}
+	result, ok := raw.(*ApplyResult)
+	if !ok {
+		t.Fatalf("expected *ApplyResult, got %T", raw)
+	}
+
+	if fr.realizeCalls != 0 {
+		t.Errorf("Realize called %d times, want 0 (all present)", fr.realizeCalls)
+	}
+	// Already-present nix packages count as skipped in the apply phase.
+	if result.Summary.Skipped != 2 {
+		t.Errorf("Summary.Skipped = %d, want 2", result.Summary.Skipped)
+	}
+	if result.Summary.Failed != 0 {
+		t.Errorf("Summary.Failed = %d, want 0", result.Summary.Failed)
+	}
+}
+
+// TestRunApplyRealizer_DryRun: DryRun=true means Plan is called but Realize
+// is not, and result.DryRun==true.
+func TestRunApplyRealizer_DryRun(t *testing.T) {
+	app1 := nixApp("ripgrep", "nixpkgs#ripgrep")
+	app2 := nixApp("jq", "nixpkgs#jq")
+	mf := nixManifest(app1, app2)
+
+	ins1 := realizer.Installable{ID: "ripgrep", Ref: hostRef(app1)}
+	ins2 := realizer.Installable{ID: "jq", Ref: hostRef(app2)}
+
+	fr := &fakeRealizer{
+		planDiff: realizer.Diff{
+			ToAdd:   []realizer.Installable{ins1, ins2},
+			Present: nil,
+		},
+	}
+
+	flags := ApplyFlags{Manifest: "nix-test", DryRun: true}
+	raw, envelopeErr := runApplyRealizer(flags, mf, fr, noopEmitter(), "run-dry", nil, nil)
+
+	if envelopeErr != nil {
+		t.Fatalf("runApplyRealizer dry-run returned envelope error: %v", envelopeErr)
+	}
+	result, ok := raw.(*ApplyResult)
+	if !ok {
+		t.Fatalf("expected *ApplyResult, got %T", raw)
+	}
+
+	if !result.DryRun {
+		t.Error("result.DryRun = false, want true")
+	}
+	if fr.planCalls != 1 {
+		t.Errorf("Plan called %d times, want 1", fr.planCalls)
+	}
+	if fr.realizeCalls != 0 {
+		t.Errorf("Realize called %d times in dry-run, want 0", fr.realizeCalls)
+	}
+}
+
+// TestRunApplyRealizer_DryRun_ViaPackageVar: end-to-end test that exercises
+// the newRealizerFn injection path through RunApply, covering the complete
+// wiring from the exported command entry-point.
+func TestRunApplyRealizer_DryRun_ViaPackageVar(t *testing.T) {
+	app1 := nixApp("ripgrep", "nixpkgs#ripgrep")
+	app2 := nixApp("jq", "nixpkgs#jq")
+
+	fr := &fakeRealizer{
+		planDiff: realizer.Diff{
+			ToAdd: []realizer.Installable{
+				{ID: "ripgrep", Ref: hostRef(app1)},
+				{ID: "jq", Ref: hostRef(app2)},
+			},
+		},
+	}
+
+	// Write a temp manifest file so RunApply can load it via loadManifest.
+	tmpDir := t.TempDir()
+	manifestPath := tmpDir + "/nix.jsonc"
+	manifestContent := `{
+		"version": 1,
+		"name": "nix-wiring-test",
+		"apps": [
+			{ "id": "ripgrep", "displayName": "ripgrep", "refs": { "linux": "nixpkgs#ripgrep", "darwin": "nixpkgs#ripgrep" } },
+			{ "id": "jq",      "displayName": "jq",      "refs": { "linux": "nixpkgs#jq",      "darwin": "nixpkgs#jq"      } }
+		]
+	}`
+	if err := os.WriteFile(manifestPath, []byte(manifestContent), 0644); err != nil {
+		t.Fatalf("could not write temp manifest: %v", err)
+	}
+
+	var result *ApplyResult
+	withFakeRealizer(fr, func() {
+		r, err := RunApply(ApplyFlags{
+			Manifest: manifestPath,
+			DryRun:   true,
+		})
+		if err != nil {
+			t.Fatalf("RunApply returned envelope error: %v", err)
+		}
+		result = r.(*ApplyResult)
+	})
+
+	if !result.DryRun {
+		t.Error("result.DryRun = false, want true")
+	}
+	if fr.realizeCalls != 0 {
+		t.Errorf("Realize called %d times in dry-run via RunApply, want 0", fr.realizeCalls)
+	}
+}

--- a/go-engine/internal/commands/capabilities.go
+++ b/go-engine/internal/commands/capabilities.go
@@ -174,5 +174,8 @@ func driversFor(goos string) []string {
 	if d, err := selectBackend(goos); err == nil && d != nil {
 		return []string{d.Name()}
 	}
+	if r, err := selectRealizer(goos); err == nil && r != nil {
+		return []string{r.Name()}
+	}
 	return []string{}
 }

--- a/go-engine/internal/commands/commands_test.go
+++ b/go-engine/internal/commands/commands_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Artexis10/endstate/go-engine/internal/events"
 	"github.com/Artexis10/endstate/go-engine/internal/manifest"
 	"github.com/Artexis10/endstate/go-engine/internal/modules"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
 )
 
 // ---------------------------------------------------------------------------
@@ -111,9 +112,17 @@ func parseEvents(buf *bytes.Buffer) []map[string]interface{} {
 // withMockDriver replaces newDriverFn with one that returns md, calls f, then
 // restores the original factory.
 func withMockDriver(md *mockDriver, f func()) {
-	orig := newDriverFn
+	origDriver := newDriverFn
+	origRealizer := newRealizerFn
 	newDriverFn = func() (driver.Driver, error) { return md, nil }
-	defer func() { newDriverFn = orig }()
+	// Force the per-package driver path the way a no-realizer host (e.g. Windows)
+	// would: without this, the realizer fork in apply/verify/plan takes over on
+	// linux/darwin and these driver-path tests would exercise the wrong backend.
+	newRealizerFn = func() (realizer.Realizer, error) { return nil, ErrNoRealizer }
+	defer func() {
+		newDriverFn = origDriver
+		newRealizerFn = origRealizer
+	}()
 	f()
 }
 
@@ -741,8 +750,8 @@ func TestRunCapabilities_PlatformInfo(t *testing.T) {
 	result, _ := RunCapabilities()
 	data := result.(CapabilitiesData)
 
-	if data.Platform.OS != "windows" {
-		t.Errorf("expected platform.os=%q, got %q", "windows", data.Platform.OS)
+	if data.Platform.OS != runtime.GOOS {
+		t.Errorf("expected platform.os=%q, got %q", runtime.GOOS, data.Platform.OS)
 	}
 	if len(data.Platform.Drivers) == 0 {
 		t.Error("expected at least one driver in platform.drivers")

--- a/go-engine/internal/commands/doctor_test.go
+++ b/go-engine/internal/commands/doctor_test.go
@@ -6,6 +6,7 @@ package commands
 import (
 	"context"
 	"os/exec"
+	"runtime"
 	"testing"
 )
 
@@ -104,8 +105,12 @@ func TestCheckWinget_WithMockSuccess(t *testing.T) {
 
 	// Mock ExecCommandContext to simulate winget --version returning "v1.9.0"
 	ExecCommandContext = func(ctx context.Context, name string, args ...string) *exec.Cmd {
-		// Use "echo" to simulate winget output
-		return exec.CommandContext(ctx, "cmd", "/C", "echo v1.9.0")
+		// Simulate winget --version output with a host-appropriate shell so the
+		// doctor's parsing logic is exercised on Windows AND Linux/macOS CI.
+		if runtime.GOOS == "windows" {
+			return exec.CommandContext(ctx, "cmd", "/C", "echo v1.9.0")
+		}
+		return exec.CommandContext(ctx, "sh", "-c", "echo v1.9.0")
 	}
 
 	checks := checkWinget()

--- a/go-engine/internal/commands/plan.go
+++ b/go-engine/internal/commands/plan.go
@@ -46,6 +46,13 @@ func RunPlan(flags PlanFlags) (interface{}, *envelope.Error) {
 		return nil, envelopeErr
 	}
 
+	// --- 2a. Realizer path (whole-set, e.g. Nix on linux/darwin) ---
+	// On Windows newRealizerFn returns ErrNoRealizer and control falls through to
+	// the winget driver plan below, byte-identical to prior behavior.
+	if rz, rerr := newRealizerFn(); rerr == nil {
+		return runPlanRealizer(flags, mf, rz, emitter)
+	}
+
 	// --- 2. Create driver and compute plan ---
 	d, derr := newDriverFn()
 	if derr != nil {

--- a/go-engine/internal/commands/select.go
+++ b/go-engine/internal/commands/select.go
@@ -8,12 +8,19 @@ import (
 
 	"github.com/Artexis10/endstate/go-engine/internal/driver"
 	"github.com/Artexis10/endstate/go-engine/internal/driver/winget"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer/nix"
 )
 
 // ErrNoBackend indicates that no package backend is implemented for the host
 // operating system. Non-Windows hosts return this until a platform backend
 // (e.g. a Nix realizer) is added.
 var ErrNoBackend = errors.New("no package backend available for this platform")
+
+// ErrNoRealizer indicates that no whole-set package realizer is implemented for
+// the host operating system. Windows returns this (it uses the per-package
+// winget driver via selectBackend instead).
+var ErrNoRealizer = errors.New("no package realizer available for this platform")
 
 // selectBackend returns the package-manager driver for the given OS. Windows
 // uses the winget driver; other platforms have no backend yet and return
@@ -24,5 +31,22 @@ func selectBackend(goos string) (driver.Driver, error) {
 		return winget.New(), nil
 	default:
 		return nil, ErrNoBackend
+	}
+}
+
+// selectRealizer returns the whole-set package realizer for the given OS. Linux
+// and macOS use the Nix realizer; other platforms (Windows) have no realizer and
+// return ErrNoRealizer, so callers fall back to the per-package driver path.
+//
+// selectBackend and selectRealizer are siblings: on any host at most one
+// succeeds. The realizer is deliberately NOT a driver.Driver (the whole-set,
+// atomic-generation model is kept beside the per-package Driver, not shoehorned
+// into Driver.Install).
+func selectRealizer(goos string) (realizer.Realizer, error) {
+	switch goos {
+	case "linux", "darwin":
+		return nix.New(), nil
+	default:
+		return nil, ErrNoRealizer
 	}
 }

--- a/go-engine/internal/commands/select_realizer_test.go
+++ b/go-engine/internal/commands/select_realizer_test.go
@@ -1,0 +1,183 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/driver"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+// ---------------------------------------------------------------------------
+// Selection matrix — selectBackend / selectRealizer / driversFor
+// ---------------------------------------------------------------------------
+
+func TestSelectRealizer_LinuxReturnsNix(t *testing.T) {
+	r, err := selectRealizer("linux")
+	if err != nil {
+		t.Fatalf("selectRealizer(linux) error = %v, want nil", err)
+	}
+	if r == nil {
+		t.Fatal("selectRealizer(linux) realizer = nil, want non-nil")
+	}
+	if r.Name() != "nix" {
+		t.Errorf("selectRealizer(linux).Name() = %q, want nix", r.Name())
+	}
+}
+
+func TestSelectRealizer_DarwinReturnsNix(t *testing.T) {
+	r, err := selectRealizer("darwin")
+	if err != nil {
+		t.Fatalf("selectRealizer(darwin) error = %v, want nil", err)
+	}
+	if r == nil {
+		t.Fatal("selectRealizer(darwin) realizer = nil, want non-nil")
+	}
+	if r.Name() != "nix" {
+		t.Errorf("selectRealizer(darwin).Name() = %q, want nix", r.Name())
+	}
+}
+
+func TestSelectRealizer_WindowsReturnsErrNoRealizer(t *testing.T) {
+	r, err := selectRealizer("windows")
+	if !errors.Is(err, ErrNoRealizer) {
+		t.Errorf("selectRealizer(windows) error = %v, want ErrNoRealizer", err)
+	}
+	if r != nil {
+		t.Errorf("selectRealizer(windows) realizer = %v, want nil", r)
+	}
+}
+
+func TestSelectRealizer_Plan9ReturnsErrNoRealizer(t *testing.T) {
+	r, err := selectRealizer("plan9")
+	if !errors.Is(err, ErrNoRealizer) {
+		t.Errorf("selectRealizer(plan9) error = %v, want ErrNoRealizer", err)
+	}
+	if r != nil {
+		t.Errorf("selectRealizer(plan9) realizer = %v, want nil", r)
+	}
+}
+
+func TestSelectBackend_LinuxReturnsErrNoBackend(t *testing.T) {
+	d, err := selectBackend("linux")
+	if !errors.Is(err, ErrNoBackend) {
+		t.Errorf("selectBackend(linux) error = %v, want ErrNoBackend", err)
+	}
+	if d != nil {
+		t.Errorf("selectBackend(linux) driver = %v, want nil", d)
+	}
+}
+
+func TestSelectBackend_DarwinReturnsErrNoBackend(t *testing.T) {
+	d, err := selectBackend("darwin")
+	if !errors.Is(err, ErrNoBackend) {
+		t.Errorf("selectBackend(darwin) error = %v, want ErrNoBackend", err)
+	}
+	if d != nil {
+		t.Errorf("selectBackend(darwin) driver = %v, want nil", d)
+	}
+}
+
+func TestSelectBackend_Plan9ReturnsErrNoBackend(t *testing.T) {
+	d, err := selectBackend("plan9")
+	if !errors.Is(err, ErrNoBackend) {
+		t.Errorf("selectBackend(plan9) error = %v, want ErrNoBackend", err)
+	}
+	if d != nil {
+		t.Errorf("selectBackend(plan9) driver = %v, want nil", d)
+	}
+}
+
+func TestDriversFor_Windows(t *testing.T) {
+	got := driversFor("windows")
+	if len(got) != 1 {
+		t.Fatalf("driversFor(windows) = %v, want [winget]", got)
+	}
+	if got[0] != "winget" {
+		t.Errorf("driversFor(windows)[0] = %q, want winget", got[0])
+	}
+}
+
+func TestDriversFor_Linux(t *testing.T) {
+	got := driversFor("linux")
+	if len(got) != 1 {
+		t.Fatalf("driversFor(linux) = %v, want [nix]", got)
+	}
+	if got[0] != "nix" {
+		t.Errorf("driversFor(linux)[0] = %q, want nix", got[0])
+	}
+}
+
+func TestDriversFor_Darwin(t *testing.T) {
+	got := driversFor("darwin")
+	if len(got) != 1 {
+		t.Fatalf("driversFor(darwin) = %v, want [nix]", got)
+	}
+	if got[0] != "nix" {
+		t.Errorf("driversFor(darwin)[0] = %q, want nix", got[0])
+	}
+}
+
+func TestDriversFor_Plan9_IsEmpty(t *testing.T) {
+	got := driversFor("plan9")
+	if len(got) != 0 {
+		t.Errorf("driversFor(plan9) = %v, want empty slice", got)
+	}
+}
+
+// TestWingetDriverIsNotRealizer proves that the winget driver does NOT satisfy
+// realizer.Realizer — no Nix concept leaked into the winget type.
+func TestWingetDriverIsNotRealizer(t *testing.T) {
+	d, err := selectBackend("windows")
+	if err != nil {
+		t.Fatalf("selectBackend(windows) error = %v", err)
+	}
+	_, ok := d.(realizer.Realizer)
+	if ok {
+		t.Error("winget driver must NOT implement realizer.Realizer — abstraction leak")
+	}
+}
+
+// TestSelectBackendAndRealizerMutuallyExclusive verifies that for any host
+// exactly one of the two selectors succeeds (or both fail for unknown OS).
+func TestSelectBackendAndRealizerMutuallyExclusive(t *testing.T) {
+	tests := []struct {
+		goos       string
+		backendOK  bool
+		realizerOK bool
+	}{
+		{"windows", true, false},
+		{"linux", false, true},
+		{"darwin", false, true},
+		{"plan9", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.goos, func(t *testing.T) {
+			d, derr := selectBackend(tt.goos)
+			r, rerr := selectRealizer(tt.goos)
+
+			gotBackendOK := derr == nil && d != nil
+			gotRealizerOK := rerr == nil && r != nil
+
+			if gotBackendOK != tt.backendOK {
+				t.Errorf("selectBackend(%s): ok=%v, want %v (err=%v)", tt.goos, gotBackendOK, tt.backendOK, derr)
+			}
+			if gotRealizerOK != tt.realizerOK {
+				t.Errorf("selectRealizer(%s): ok=%v, want %v (err=%v)", tt.goos, gotRealizerOK, tt.realizerOK, rerr)
+			}
+
+			// At most one should succeed simultaneously.
+			if gotBackendOK && gotRealizerOK {
+				t.Errorf("both selectBackend and selectRealizer succeeded for %s — must be mutually exclusive", tt.goos)
+			}
+		})
+	}
+}
+
+// Compile-time check: mockDriver (from commands_test.go) is NOT a Realizer.
+// This keeps the package-level "winget ≠ realizer" invariant honest in tests too.
+var _ driver.Driver = (*mockDriver)(nil)

--- a/go-engine/internal/commands/testdata/manual-and-winget.jsonc
+++ b/go-engine/internal/commands/testdata/manual-and-winget.jsonc
@@ -12,7 +12,7 @@
     {
       "id": "adobe-lightroom",
       "manual": {
-        "verifyPath": "%MANUAL_TEST_DIR%\\lightroom.exe",
+        "verifyPath": "$MANUAL_TEST_DIR/lightroom.exe",
         "launch": "https://example.com/lightroom",
         "instructions": "Install via Adobe Creative Cloud."
       }

--- a/go-engine/internal/commands/testdata/manual-app.jsonc
+++ b/go-engine/internal/commands/testdata/manual-app.jsonc
@@ -6,7 +6,7 @@
     {
       "id": "adobe-lightroom",
       "manual": {
-        "verifyPath": "%MANUAL_TEST_DIR%\\lightroom.exe",
+        "verifyPath": "$MANUAL_TEST_DIR/lightroom.exe",
         "launch": "https://example.com/lightroom",
         "instructions": "Install via Adobe Creative Cloud."
       }

--- a/go-engine/internal/commands/testdata/nix-two-apps.jsonc
+++ b/go-engine/internal/commands/testdata/nix-two-apps.jsonc
@@ -1,0 +1,24 @@
+{
+  // Fixture manifest for realizer tests — two apps with linux AND darwin refs
+  // so the same fixture works on any POSIX host running `go test`.
+  "version": 1,
+  "name": "nix-test-manifest",
+  "apps": [
+    {
+      "id": "ripgrep",
+      "displayName": "ripgrep",
+      "refs": {
+        "linux": "nixpkgs#ripgrep",
+        "darwin": "nixpkgs#ripgrep"
+      }
+    },
+    {
+      "id": "jq",
+      "displayName": "jq",
+      "refs": {
+        "linux": "nixpkgs#jq",
+        "darwin": "nixpkgs#jq"
+      }
+    }
+  ]
+}

--- a/go-engine/internal/commands/verify.go
+++ b/go-engine/internal/commands/verify.go
@@ -16,6 +16,7 @@ import (
 	"github.com/Artexis10/endstate/go-engine/internal/events"
 	"github.com/Artexis10/endstate/go-engine/internal/manifest"
 	"github.com/Artexis10/endstate/go-engine/internal/modules"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
 	"github.com/Artexis10/endstate/go-engine/internal/verifier"
 )
 
@@ -25,6 +26,15 @@ import (
 // host OS (non-Windows, until a platform backend is added).
 var newDriverFn func() (driver.Driver, error) = func() (driver.Driver, error) {
 	return selectBackend(runtime.GOOS)
+}
+
+// newRealizerFn is the factory for the host's whole-set package realizer (Nix on
+// linux/darwin). It defaults to selectRealizer(runtime.GOOS) and can be replaced
+// in tests to inject a fake. It returns ErrNoRealizer when the host has no
+// realizer (e.g. Windows, which uses newDriverFn instead). Shared by apply/
+// verify/plan so exactly one of newDriverFn/newRealizerFn drives a given host.
+var newRealizerFn func() (realizer.Realizer, error) = func() (realizer.Realizer, error) {
+	return selectRealizer(runtime.GOOS)
 }
 
 // VerifyFlags holds the parsed CLI flags for the verify command.
@@ -101,6 +111,13 @@ func RunVerify(flags VerifyFlags) (interface{}, *envelope.Error) {
 		if catalogErr == nil && len(catalog) > 0 {
 			modules.SynthesizeAppsFromModules(mf, catalog)
 		}
+	}
+
+	// --- 2a. Realizer path (whole-set, e.g. Nix on linux/darwin) ---
+	// On Windows newRealizerFn returns ErrNoRealizer and control falls through to
+	// the winget driver detect loop below, byte-identical to prior behavior.
+	if rz, rerr := newRealizerFn(); rerr == nil {
+		return runVerifyRealizer(flags, mf, rz, emitter)
 	}
 
 	// --- 2. Create driver (platform-selected backend) ---

--- a/go-engine/internal/commands/verify_plan_realizer.go
+++ b/go-engine/internal/commands/verify_plan_realizer.go
@@ -1,0 +1,136 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/events"
+	"github.com/Artexis10/endstate/go-engine/internal/manifest"
+	"github.com/Artexis10/endstate/go-engine/internal/planner"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+	"github.com/Artexis10/endstate/go-engine/internal/verifier"
+)
+
+// runVerifyRealizer is the verify path for a realizer backend (Nix). It reads
+// the current generation once and reports each host package present/missing,
+// preserving the per-item event stream. Verify is read-only (verification-first
+// invariant) and does not touch configs.
+func runVerifyRealizer(flags VerifyFlags, mf *manifest.Manifest, r realizer.Realizer, emitter *events.Emitter) (interface{}, *envelope.Error) {
+	driverName := r.Name()
+	emitter.EmitPhase("verify")
+
+	cur, cerr := r.Current()
+	if cerr != nil {
+		if rerr, ok := cerr.(*realizer.Error); ok && isSystemic(rerr.Code) {
+			return nil, realizerEnvelopeError(rerr)
+		}
+		// Non-systemic read issue: treat as empty (apps report missing).
+	}
+
+	var results []VerifyItem
+	pass, fail := 0, 0
+	for _, app := range mf.Apps {
+		ref := app.Refs[runtime.GOOS] // strict host ref
+		name := realizerItemName(app)
+		switch {
+		case ref != "":
+			item := VerifyItem{Type: "app", ID: app.ID, Ref: ref, Name: name}
+			if presentInSet(cur, ref) {
+				item.Status = "pass"
+				emitter.EmitItem(ref, driverName, "present", "", "Verified installed", name)
+				pass++
+			} else {
+				item.Status, item.Reason, item.Message = "fail", "missing", "Missing - not installed"
+				emitter.EmitItem(ref, driverName, "failed", "missing", item.Message, name)
+				fail++
+			}
+			results = append(results, item)
+		case app.Manual != nil && app.Manual.VerifyPath != "":
+			expanded, exists := checkVerifyPath(app.Manual.VerifyPath)
+			item := VerifyItem{Type: "app", ID: app.ID, Name: name}
+			if exists {
+				item.Status, item.Message = "pass", fmt.Sprintf("Verified at %s", expanded)
+				emitter.EmitItem(app.ID, "manual", "present", "", item.Message, name)
+				pass++
+			} else {
+				item.Status, item.Reason, item.Message = "fail", "missing", fmt.Sprintf("Missing at %s", expanded)
+				emitter.EmitItem(app.ID, "manual", "failed", "missing", item.Message, name)
+				fail++
+			}
+			results = append(results, item)
+		}
+	}
+
+	// Manifest verify entries run through the same verifier dispatcher.
+	if len(mf.Verify) > 0 {
+		for _, vr := range verifier.RunVerify(mf.Verify) {
+			item := VerifyItem{Type: vr.Type, Status: "fail", Message: vr.Message}
+			if vr.Pass {
+				item.Status = "pass"
+				pass++
+			} else {
+				fail++
+			}
+			results = append(results, item)
+		}
+	}
+
+	total := pass + fail
+	emitter.EmitSummary("verify", total, pass, 0, fail)
+	return &VerifyResult{
+		Manifest: VerifyManifestRef{Path: flags.Manifest, Name: mf.Name},
+		Summary:  VerifySummary{Total: total, Pass: pass, Fail: fail},
+		Results:  results,
+	}, nil
+}
+
+// runPlanRealizer is the plan (read-only preview) path for a realizer backend.
+// It computes one whole-set diff and reports it as planner actions.
+func runPlanRealizer(flags PlanFlags, mf *manifest.Manifest, r realizer.Realizer, emitter *events.Emitter) (interface{}, *envelope.Error) {
+	driverName := r.Name()
+	emitter.EmitPhase("plan")
+
+	var desired []realizer.Installable
+	nameByID := map[string]string{}
+	for _, app := range mf.Apps {
+		ref := app.Refs[runtime.GOOS]
+		if ref == "" {
+			continue
+		}
+		desired = append(desired, realizer.Installable{ID: app.ID, Ref: ref})
+		nameByID[app.ID] = realizerItemName(app)
+	}
+
+	diff, perr := r.Plan(desired)
+	if perr != nil {
+		if rerr, ok := perr.(*realizer.Error); ok && isSystemic(rerr.Code) {
+			return nil, realizerEnvelopeError(rerr)
+		}
+		return nil, envelope.NewError(envelope.ErrInternalError, "Failed to plan the package set.")
+	}
+
+	var actions []planner.PlanAction
+	toInstall, present := 0, 0
+	for _, ins := range diff.Present {
+		actions = append(actions, planner.PlanAction{Type: "app", ID: ins.ID, Ref: ins.Ref, Driver: driverName, CurrentStatus: "present", PlannedAction: "none", DisplayName: nameByID[ins.ID]})
+		emitter.EmitItem(ins.Ref, driverName, "present", "", "none", nameByID[ins.ID])
+		present++
+	}
+	for _, ins := range diff.ToAdd {
+		actions = append(actions, planner.PlanAction{Type: "app", ID: ins.ID, Ref: ins.Ref, Driver: driverName, CurrentStatus: "missing", PlannedAction: "install", DisplayName: nameByID[ins.ID]})
+		emitter.EmitItem(ins.Ref, driverName, "missing", "", "install", nameByID[ins.ID])
+		toInstall++
+	}
+
+	total := present + toInstall
+	emitter.EmitSummary("plan", total, present, 0, toInstall)
+	return &PlanResult{
+		Manifest: PlanManifestRef{Path: flags.Manifest, Name: mf.Name},
+		Plan:     planner.PlanSummary{Total: total, ToInstall: toInstall, AlreadyPresent: present},
+		Actions:  actions,
+	}, nil
+}

--- a/go-engine/internal/commands/verify_plan_realizer_test.go
+++ b/go-engine/internal/commands/verify_plan_realizer_test.go
@@ -7,7 +7,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/Artexis10/endstate/go-engine/internal/manifest"
 	"github.com/Artexis10/endstate/go-engine/internal/realizer"
 )
 
@@ -20,27 +19,9 @@ import (
 // Expected: Summary.Pass==1 (ripgrep present), Summary.Fail==1 (missingpkg
 // absent).
 func TestRunVerifyRealizer_PresentAndMissing(t *testing.T) {
-	appPresent := manifest.App{
-		ID:          "ripgrep",
-		DisplayName: "ripgrep",
-		Refs: map[string]string{
-			"linux":  "nixpkgs#ripgrep",
-			"darwin": "nixpkgs#ripgrep",
-		},
-	}
-	appMissing := manifest.App{
-		ID:          "missingpkg",
-		DisplayName: "missingpkg",
-		Refs: map[string]string{
-			"linux":  "nixpkgs#missingpkg",
-			"darwin": "nixpkgs#missingpkg",
-		},
-	}
-	mf := &manifest.Manifest{
-		Version: 1,
-		Name:    "verify-test",
-		Apps:    []manifest.App{appPresent, appMissing},
-	}
+	appPresent := nixApp("ripgrep", "nixpkgs#ripgrep")
+	appMissing := nixApp("missingpkg", "nixpkgs#missingpkg")
+	mf := nixManifest(appPresent, appMissing)
 
 	fr := &fakeRealizer{
 		currentSet: realizer.Set{
@@ -156,14 +137,9 @@ func TestRunVerifyRealizer_CurrentOnlyCalledOnce(t *testing.T) {
 // TestRunVerifyRealizer_SkipsAppsWithNoHostRef: An app with refs only for
 // "windows" should be silently skipped on linux/darwin.
 func TestRunVerifyRealizer_SkipsAppsWithNoHostRef(t *testing.T) {
-	windowsOnlyApp := manifest.App{
-		ID: "vscode",
-		Refs: map[string]string{
-			"windows": "Microsoft.VisualStudioCode",
-		},
-	}
+	noHostApp := foreignRefApp("vscode", "Some.Pkg")
 	nixApp1 := nixApp("ripgrep", "nixpkgs#ripgrep")
-	mf := nixManifest(windowsOnlyApp, nixApp1)
+	mf := nixManifest(noHostApp, nixApp1)
 
 	fr := &fakeRealizer{
 		currentSet: realizer.Set{
@@ -339,14 +315,9 @@ func TestRunPlanRealizer_PlanOnlyCalledOnce(t *testing.T) {
 // TestRunPlanRealizer_SkipsAppsWithNoHostRef: Apps without a ref for the
 // current GOOS are excluded from the planned installables.
 func TestRunPlanRealizer_SkipsAppsWithNoHostRef(t *testing.T) {
-	windowsOnlyApp := manifest.App{
-		ID: "vscode",
-		Refs: map[string]string{
-			"windows": "Microsoft.VisualStudioCode",
-		},
-	}
+	noHostApp := foreignRefApp("vscode", "Some.Pkg")
 	nixApp1 := nixApp("ripgrep", "nixpkgs#ripgrep")
-	mf := nixManifest(windowsOnlyApp, nixApp1)
+	mf := nixManifest(noHostApp, nixApp1)
 
 	fr := &fakeRealizer{
 		planDiff: realizer.Diff{

--- a/go-engine/internal/commands/verify_plan_realizer_test.go
+++ b/go-engine/internal/commands/verify_plan_realizer_test.go
@@ -1,0 +1,395 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/manifest"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+// ---------------------------------------------------------------------------
+// runVerifyRealizer tests
+// ---------------------------------------------------------------------------
+
+// TestRunVerifyRealizer_PresentAndMissing: Current() returns a Set containing
+// element "ripgrep" but not "missingpkg".
+// Expected: Summary.Pass==1 (ripgrep present), Summary.Fail==1 (missingpkg
+// absent).
+func TestRunVerifyRealizer_PresentAndMissing(t *testing.T) {
+	appPresent := manifest.App{
+		ID:          "ripgrep",
+		DisplayName: "ripgrep",
+		Refs: map[string]string{
+			"linux":  "nixpkgs#ripgrep",
+			"darwin": "nixpkgs#ripgrep",
+		},
+	}
+	appMissing := manifest.App{
+		ID:          "missingpkg",
+		DisplayName: "missingpkg",
+		Refs: map[string]string{
+			"linux":  "nixpkgs#missingpkg",
+			"darwin": "nixpkgs#missingpkg",
+		},
+	}
+	mf := &manifest.Manifest{
+		Version: 1,
+		Name:    "verify-test",
+		Apps:    []manifest.App{appPresent, appMissing},
+	}
+
+	fr := &fakeRealizer{
+		currentSet: realizer.Set{
+			Generation: 5,
+			Elements: map[string]realizer.Element{
+				"ripgrep": {Name: "ripgrep", AttrPath: "ripgrep"},
+				// "missingpkg" is intentionally absent
+			},
+		},
+	}
+
+	flags := VerifyFlags{Manifest: "verify-test"}
+	raw, envelopeErr := runVerifyRealizer(flags, mf, fr, noopEmitter())
+
+	if envelopeErr != nil {
+		t.Fatalf("runVerifyRealizer returned envelope error: %v", envelopeErr)
+	}
+	vr, ok := raw.(*VerifyResult)
+	if !ok {
+		t.Fatalf("expected *VerifyResult, got %T", raw)
+	}
+
+	if vr.Summary.Pass != 1 {
+		t.Errorf("Summary.Pass = %d, want 1", vr.Summary.Pass)
+	}
+	if vr.Summary.Fail != 1 {
+		t.Errorf("Summary.Fail = %d, want 1", vr.Summary.Fail)
+	}
+	if vr.Summary.Total != 2 {
+		t.Errorf("Summary.Total = %d, want 2", vr.Summary.Total)
+	}
+
+	// Find each item by ID and verify its status.
+	byID := make(map[string]VerifyItem, len(vr.Results))
+	for _, item := range vr.Results {
+		byID[item.ID] = item
+	}
+
+	if item, found := byID["ripgrep"]; !found {
+		t.Error("expected result item for ripgrep, not found")
+	} else if item.Status != "pass" {
+		t.Errorf("ripgrep status = %q, want pass", item.Status)
+	}
+
+	if item, found := byID["missingpkg"]; !found {
+		t.Error("expected result item for missingpkg, not found")
+	} else if item.Status != "fail" {
+		t.Errorf("missingpkg status = %q, want fail", item.Status)
+	}
+}
+
+// TestRunVerifyRealizer_AllPresent: Current() returns both elements.
+// Expected: Summary.Pass==2, Summary.Fail==0.
+func TestRunVerifyRealizer_AllPresent(t *testing.T) {
+	app1 := nixApp("ripgrep", "nixpkgs#ripgrep")
+	app2 := nixApp("jq", "nixpkgs#jq")
+	mf := nixManifest(app1, app2)
+
+	fr := &fakeRealizer{
+		currentSet: realizer.Set{
+			Generation: 3,
+			Elements: map[string]realizer.Element{
+				"ripgrep": {Name: "ripgrep", AttrPath: "ripgrep"},
+				"jq":      {Name: "jq", AttrPath: "jq"},
+			},
+		},
+	}
+
+	flags := VerifyFlags{Manifest: "verify-all-present"}
+	raw, envelopeErr := runVerifyRealizer(flags, mf, fr, noopEmitter())
+
+	if envelopeErr != nil {
+		t.Fatalf("runVerifyRealizer returned envelope error: %v", envelopeErr)
+	}
+	vr := raw.(*VerifyResult)
+
+	if vr.Summary.Pass != 2 {
+		t.Errorf("Summary.Pass = %d, want 2", vr.Summary.Pass)
+	}
+	if vr.Summary.Fail != 0 {
+		t.Errorf("Summary.Fail = %d, want 0", vr.Summary.Fail)
+	}
+}
+
+// TestRunVerifyRealizer_CurrentOnlyCalledOnce: Current() should be called
+// exactly once per verify run (read-only; no mutations).
+func TestRunVerifyRealizer_CurrentOnlyCalledOnce(t *testing.T) {
+	app1 := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := nixManifest(app1)
+
+	fr := &fakeRealizer{
+		currentSet: realizer.Set{
+			Elements: map[string]realizer.Element{
+				"ripgrep": {Name: "ripgrep", AttrPath: "ripgrep"},
+			},
+		},
+	}
+
+	flags := VerifyFlags{Manifest: "verify-once"}
+	_, _ = runVerifyRealizer(flags, mf, fr, noopEmitter())
+
+	if fr.currentCalls != 1 {
+		t.Errorf("Current() called %d times, want exactly 1", fr.currentCalls)
+	}
+	if fr.planCalls != 0 {
+		t.Errorf("Plan() called %d times in verify, want 0", fr.planCalls)
+	}
+	if fr.realizeCalls != 0 {
+		t.Errorf("Realize() called %d times in verify, want 0", fr.realizeCalls)
+	}
+}
+
+// TestRunVerifyRealizer_SkipsAppsWithNoHostRef: An app with refs only for
+// "windows" should be silently skipped on linux/darwin.
+func TestRunVerifyRealizer_SkipsAppsWithNoHostRef(t *testing.T) {
+	windowsOnlyApp := manifest.App{
+		ID: "vscode",
+		Refs: map[string]string{
+			"windows": "Microsoft.VisualStudioCode",
+		},
+	}
+	nixApp1 := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := nixManifest(windowsOnlyApp, nixApp1)
+
+	fr := &fakeRealizer{
+		currentSet: realizer.Set{
+			Elements: map[string]realizer.Element{
+				"ripgrep": {Name: "ripgrep", AttrPath: "ripgrep"},
+			},
+		},
+	}
+
+	flags := VerifyFlags{Manifest: "verify-skip-windows"}
+	raw, envelopeErr := runVerifyRealizer(flags, mf, fr, noopEmitter())
+
+	if envelopeErr != nil {
+		t.Fatalf("runVerifyRealizer returned envelope error: %v", envelopeErr)
+	}
+	vr := raw.(*VerifyResult)
+
+	// Only ripgrep should appear — windows-only app is skipped.
+	if vr.Summary.Total != 1 {
+		t.Errorf("Summary.Total = %d, want 1 (windows-only app must be skipped)", vr.Summary.Total)
+	}
+	if vr.Summary.Pass != 1 {
+		t.Errorf("Summary.Pass = %d, want 1", vr.Summary.Pass)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// runPlanRealizer tests
+// ---------------------------------------------------------------------------
+
+// TestRunPlanRealizer_PresentAndToAdd: Plan returns 1 Present + 1 ToAdd.
+// Expected: Plan.AlreadyPresent==1, Plan.ToInstall==1, actions with
+// currentStatus "present"/"missing" respectively.
+func TestRunPlanRealizer_PresentAndToAdd(t *testing.T) {
+	app1 := nixApp("ripgrep", "nixpkgs#ripgrep")
+	app2 := nixApp("jq", "nixpkgs#jq")
+	mf := nixManifest(app1, app2)
+
+	ins1 := realizer.Installable{ID: "ripgrep", Ref: hostRef(app1)}
+	ins2 := realizer.Installable{ID: "jq", Ref: hostRef(app2)}
+
+	fr := &fakeRealizer{
+		planDiff: realizer.Diff{
+			Present: []realizer.Installable{ins1},
+			ToAdd:   []realizer.Installable{ins2},
+		},
+	}
+
+	flags := PlanFlags{Manifest: "plan-test"}
+	raw, envelopeErr := runPlanRealizer(flags, mf, fr, noopEmitter())
+
+	if envelopeErr != nil {
+		t.Fatalf("runPlanRealizer returned envelope error: %v", envelopeErr)
+	}
+	pr, ok := raw.(*PlanResult)
+	if !ok {
+		t.Fatalf("expected *PlanResult, got %T", raw)
+	}
+
+	if pr.Plan.AlreadyPresent != 1 {
+		t.Errorf("Plan.AlreadyPresent = %d, want 1", pr.Plan.AlreadyPresent)
+	}
+	if pr.Plan.ToInstall != 1 {
+		t.Errorf("Plan.ToInstall = %d, want 1", pr.Plan.ToInstall)
+	}
+	if pr.Plan.Total != 2 {
+		t.Errorf("Plan.Total = %d, want 2", pr.Plan.Total)
+	}
+
+	// Check per-action currentStatus.
+	byID := make(map[string]string, len(pr.Actions))
+	for _, a := range pr.Actions {
+		byID[a.ID] = a.CurrentStatus
+	}
+
+	if status, found := byID["ripgrep"]; !found {
+		t.Error("expected plan action for ripgrep")
+	} else if status != "present" {
+		t.Errorf("ripgrep currentStatus = %q, want present", status)
+	}
+
+	if status, found := byID["jq"]; !found {
+		t.Error("expected plan action for jq")
+	} else if status != "missing" {
+		t.Errorf("jq currentStatus = %q, want missing", status)
+	}
+}
+
+// TestRunPlanRealizer_AllPresent: Plan returns everything as Present.
+// Expected: ToInstall==0, AlreadyPresent==2.
+func TestRunPlanRealizer_AllPresent(t *testing.T) {
+	app1 := nixApp("ripgrep", "nixpkgs#ripgrep")
+	app2 := nixApp("jq", "nixpkgs#jq")
+	mf := nixManifest(app1, app2)
+
+	ins1 := realizer.Installable{ID: "ripgrep", Ref: hostRef(app1)}
+	ins2 := realizer.Installable{ID: "jq", Ref: hostRef(app2)}
+
+	fr := &fakeRealizer{
+		planDiff: realizer.Diff{
+			Present: []realizer.Installable{ins1, ins2},
+			ToAdd:   nil,
+		},
+	}
+
+	flags := PlanFlags{Manifest: "plan-all-present"}
+	raw, _ := runPlanRealizer(flags, mf, fr, noopEmitter())
+	pr := raw.(*PlanResult)
+
+	if pr.Plan.AlreadyPresent != 2 {
+		t.Errorf("Plan.AlreadyPresent = %d, want 2", pr.Plan.AlreadyPresent)
+	}
+	if pr.Plan.ToInstall != 0 {
+		t.Errorf("Plan.ToInstall = %d, want 0", pr.Plan.ToInstall)
+	}
+}
+
+// TestRunPlanRealizer_AllToAdd: Plan returns everything as ToAdd.
+// Expected: ToInstall==2, AlreadyPresent==0.
+func TestRunPlanRealizer_AllToAdd(t *testing.T) {
+	app1 := nixApp("ripgrep", "nixpkgs#ripgrep")
+	app2 := nixApp("jq", "nixpkgs#jq")
+	mf := nixManifest(app1, app2)
+
+	ins1 := realizer.Installable{ID: "ripgrep", Ref: hostRef(app1)}
+	ins2 := realizer.Installable{ID: "jq", Ref: hostRef(app2)}
+
+	fr := &fakeRealizer{
+		planDiff: realizer.Diff{
+			ToAdd:   []realizer.Installable{ins1, ins2},
+			Present: nil,
+		},
+	}
+
+	flags := PlanFlags{Manifest: "plan-all-toadd"}
+	raw, _ := runPlanRealizer(flags, mf, fr, noopEmitter())
+	pr := raw.(*PlanResult)
+
+	if pr.Plan.ToInstall != 2 {
+		t.Errorf("Plan.ToInstall = %d, want 2", pr.Plan.ToInstall)
+	}
+	if pr.Plan.AlreadyPresent != 0 {
+		t.Errorf("Plan.AlreadyPresent = %d, want 0", pr.Plan.AlreadyPresent)
+	}
+}
+
+// TestRunPlanRealizer_PlanOnlyCalledOnce: Plan() is called exactly once and
+// Realize is never called (plan is read-only).
+func TestRunPlanRealizer_PlanOnlyCalledOnce(t *testing.T) {
+	app1 := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := nixManifest(app1)
+
+	fr := &fakeRealizer{
+		planDiff: realizer.Diff{
+			Present: []realizer.Installable{{ID: "ripgrep", Ref: hostRef(app1)}},
+		},
+	}
+
+	flags := PlanFlags{Manifest: "plan-calls"}
+	_, _ = runPlanRealizer(flags, mf, fr, noopEmitter())
+
+	if fr.planCalls != 1 {
+		t.Errorf("Plan() called %d times, want 1", fr.planCalls)
+	}
+	if fr.realizeCalls != 0 {
+		t.Errorf("Realize() called %d times in plan, want 0", fr.realizeCalls)
+	}
+	if fr.currentCalls != 0 {
+		t.Errorf("Current() called %d times in plan, want 0", fr.currentCalls)
+	}
+}
+
+// TestRunPlanRealizer_SkipsAppsWithNoHostRef: Apps without a ref for the
+// current GOOS are excluded from the planned installables.
+func TestRunPlanRealizer_SkipsAppsWithNoHostRef(t *testing.T) {
+	windowsOnlyApp := manifest.App{
+		ID: "vscode",
+		Refs: map[string]string{
+			"windows": "Microsoft.VisualStudioCode",
+		},
+	}
+	nixApp1 := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := nixManifest(windowsOnlyApp, nixApp1)
+
+	fr := &fakeRealizer{
+		planDiff: realizer.Diff{
+			ToAdd: []realizer.Installable{{ID: "ripgrep", Ref: "nixpkgs#ripgrep"}},
+		},
+	}
+
+	flags := PlanFlags{Manifest: "plan-skip-windows"}
+	_, envelopeErr := runPlanRealizer(flags, mf, fr, noopEmitter())
+
+	if envelopeErr != nil {
+		t.Fatalf("runPlanRealizer returned envelope error: %v", envelopeErr)
+	}
+
+	// Plan() should only receive the nix-applicable installable — not the
+	// windows ref.
+	if len(fr.lastPlanArgs) != 1 {
+		t.Errorf("Plan received %d installables, want 1 (windows-only app excluded)", len(fr.lastPlanArgs))
+	}
+	if len(fr.lastPlanArgs) == 1 && fr.lastPlanArgs[0].Ref != nixApp1.Refs[runtime.GOOS] {
+		t.Errorf("Plan installable ref = %q, want %q", fr.lastPlanArgs[0].Ref, nixApp1.Refs[runtime.GOOS])
+	}
+}
+
+// TestRunPlanRealizer_ActionDriver: Each plan action should carry driver="nix".
+func TestRunPlanRealizer_ActionDriver(t *testing.T) {
+	app1 := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := nixManifest(app1)
+
+	fr := &fakeRealizer{
+		planDiff: realizer.Diff{
+			Present: []realizer.Installable{{ID: "ripgrep", Ref: hostRef(app1)}},
+		},
+	}
+
+	flags := PlanFlags{Manifest: "plan-driver"}
+	raw, _ := runPlanRealizer(flags, mf, fr, noopEmitter())
+	pr := raw.(*PlanResult)
+
+	if len(pr.Actions) != 1 {
+		t.Fatalf("expected 1 action, got %d", len(pr.Actions))
+	}
+	if pr.Actions[0].Driver != "nix" {
+		t.Errorf("action Driver = %q, want nix", pr.Actions[0].Driver)
+	}
+}

--- a/go-engine/internal/config/paths_test.go
+++ b/go-engine/internal/config/paths_test.go
@@ -149,10 +149,22 @@ func TestProfileDir_ReturnsNonEmpty(t *testing.T) {
 	if dir == "" {
 		t.Error("expected non-empty profile directory")
 	}
-	if !strings.Contains(dir, "Endstate") {
-		t.Errorf("expected profile dir to contain 'Endstate', got %q", dir)
-	}
-	if !strings.Contains(dir, "Profiles") {
-		t.Errorf("expected profile dir to contain 'Profiles', got %q", dir)
+	// Path conventions are host-specific: Windows uses Documents\Endstate\Profiles;
+	// Linux/macOS follow XDG (~/.local/share/endstate/profiles).
+	if runtime.GOOS == "windows" {
+		if !strings.Contains(dir, "Endstate") {
+			t.Errorf("expected profile dir to contain 'Endstate', got %q", dir)
+		}
+		if !strings.Contains(dir, "Profiles") {
+			t.Errorf("expected profile dir to contain 'Profiles', got %q", dir)
+		}
+	} else {
+		lower := strings.ToLower(dir)
+		if !strings.Contains(lower, "endstate") {
+			t.Errorf("expected profile dir to contain 'endstate', got %q", dir)
+		}
+		if !strings.Contains(lower, "profiles") {
+			t.Errorf("expected profile dir to contain 'profiles', got %q", dir)
+		}
 	}
 }

--- a/go-engine/internal/driver/winget/winget_test.go
+++ b/go-engine/internal/driver/winget/winget_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strconv"
 	"testing"
 
@@ -142,6 +143,9 @@ func TestInstall_AlreadyInstalled(t *testing.T) {
 	// os.Exit propagates the full 32-bit value and exec.ExitError.ExitCode()
 	// recovers it correctly via GetExitCodeProcess. This test is therefore
 	// Windows-only by design; the production target is Windows.
+	if runtime.GOOS != "windows" {
+		t.Skip("HRESULT exit code 0x8A150019 cannot survive POSIX 8-bit exit-code truncation; winget is Windows-only in production")
+	}
 	d := &WingetDriver{ExecCommand: fakeCommand(alreadyInstalledExitCodeSigned, "", "")}
 	result, err := d.Install("Git.Git")
 	if err != nil {

--- a/go-engine/internal/envelope/errors.go
+++ b/go-engine/internal/envelope/errors.go
@@ -15,6 +15,7 @@ const (
 	ErrPlanNotFound           ErrorCode = "PLAN_NOT_FOUND"
 	ErrPlanParseError         ErrorCode = "PLAN_PARSE_ERROR"
 	ErrWingetNotAvailable     ErrorCode = "WINGET_NOT_AVAILABLE"
+	ErrRealizerUnavailable    ErrorCode = "REALIZER_UNAVAILABLE"
 	ErrEngineCLINotFound      ErrorCode = "ENGINE_CLI_NOT_FOUND"
 	ErrCaptureFailed          ErrorCode = "CAPTURE_FAILED"
 	ErrCaptureBlocked         ErrorCode = "CAPTURE_BLOCKED"

--- a/go-engine/internal/modules/catalog_test.go
+++ b/go-engine/internal/modules/catalog_test.go
@@ -6,6 +6,7 @@ package modules
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/Artexis10/endstate/go-engine/internal/manifest"
@@ -494,8 +495,15 @@ func TestMatchModulesForApps_PathExists_WithEnvVar(t *testing.T) {
 
 	t.Setenv("ENDSTATE_PATH_MATCHER_TEST", dir)
 
-	// Use %ENDSTATE_PATH_MATCHER_TEST% which should be expanded.
-	envVarPath := `%ENDSTATE_PATH_MATCHER_TEST%\envtest.cfg`
+	// Use the host-appropriate env var syntax:
+	//   Windows: %VAR%\file  (config.ExpandEnvVars dispatches to ExpandWindowsEnvVars)
+	//   Linux/macOS: $VAR/file  (config.ExpandEnvVars dispatches to os.ExpandEnv)
+	var envVarPath string
+	if runtime.GOOS == "windows" {
+		envVarPath = `%ENDSTATE_PATH_MATCHER_TEST%\envtest.cfg`
+	} else {
+		envVarPath = "$ENDSTATE_PATH_MATCHER_TEST/envtest.cfg"
+	}
 
 	catalog := map[string]*Module{
 		"apps.envtest": {

--- a/go-engine/internal/planner/planner_test.go
+++ b/go-engine/internal/planner/planner_test.go
@@ -5,6 +5,7 @@ package planner
 
 import (
 	"os"
+	"runtime"
 	"testing"
 
 	"github.com/Artexis10/endstate/go-engine/internal/driver"
@@ -455,9 +456,22 @@ func TestComputePlan_FallbackRef(t *testing.T) {
 }
 
 // TestComputePlan_WindowsRefPreferred verifies that when both "windows" and
-// another platform ref exist, "windows" is preferred.
+// "linux" refs exist, the host platform's ref is preferred.
 func TestComputePlan_WindowsRefPreferred(t *testing.T) {
-	drv := &testDriver{installed: map[string]bool{"Win.App": true}}
+	// Determine the expected ref and installed set based on the host platform.
+	// On Windows, refs["windows"] is preferred; on Linux, refs["linux"] is preferred.
+	// On other platforms the fallback to first-non-empty applies.
+	var expectedRef string
+	var installedSet map[string]bool
+	if runtime.GOOS == "windows" {
+		expectedRef = "Win.App"
+		installedSet = map[string]bool{"Win.App": true}
+	} else {
+		expectedRef = "linux-app"
+		installedSet = map[string]bool{"linux-app": true}
+	}
+
+	drv := &testDriver{installed: installedSet}
 
 	mf := &manifest.Manifest{
 		Apps: []manifest.App{
@@ -476,8 +490,8 @@ func TestComputePlan_WindowsRefPreferred(t *testing.T) {
 	if len(plan.Actions) != 1 {
 		t.Fatalf("expected 1 action, got %d", len(plan.Actions))
 	}
-	if plan.Actions[0].Ref != "Win.App" {
-		t.Errorf("expected ref=%q (windows preferred), got %q", "Win.App", plan.Actions[0].Ref)
+	if plan.Actions[0].Ref != expectedRef {
+		t.Errorf("expected ref=%q (host platform preferred), got %q", expectedRef, plan.Actions[0].Ref)
 	}
 }
 
@@ -615,12 +629,22 @@ func TestComputePlan_DualDriver(t *testing.T) {
 }
 
 // TestComputePlan_ManualEnvExpansion verifies that environment variables in
-// verifyPath are expanded correctly.
+// verifyPath are expanded correctly using the host platform's variable syntax.
 func TestComputePlan_ManualEnvExpansion(t *testing.T) {
 	tmpDir := t.TempDir()
 	os.WriteFile(tmpDir+"/expanded.exe", []byte("fake"), 0644)
 
 	t.Setenv("ENDSTATE_MANUAL_TEST_DIR", tmpDir)
+
+	// Use the host-appropriate env var syntax:
+	//   Windows: %VAR%\file  (config.ExpandEnvVars dispatches to ExpandWindowsEnvVars)
+	//   Linux/macOS: $VAR/file  (config.ExpandEnvVars dispatches to os.ExpandEnv)
+	var verifyPath string
+	if runtime.GOOS == "windows" {
+		verifyPath = `%ENDSTATE_MANUAL_TEST_DIR%\expanded.exe`
+	} else {
+		verifyPath = "$ENDSTATE_MANUAL_TEST_DIR/expanded.exe"
+	}
 
 	drv := &testDriver{installed: map[string]bool{}}
 
@@ -629,7 +653,7 @@ func TestComputePlan_ManualEnvExpansion(t *testing.T) {
 			{
 				ID: "env-manual",
 				Manual: &manifest.ManualApp{
-					VerifyPath: "%ENDSTATE_MANUAL_TEST_DIR%\\expanded.exe",
+					VerifyPath: verifyPath,
 				},
 			},
 		},

--- a/go-engine/internal/realizer/nix/classify.go
+++ b/go-engine/internal/realizer/nix/classify.go
@@ -1,0 +1,76 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package nix
+
+import (
+	"strings"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+// anchor maps a stable Nix message-text substring to an engine error class.
+type anchor struct {
+	needle  string // lowercase substring
+	code    envelope.ErrorCode
+	subcode string
+}
+
+// anchorTable carries the TOP-LEVEL error class for the failure classes the
+// validation spike proved are NOT structurally separable (daemon, permission,
+// eval). Every needle is HARVESTED FROM REAL Determinate Nix 3.21.0 output and
+// locked by classify_contract_test.go against captured stderr fixtures — never
+// reasoned (the spike got 0/3 collision anchors right by reasoning). Order
+// matters: most specific / most operator-actionable first.
+var anchorTable = []anchor{
+	{"opening a connection to remote store", envelope.ErrRealizerUnavailable, "daemon"},
+	{"cannot connect to socket", envelope.ErrRealizerUnavailable, "daemon"},
+	{"connection refused", envelope.ErrRealizerUnavailable, "daemon"},
+	{"permission denied", envelope.ErrPermissionDenied, "permission"},
+	{"read-only file system", envelope.ErrPermissionDenied, "permission"},
+	{"does not provide attribute", envelope.ErrInstallFailed, "eval"},
+	{"undefined variable", envelope.ErrInstallFailed, "eval"},
+	{"unable to download", envelope.ErrInstallFailed, "network"},
+	{"http error", envelope.ErrInstallFailed, "network"},
+	{"while fetching", envelope.ErrInstallFailed, "network"},
+	{"couldn't resolve host", envelope.ErrInstallFailed, "network"},
+	{"an existing package already provides the following file", envelope.ErrInstallFailed, "collision"},
+	{"the conflicting packages have a priority of", envelope.ErrInstallFailed, "collision"},
+	{"no space left", envelope.ErrInstallFailed, "store"},
+}
+
+// classify maps a nix invocation outcome to an engine error. It is the SINGLE
+// source of the error code:
+//   - exitCode < 0  -> spawn failure (nix missing/unrunnable) -> REALIZER_UNAVAILABLE
+//   - exit 0 + generation advanced -> success (nil)
+//   - otherwise: anchor table carries the top-level class; structural signals
+//     refine the subcode; unrecognised -> INSTALL_FAILED with raw text retained
+//     in Err.Raw (which only ever lands in envelope error.detail).
+func classify(exitCode int, p parsedLog, generationAdvanced bool) *realizer.Error {
+	raw := strings.Join(p.errorMsgs, "\n")
+
+	if exitCode < 0 {
+		return &realizer.Error{Code: envelope.ErrRealizerUnavailable, Subcode: "spawn", Stage: "spawn", Raw: raw}
+	}
+	if exitCode == 0 && generationAdvanced {
+		return nil
+	}
+
+	for _, a := range anchorTable {
+		if strings.Contains(p.blob, a.needle) {
+			return &realizer.Error{Code: a.code, Subcode: a.subcode, Stage: stageOf(p, generationAdvanced), Raw: raw}
+		}
+	}
+
+	// No anchor matched: fall back to INSTALL_FAILED. Use structural signals for
+	// a best-effort subcode (never for the top-level class).
+	subcode := ""
+	switch {
+	case p.sawBuild() && !generationAdvanced:
+		subcode = "collision"
+	case p.sawDownload() && !p.sawBuild():
+		subcode = "network"
+	}
+	return &realizer.Error{Code: envelope.ErrInstallFailed, Subcode: subcode, Stage: stageOf(p, generationAdvanced), Raw: raw}
+}

--- a/go-engine/internal/realizer/nix/classify_contract_test.go
+++ b/go-engine/internal/realizer/nix/classify_contract_test.go
@@ -1,0 +1,147 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package nix
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// This is the LOCKED ANCHOR CONTRACT TEST. Each fixture is the real error text
+// emitted by Determinate Nix 3.21.0, captured by re-running the spike
+// provocations against live Nix on 2026-05-29 (isolated /tmp profiles,
+// --log-format internal-json). The spike's #1 lesson: reasoned anchors are
+// wrong (it guessed 0/3 collision anchors right). These assertions fail loudly
+// if the anchor table drifts from real output or a Nix upgrade rewords a
+// message — re-harvest and re-lock when that happens.
+
+// mkStderr builds an internal-json (`@nix {...}`) stderr blob from msg events
+// (level + text) and started activity types, the way real `nix --log-format
+// internal-json` emits them.
+func mkStderr(msgs []struct {
+	level int
+	text  string
+}, acts []int) []byte {
+	var b strings.Builder
+	for _, a := range acts {
+		line, _ := json.Marshal(map[string]any{"action": "start", "type": a})
+		b.WriteString("@nix ")
+		b.Write(line)
+		b.WriteByte('\n')
+	}
+	for _, m := range msgs {
+		line, _ := json.Marshal(map[string]any{"action": "msg", "level": m.level, "msg": m.text})
+		b.WriteString("@nix ")
+		b.Write(line)
+		b.WriteByte('\n')
+	}
+	return []byte(b.String())
+}
+
+func TestClassify_AnchorContract(t *testing.T) {
+	type msg = struct {
+		level int
+		text  string
+	}
+	cases := []struct {
+		name     string
+		exit     int
+		advanced bool
+		acts     []int // started activity types
+		msgs     []msg
+		wantCode envelope.ErrorCode
+		wantSub  string
+	}{
+		{
+			name: "eval-bad-attr", exit: 1, advanced: false,
+			msgs:     []msg{{0, "error: flake 'flake:nixpkgs' does not provide attribute 'packages.x86_64-linux.thispackagedoesnotexist12345zz', 'legacyPackages.x86_64-linux.thispackagedoesnotexist12345zz' or 'thispackagedoesnotexist12345zz'"}},
+			wantCode: envelope.ErrInstallFailed, wantSub: "eval",
+		},
+		{
+			name: "network-bad-host", exit: 1, advanced: false,
+			acts:     []int{actFileTransfer, actFileTransfer},
+			msgs:     []msg{{0, "error:\n       … while fetching the input 'github:endstate-spike-nonexistent-org/nonexistent-repo-qpz'\n\n       error: unable to download 'https://api.github.com/repos/endstate-spike-nonexistent-org/nonexistent-repo-qpz/commits/HEAD': HTTP error 404"}},
+			wantCode: envelope.ErrInstallFailed, wantSub: "network",
+		},
+		{
+			name: "daemon-unavailable", exit: 1, advanced: false,
+			msgs: []msg{
+				{1, "warning: cannot fetch global flake registry 'https://install.determinate.systems/flake-registry/stable/flake-registry.json', will use builtin fallback registry: cannot connect to socket at '/nonexistent/spike-store-socket': No such file or directory"},
+				{0, "error: opening a connection to remote store 'unix:///nonexistent/spike-store-socket' previously failed"},
+			},
+			wantCode: envelope.ErrRealizerUnavailable, wantSub: "daemon",
+		},
+		{
+			// Permission failure surfaces AFTER a successful build, at the commit
+			// step — structurally identical to a build/collision failure (build
+			// ran, generation did not advance). The msg anchor MUST win over the
+			// structural collision guess. This is the spike's YELLOW case.
+			name: "permission-readonly", exit: 1, advanced: false,
+			acts:     []int{actRealise, actBuilds, actCopyPathsType()},
+			msgs:     []msg{{0, "error: creating symlink \"/tmp/endstate-nix-harvest/6-permission-ro/profile-1-link.tmp-16449-846930886\" -> \"/nix/store/41qh53y9gyw2h2bn8v32x1ch7pmrj4bk-profile\": Permission denied"}},
+			wantCode: envelope.ErrPermissionDenied, wantSub: "permission",
+		},
+		{
+			// Spike-sourced (collision auto-resolves at default priority, so it
+			// could not be re-harvested live; this anchor is from the forced
+			// equal-priority probe and is best-effort).
+			name: "collision-forced", exit: 1, advanced: false,
+			acts:     []int{actRealise, actBuilds},
+			msgs:     []msg{{0, "error: an existing package already provides the following file:\n         /nix/store/.../bin/cp\n       The conflicting packages have a priority of 5"}},
+			wantCode: envelope.ErrInstallFailed, wantSub: "collision",
+		},
+		{
+			name: "unrecognised", exit: 1, advanced: false,
+			msgs:     []msg{{0, "error: something the anchor table has never seen before"}},
+			wantCode: envelope.ErrInstallFailed, wantSub: "",
+		},
+		{
+			name: "happy", exit: 0, advanced: true,
+			acts:     []int{actRealise, actBuilds, actCopyPathsType()},
+			wantCode: "", wantSub: "", // nil error
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			p := parseInternalJSON(mkStderr(c.msgs, c.acts))
+			got := classify(c.exit, p, c.advanced)
+			if c.wantCode == "" {
+				if got != nil {
+					t.Fatalf("expected nil error, got %+v", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected code %s, got nil", c.wantCode)
+			}
+			if got.Code != c.wantCode {
+				t.Errorf("code: want %s, got %s", c.wantCode, got.Code)
+			}
+			if got.Subcode != c.wantSub {
+				t.Errorf("subcode: want %q, got %q", c.wantSub, got.Subcode)
+			}
+			// Moat: raw text is retained for error.detail (never empty when there
+			// were error messages).
+			if len(c.msgs) > 0 && got.Raw == "" {
+				t.Errorf("expected raw text retained for error.detail")
+			}
+		})
+	}
+}
+
+// actCopyPathsType returns the CopyPaths activity type id (103), kept as a
+// helper so the fixtures read clearly.
+func actCopyPathsType() int { return 103 }
+
+func TestClassify_SpawnFailure(t *testing.T) {
+	// exitCode < 0 means the nix binary could not be spawned.
+	got := classify(-1, parseInternalJSON(nil), false)
+	if got == nil || got.Code != envelope.ErrRealizerUnavailable || got.Subcode != "spawn" {
+		t.Fatalf("spawn failure: want REALIZER_UNAVAILABLE/spawn, got %+v", got)
+	}
+}

--- a/go-engine/internal/realizer/nix/nix.go
+++ b/go-engine/internal/realizer/nix/nix.go
@@ -1,0 +1,256 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+// Package nix implements realizer.Realizer for Nix via `nix profile`. It uses
+// `nix profile add` (the supported verb, not the deprecated `install` alias) and
+// reads `nix profile list --json`, classifying failures to engine error codes
+// from the process exit code + internal-json activity + whether the profile
+// generation advanced. Installs go into an Endstate-managed profile so the
+// engine owns the generation lineage.
+package nix
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+// Runner executes `nix <args...>` and returns captured stdout/stderr, the
+// process exit code, and a non-nil error ONLY for spawn failures (binary
+// missing/unrunnable) — an expected non-zero exit is reported via exitCode with
+// a nil error. It is an injection point so tests stay hermetic.
+type Runner func(args ...string) (stdout, stderr []byte, exitCode int, err error)
+
+// Backend implements realizer.Realizer over the Nix CLI.
+type Backend struct {
+	// Profile is the Endstate-managed nix profile path.
+	Profile string
+	// Pin is the base flakeref a bare attribute is expanded against (e.g.
+	// "nixpkgs" or a rev-pinned "github:NixOS/nixpkgs/<rev>").
+	Pin string
+	// Run executes nix; defaults to the real exec runner.
+	Run Runner
+	// genFn overrides generation reading; nil means read the profile symlink.
+	// Tests (in-package) set this to drive Realize's atomicity detection
+	// hermetically without a real generation switch.
+	genFn func() int
+}
+
+// gen returns the active generation number, via genFn when set (tests) else by
+// reading the profile symlink.
+func (b *Backend) gen() int {
+	if b.genFn != nil {
+		return b.genFn()
+	}
+	return b.generation()
+}
+
+// New returns a Backend with the default Endstate-managed profile, pin, and a
+// real exec runner.
+func New() *Backend {
+	return &Backend{Profile: DefaultProfile(), Pin: defaultPin(), Run: defaultRunner}
+}
+
+// Name satisfies realizer.Realizer.
+func (b *Backend) Name() string { return "nix" }
+
+// DefaultProfile returns the Endstate-managed nix profile path, overridable via
+// ENDSTATE_NIX_PROFILE. It follows the XDG state-dir convention rather than a
+// hardcoded absolute path.
+func DefaultProfile() string {
+	if p := os.Getenv("ENDSTATE_NIX_PROFILE"); p != "" {
+		return p
+	}
+	base := os.Getenv("XDG_STATE_HOME")
+	if base == "" {
+		home, _ := os.UserHomeDir()
+		base = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(base, "endstate", "nix-profile")
+}
+
+func defaultPin() string {
+	if p := os.Getenv("ENDSTATE_NIXPKGS_PIN"); p != "" {
+		return p
+	}
+	// Default base flakeref. For full reproducibility a production pin is a
+	// rev-locked "github:NixOS/nixpkgs/<rev>"; the registry "nixpkgs" is the
+	// pragmatic default (on Determinate Nix it resolves via the pinned weekly
+	// registry).
+	return "nixpkgs"
+}
+
+// nixBin resolves the nix binary: ENDSTATE_NIX_BIN, else PATH, else the
+// Determinate default install location.
+func nixBin() string {
+	if p := os.Getenv("ENDSTATE_NIX_BIN"); p != "" {
+		return p
+	}
+	if _, err := exec.LookPath("nix"); err == nil {
+		return "nix"
+	}
+	return "/nix/var/nix/profiles/default/bin/nix"
+}
+
+// defaultRunner runs the real nix CLI, forcing the experimental features the
+// `nix profile`/flake commands require (harmless if already enabled).
+func defaultRunner(args ...string) ([]byte, []byte, int, error) {
+	full := append([]string{}, args...)
+	full = append(full, "--extra-experimental-features", "nix-command flakes")
+	cmd := exec.Command(nixBin(), full...)
+	var out, errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	runErr := cmd.Run()
+	if runErr == nil {
+		return out.Bytes(), errb.Bytes(), 0, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		// Expected non-zero exit; not a spawn failure.
+		return out.Bytes(), errb.Bytes(), exitErr.ExitCode(), nil
+	}
+	// Spawn failure (binary missing, not executable, etc.).
+	return out.Bytes(), errb.Bytes(), -1, runErr
+}
+
+// ResolveInstallable expands a manifest ref into a concrete nix installable. A
+// bare attribute ("ripgrep") is expanded against the pin ("nixpkgs#ripgrep"); a
+// ref already in flakeref/installable form (containing '#' or a known scheme) is
+// returned verbatim so power users can pin per-app.
+func (b *Backend) ResolveInstallable(ref string) string {
+	r := strings.TrimSpace(ref)
+	if strings.Contains(r, "#") {
+		return r
+	}
+	for _, scheme := range []string{"github:", "git+", "path:", "flake:", "tarball:", "file:", "/", "."} {
+		if strings.HasPrefix(r, scheme) {
+			return r
+		}
+	}
+	return b.Pin + "#" + r
+}
+
+// generation reads the active generation number from the profile symlink
+// (<profile> -> <profile>-<N>-link). Returns 0 when the profile does not exist.
+func (b *Backend) generation() int {
+	target, err := os.Readlink(b.Profile)
+	if err != nil {
+		return 0
+	}
+	base := strings.TrimSuffix(filepath.Base(target), "-link")
+	if i := strings.LastIndex(base, "-"); i >= 0 {
+		if n, err := strconv.Atoi(base[i+1:]); err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+// Current reads the installed set via `nix profile list --json`.
+func (b *Backend) Current() (realizer.Set, error) {
+	empty := realizer.Set{Elements: map[string]realizer.Element{}, Generation: b.generation()}
+	stdout, stderr, exit, err := b.Run("profile", "list", "--profile", b.Profile, "--json")
+	if err != nil {
+		return empty, classify(-1, parseInternalJSON(stderr), false)
+	}
+	if exit != 0 {
+		// A profile that does not exist yet lists as empty rather than an error.
+		return empty, nil
+	}
+	set, perr := parseProfileList(stdout)
+	if perr != nil {
+		return empty, nil
+	}
+	set.Generation = b.generation()
+	return set, nil
+}
+
+// Plan computes the diff between desired installables and the current set,
+// without mutating state. An installable is considered present when its leaf
+// attribute matches an installed element name or attrPath.
+func (b *Backend) Plan(desired []realizer.Installable) (realizer.Diff, error) {
+	cur, err := b.Current()
+	if err != nil {
+		return realizer.Diff{}, err
+	}
+	var d realizer.Diff
+	for _, ins := range desired {
+		if isPresent(cur, ins.Ref) {
+			d.Present = append(d.Present, ins)
+		} else {
+			d.ToAdd = append(d.ToAdd, ins)
+		}
+	}
+	return d, nil
+}
+
+// isPresent reports whether ref's leaf attribute matches an installed element.
+func isPresent(set realizer.Set, ref string) bool {
+	leaf := attrLeaf(ref)
+	if leaf == "" {
+		return false
+	}
+	if _, ok := set.Elements[leaf]; ok {
+		return true
+	}
+	for _, e := range set.Elements {
+		if e.Name == leaf || attrLeaf(e.AttrPath) == leaf {
+			return true
+		}
+	}
+	return false
+}
+
+// Realize adds the given installables in one `nix profile add`, an atomic
+// generation switch. It receives only the to-add set. On any failure the prior
+// generation is left intact (spike-confirmed) and Result.Err carries the
+// classified engine code.
+func (b *Backend) Realize(toAdd []realizer.Installable) (realizer.Result, error) {
+	res := realizer.Result{FromGeneration: -1, ToGeneration: -1}
+	if len(toAdd) == 0 {
+		cur, _ := b.Current()
+		res.After = cur
+		res.FromGeneration, res.ToGeneration = cur.Generation, cur.Generation
+		return res, nil
+	}
+
+	if err := os.MkdirAll(filepath.Dir(b.Profile), 0o755); err != nil {
+		res.Err = &realizer.Error{Code: envelope.ErrInternalError, Subcode: "profile-dir", Stage: "commit", Raw: err.Error()}
+		return res, nil
+	}
+
+	before := b.gen()
+	res.FromGeneration = before
+
+	args := []string{"profile", "add", "--profile", b.Profile}
+	for _, ins := range toAdd {
+		args = append(args, b.ResolveInstallable(ins.Ref))
+	}
+	args = append(args, "--log-format", "internal-json")
+
+	_, stderr, exit, err := b.Run(args...)
+	p := parseInternalJSON(stderr)
+	if err != nil { // spawn failure
+		res.Err = classify(-1, p, false)
+		return res, nil
+	}
+
+	after := b.gen()
+	res.ToGeneration = after
+	res.Advanced = after > before
+	if exit != 0 || !res.Advanced {
+		res.Err = classify(exit, p, res.Advanced)
+	}
+
+	cur, _ := b.Current()
+	res.After = cur
+	return res, nil
+}

--- a/go-engine/internal/realizer/nix/nix_test.go
+++ b/go-engine/internal/realizer/nix/nix_test.go
@@ -1,0 +1,144 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package nix
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+func TestResolveInstallable(t *testing.T) {
+	b := &Backend{Pin: "nixpkgs"}
+	cases := map[string]string{
+		"ripgrep":                           "nixpkgs#ripgrep",                   // bare attr -> pinned
+		"nixpkgs#jq":                        "nixpkgs#jq",                        // already has '#'
+		"github:NixOS/nixpkgs/abc123#hello": "github:NixOS/nixpkgs/abc123#hello", // flakeref verbatim
+	}
+	for in, want := range cases {
+		if got := b.ResolveInstallable(in); got != want {
+			t.Errorf("ResolveInstallable(%q): want %q, got %q", in, want, got)
+		}
+	}
+}
+
+func TestIsPresent(t *testing.T) {
+	set := realizer.Set{Elements: map[string]realizer.Element{
+		"ripgrep": {Name: "ripgrep", AttrPath: "legacyPackages.x86_64-linux.ripgrep"},
+	}}
+	if !isPresent(set, "nixpkgs#ripgrep") {
+		t.Error("nixpkgs#ripgrep should be present (leaf match)")
+	}
+	if !isPresent(set, "ripgrep") {
+		t.Error("bare ripgrep should be present")
+	}
+	if isPresent(set, "nixpkgs#jq") {
+		t.Error("jq should NOT be present")
+	}
+}
+
+// fakeRun dispatches on the `profile <sub>` subcommand.
+func fakeRun(addStderr []byte, addExit int, addErr error, listJSON []byte) Runner {
+	return func(args ...string) ([]byte, []byte, int, error) {
+		sub := ""
+		for i, a := range args {
+			if a == "profile" && i+1 < len(args) {
+				sub = args[i+1]
+				break
+			}
+		}
+		switch sub {
+		case "add":
+			return nil, addStderr, addExit, addErr
+		case "list":
+			return listJSON, nil, 0, nil
+		}
+		return nil, nil, 0, nil
+	}
+}
+
+func TestCurrent_InjectedRunner(t *testing.T) {
+	b := &Backend{Profile: "/tmp/endstate-nix-test-nonexistent", Run: fakeRun(nil, 0, nil, []byte(`{"version":3,"elements":{"ripgrep":{"attrPath":"x.ripgrep","storePaths":["/nix/store/a-ripgrep"]}}}`))}
+	set, err := b.Current()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := set.Elements["ripgrep"]; !ok {
+		t.Fatalf("expected ripgrep in current set, got %+v", set.Elements)
+	}
+}
+
+func TestPlan_InjectedRunner(t *testing.T) {
+	b := &Backend{Profile: "/tmp/endstate-nix-test-nonexistent", Pin: "nixpkgs", Run: fakeRun(nil, 0, nil, []byte(`{"version":3,"elements":{"ripgrep":{"attrPath":"x.ripgrep"}}}`))}
+	diff, err := b.Plan([]realizer.Installable{{ID: "ripgrep", Ref: "ripgrep"}, {ID: "jq", Ref: "jq"}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(diff.Present) != 1 || diff.Present[0].ID != "ripgrep" {
+		t.Errorf("want ripgrep present, got %+v", diff.Present)
+	}
+	if len(diff.ToAdd) != 1 || diff.ToAdd[0].ID != "jq" {
+		t.Errorf("want jq to-add, got %+v", diff.ToAdd)
+	}
+}
+
+func TestRealize_Success(t *testing.T) {
+	gen := 0
+	b := &Backend{
+		Profile: "/tmp/endstate-nix-test-nonexistent",
+		Pin:     "nixpkgs",
+		Run:     fakeRun(nil, 0, nil, []byte(`{"version":3,"elements":{}}`)),
+		genFn:   func() int { v := gen; gen++; return v }, // 0 (before) -> 1 (after) = advanced
+	}
+	res, _ := b.Realize([]realizer.Installable{{ID: "jq", Ref: "jq"}})
+	if !res.Advanced {
+		t.Errorf("expected Advanced=true")
+	}
+	if res.Err != nil {
+		t.Errorf("expected nil Err, got %+v", res.Err)
+	}
+}
+
+func TestRealize_InstallFailure(t *testing.T) {
+	evalStderr := mkStderr([]struct {
+		level int
+		text  string
+	}{{0, "error: flake 'flake:nixpkgs' does not provide attribute 'bogus'"}}, nil)
+	b := &Backend{
+		Profile: "/tmp/endstate-nix-test-nonexistent",
+		Pin:     "nixpkgs",
+		Run:     fakeRun(evalStderr, 1, nil, []byte(`{"version":3,"elements":{}}`)),
+		genFn:   func() int { return 0 }, // no advance
+	}
+	res, _ := b.Realize([]realizer.Installable{{ID: "bogus", Ref: "bogus"}})
+	if res.Advanced {
+		t.Errorf("expected Advanced=false")
+	}
+	if res.Err == nil || res.Err.Code != envelope.ErrInstallFailed || res.Err.Subcode != "eval" {
+		t.Fatalf("want INSTALL_FAILED/eval, got %+v", res.Err)
+	}
+}
+
+func TestRealize_Spawn(t *testing.T) {
+	b := &Backend{
+		Profile: "/tmp/endstate-nix-test-nonexistent",
+		Pin:     "nixpkgs",
+		Run:     fakeRun(nil, -1, errors.New("exec: nix not found"), nil),
+		genFn:   func() int { return 0 },
+	}
+	res, _ := b.Realize([]realizer.Installable{{ID: "jq", Ref: "jq"}})
+	if res.Err == nil || res.Err.Code != envelope.ErrRealizerUnavailable {
+		t.Fatalf("want REALIZER_UNAVAILABLE on spawn failure, got %+v", res.Err)
+	}
+}
+
+func TestRealize_EmptyToAdd(t *testing.T) {
+	b := &Backend{Profile: "/tmp/endstate-nix-test-nonexistent", Run: fakeRun(nil, 0, nil, []byte(`{"version":3,"elements":{}}`))}
+	res, _ := b.Realize(nil)
+	if res.Err != nil {
+		t.Errorf("empty to-add should be a no-op, got %+v", res.Err)
+	}
+}

--- a/go-engine/internal/realizer/nix/parse.go
+++ b/go-engine/internal/realizer/nix/parse.go
@@ -1,0 +1,173 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package nix
+
+import (
+	"bufio"
+	"encoding/json"
+	"regexp"
+	"strings"
+
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+// ActivityType subset (Nix src/libutil/logging.hh), confirmed against real
+// Determinate Nix 3.21.0 internal-json output.
+const (
+	actFileTransfer = 101
+	actRealise      = 102
+	actBuilds       = 104
+	actBuild        = 105
+	actSubstitute   = 108
+)
+
+var ansiRE = regexp.MustCompile("\x1b\\[[0-9;]*m")
+
+func stripANSI(s string) string { return ansiRE.ReplaceAllString(s, "") }
+
+// nixEvent is one parsed `@nix {...}` internal-json line. The `msg` TEXT is NOT
+// stable across Nix releases; only the locked anchor table consults it, and the
+// structural signals (activity type, generation advance) carry the stage.
+type nixEvent struct {
+	Action string `json:"action"`
+	Level  int    `json:"level"`
+	Msg    string `json:"msg"`
+	RawMsg string `json:"raw_msg"`
+	Type   int    `json:"type"`
+}
+
+// parsedLog is the structured view of a nix invocation's internal-json stderr.
+type parsedLog struct {
+	errorMsgs   []string    // level<=1 text, ANSI-stripped (raw -> error.detail only)
+	startedActs map[int]int // ActivityType -> count
+	blob        string      // lowercased concat of level<=1 msgs (for anchor matching)
+}
+
+func (p parsedLog) sawBuild() bool {
+	return p.startedActs[actBuild] > 0 || p.startedActs[actBuilds] > 0 || p.startedActs[actRealise] > 0
+}
+
+func (p parsedLog) sawDownload() bool {
+	return p.startedActs[actFileTransfer] > 0 || p.startedActs[actSubstitute] > 0
+}
+
+// parseInternalJSON extracts structured signals from `nix ... --log-format
+// internal-json` stderr. Lines that are not `@nix {...}` are ignored.
+func parseInternalJSON(stderr []byte) parsedLog {
+	p := parsedLog{startedActs: map[int]int{}}
+	var sb strings.Builder
+	sc := bufio.NewScanner(strings.NewReader(string(stderr)))
+	sc.Buffer(make([]byte, 0, 1<<20), 64<<20)
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if !strings.HasPrefix(line, "@nix ") {
+			continue
+		}
+		var ev nixEvent
+		if json.Unmarshal([]byte(line[5:]), &ev) != nil {
+			continue
+		}
+		switch ev.Action {
+		case "msg":
+			if ev.Level <= 1 {
+				txt := ev.Msg
+				if txt == "" {
+					txt = ev.RawMsg
+				}
+				txt = stripANSI(strings.TrimSpace(txt))
+				if txt != "" {
+					p.errorMsgs = append(p.errorMsgs, txt)
+					sb.WriteString(strings.ToLower(txt))
+					sb.WriteByte('\n')
+				}
+			}
+		case "start":
+			p.startedActs[ev.Type]++
+		}
+	}
+	p.blob = sb.String()
+	return p
+}
+
+// stageOf names the pipeline stage from structural signals (informational; feeds
+// realizer.Error.Stage and a future progress UI).
+func stageOf(p parsedLog, advanced bool) string {
+	switch {
+	case advanced:
+		return "commit"
+	case p.sawBuild():
+		return "build"
+	case p.sawDownload():
+		return "fetch"
+	default:
+		return "eval"
+	}
+}
+
+// profileElement is one entry of `nix profile list --json`.
+type profileElement struct {
+	StorePaths  []string `json:"storePaths"`
+	AttrPath    string   `json:"attrPath"`
+	OriginalURL string   `json:"originalUrl"`
+	URL         string   `json:"url"`
+}
+
+// parseProfileList parses `nix profile list --json`. The Nix 3.x shape is
+// {version, elements: {<name>: {...}}} (a name-keyed OBJECT); older Nix used an
+// array. Both are handled defensively. Empty/blank input yields an empty set.
+func parseProfileList(data []byte) (realizer.Set, error) {
+	set := realizer.Set{Elements: map[string]realizer.Element{}}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return set, nil
+	}
+	var probe struct {
+		Version  int             `json:"version"`
+		Elements json.RawMessage `json:"elements"`
+	}
+	if err := json.Unmarshal(data, &probe); err != nil {
+		return set, err
+	}
+	trimmed := strings.TrimSpace(string(probe.Elements))
+	if trimmed == "" || trimmed == "null" {
+		return set, nil
+	}
+	switch trimmed[0] {
+	case '{': // v3 name-keyed object
+		var obj map[string]profileElement
+		if err := json.Unmarshal(probe.Elements, &obj); err != nil {
+			return set, err
+		}
+		for name, e := range obj {
+			set.Elements[name] = realizer.Element{Name: name, AttrPath: e.AttrPath, StorePaths: e.StorePaths}
+		}
+	case '[': // legacy array
+		var arr []profileElement
+		if err := json.Unmarshal(probe.Elements, &arr); err != nil {
+			return set, err
+		}
+		for _, e := range arr {
+			name := attrLeaf(e.AttrPath)
+			if name == "" {
+				name = attrLeaf(e.OriginalURL)
+			}
+			if name == "" {
+				continue
+			}
+			set.Elements[name] = realizer.Element{Name: name, AttrPath: e.AttrPath, StorePaths: e.StorePaths}
+		}
+	}
+	return set, nil
+}
+
+// attrLeaf returns the trailing attribute of an installable/attrPath: the part
+// after the last '#', else after the last '.', else the input unchanged.
+func attrLeaf(s string) string {
+	if i := strings.LastIndex(s, "#"); i >= 0 {
+		s = s[i+1:]
+	}
+	if i := strings.LastIndex(s, "."); i >= 0 {
+		s = s[i+1:]
+	}
+	return s
+}

--- a/go-engine/internal/realizer/nix/parse_test.go
+++ b/go-engine/internal/realizer/nix/parse_test.go
@@ -1,0 +1,81 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package nix
+
+import "testing"
+
+func TestParseProfileList_V3Object(t *testing.T) {
+	// Nix 3.x shape: version + name-keyed elements OBJECT.
+	data := []byte(`{"version":3,"elements":{"ripgrep":{"attrPath":"legacyPackages.x86_64-linux.ripgrep","storePaths":["/nix/store/abc-ripgrep-15.1.0"]},"jq":{"attrPath":"legacyPackages.x86_64-linux.jq","storePaths":["/nix/store/def-jq-1.8.1"]}}}`)
+	set, err := parseProfileList(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(set.Elements) != 2 {
+		t.Fatalf("want 2 elements, got %d", len(set.Elements))
+	}
+	rg, ok := set.Elements["ripgrep"]
+	if !ok {
+		t.Fatalf("missing ripgrep element")
+	}
+	if rg.AttrPath != "legacyPackages.x86_64-linux.ripgrep" {
+		t.Errorf("attrPath: got %q", rg.AttrPath)
+	}
+}
+
+func TestParseProfileList_LegacyArray(t *testing.T) {
+	// Older Nix shape: elements ARRAY (handled defensively).
+	data := []byte(`{"version":2,"elements":[{"attrPath":"legacyPackages.x86_64-linux.jq","storePaths":["/nix/store/def-jq"]}]}`)
+	set, err := parseProfileList(data)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, ok := set.Elements["jq"]; !ok {
+		t.Fatalf("legacy array: expected element keyed by leaf 'jq', got %+v", set.Elements)
+	}
+}
+
+func TestParseProfileList_Empty(t *testing.T) {
+	for _, data := range [][]byte{[]byte(`{"version":3,"elements":{}}`), []byte(""), nil} {
+		set, err := parseProfileList(data)
+		if err != nil {
+			t.Fatalf("unexpected error for %q: %v", data, err)
+		}
+		if len(set.Elements) != 0 {
+			t.Errorf("want empty, got %d elements", len(set.Elements))
+		}
+	}
+}
+
+func TestParseInternalJSON_Signals(t *testing.T) {
+	type msg = struct {
+		level int
+		text  string
+	}
+	stderr := mkStderr([]msg{{0, "error: BOOM"}, {1, "warning: meh"}, {4, "debug: ignored"}}, []int{actBuild, actFileTransfer})
+	p := parseInternalJSON(stderr)
+	if !p.sawBuild() {
+		t.Error("expected sawBuild true")
+	}
+	if !p.sawDownload() {
+		t.Error("expected sawDownload true")
+	}
+	if len(p.errorMsgs) != 2 { // level<=1 only (debug excluded)
+		t.Errorf("want 2 error msgs (level<=1), got %d: %v", len(p.errorMsgs), p.errorMsgs)
+	}
+	if !contains(p.blob, "boom") {
+		t.Errorf("blob should be lowercased and contain 'boom': %q", p.blob)
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (func() bool {
+		for i := 0; i+len(sub) <= len(s); i++ {
+			if s[i:i+len(sub)] == sub {
+				return true
+			}
+		}
+		return false
+	})()
+}

--- a/go-engine/internal/realizer/realizer.go
+++ b/go-engine/internal/realizer/realizer.go
@@ -1,0 +1,88 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+// Package realizer defines the whole-set, declarative package backend interface
+// used on platforms whose package manager converges a desired set as one atomic
+// generation switch (e.g. Nix). It sits BESIDE driver.Driver — the per-package
+// adapter winget implements — and is never shoehorned into Driver.Install.
+//
+// The engine selects a realizer.Realizer on hosts that have one (linux/darwin via
+// Nix) and drives a whole-set apply/plan/verify path that fans the single
+// generation result back into the existing per-item event stream.
+package realizer
+
+import "github.com/Artexis10/endstate/go-engine/internal/envelope"
+
+// Installable is one resolved package to realize: the manifest App.ID plus the
+// concrete reference passed to the backend (e.g. a pinned nixpkgs flake
+// installable such as "nixpkgs#ripgrep").
+type Installable struct {
+	ID  string
+	Ref string
+}
+
+// Element is a single entry in the currently-installed set.
+type Element struct {
+	Name       string
+	AttrPath   string
+	StorePaths []string
+}
+
+// Set is the currently-installed package set plus the active generation number.
+type Set struct {
+	Generation int
+	Elements   map[string]Element // keyed by element name
+}
+
+// Diff is the result of Plan: which desired installables are missing (ToAdd)
+// versus already present in the current generation (Present).
+type Diff struct {
+	ToAdd   []Installable
+	Present []Installable
+}
+
+// Result is the outcome of Realize.
+type Result struct {
+	// Advanced is true iff a new generation became active (full success).
+	Advanced       bool
+	FromGeneration int // -1 if unknown
+	ToGeneration   int // -1 if unknown
+	After          Set // installed set after the operation
+	// Err is non-nil on failure, carrying the already-classified engine code.
+	Err *Error
+}
+
+// Error is a classified realizer failure. Raw carries the backend's raw text and
+// is destined ONLY for the envelope's error.detail — never a user-facing
+// message (the moat: the user never has to read Nix output).
+type Error struct {
+	Code    envelope.ErrorCode
+	Subcode string // eval | network | collision | store | permission | daemon | spawn
+	Stage   string // eval | fetch | build | commit | spawn (pipeline stage, informational)
+	Raw     string
+}
+
+// Error implements the error interface, returning the stable engine code.
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	return string(e.Code)
+}
+
+// Realizer is a whole-set, declarative package backend. It owns PACKAGES ONLY;
+// configuration restore/verify remain separate pipeline stages.
+type Realizer interface {
+	// Name returns the stable backend identifier (e.g. "nix").
+	Name() string
+	// Current reads the installed set and active generation.
+	Current() (Set, error)
+	// Plan computes the diff between the desired installables and Current,
+	// without mutating any state.
+	Plan(desired []Installable) (Diff, error)
+	// Realize adds the given installables in one atomic generation switch. It
+	// receives ONLY the to-add set (already-present installables are excluded by
+	// Plan, because the underlying verb appends rather than reconciles). On any
+	// failure the prior generation is left intact.
+	Realize(toAdd []Installable) (Result, error)
+}

--- a/go-engine/internal/restore/restore_test.go
+++ b/go-engine/internal/restore/restore_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -2123,12 +2124,23 @@ func TestRunRestore_DryRunAppend(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestExpandPath_WindowsPercentVar(t *testing.T) {
-	// Set a test env var and verify %VAR% expansion works.
+	// Verify env var expansion works using the host platform's variable syntax.
+	// On Windows, %VAR% is expanded by config.ExpandEnvVars (dispatches to ExpandWindowsEnvVars).
+	// On Linux/macOS, $VAR is expanded by config.ExpandEnvVars (dispatches to os.ExpandEnv).
 	t.Setenv("ENDSTATE_EXPAND_TEST", "/expanded/dir")
 
-	result := expandPath("%ENDSTATE_EXPAND_TEST%/file.txt")
-	if strings.Contains(result, "%ENDSTATE_EXPAND_TEST%") {
-		t.Errorf("expected %%VAR%% to be expanded, got %q", result)
+	var input, unexpanded string
+	if runtime.GOOS == "windows" {
+		input = "%ENDSTATE_EXPAND_TEST%/file.txt"
+		unexpanded = "%ENDSTATE_EXPAND_TEST%"
+	} else {
+		input = "$ENDSTATE_EXPAND_TEST/file.txt"
+		unexpanded = "$ENDSTATE_EXPAND_TEST"
+	}
+
+	result := expandPath(input)
+	if strings.Contains(result, unexpanded) {
+		t.Errorf("expected env var to be expanded, got %q", result)
 	}
 	if !strings.Contains(result, "/expanded/dir") {
 		t.Errorf("expected expanded path to contain /expanded/dir, got %q", result)
@@ -2180,8 +2192,18 @@ func TestExpandPath_NoVars_PassThrough(t *testing.T) {
 func TestResolveTarget_ExpandsEnvVars(t *testing.T) {
 	t.Setenv("ENDSTATE_TARGET_TEST", "/resolved/target")
 
-	result := resolveTarget("%ENDSTATE_TARGET_TEST%/config.json")
-	if strings.Contains(result, "%ENDSTATE_TARGET_TEST%") {
+	// Use the host-appropriate env var syntax.
+	var input, unexpanded string
+	if runtime.GOOS == "windows" {
+		input = "%ENDSTATE_TARGET_TEST%/config.json"
+		unexpanded = "%ENDSTATE_TARGET_TEST%"
+	} else {
+		input = "$ENDSTATE_TARGET_TEST/config.json"
+		unexpanded = "$ENDSTATE_TARGET_TEST"
+	}
+
+	result := resolveTarget(input)
+	if strings.Contains(result, unexpanded) {
 		t.Errorf("expected env var to be expanded in target, got %q", result)
 	}
 }
@@ -2229,11 +2251,19 @@ func TestRunRestore_ExpandsEnvVarInTarget(t *testing.T) {
 	os.MkdirAll(targetDir, 0755)
 	t.Setenv("ENDSTATE_TARGET_ENV_TEST", targetDir)
 
+	// Use the host-appropriate env var syntax in the target path.
+	var targetPath string
+	if runtime.GOOS == "windows" {
+		targetPath = `%ENDSTATE_TARGET_ENV_TEST%\env.conf`
+	} else {
+		targetPath = "$ENDSTATE_TARGET_ENV_TEST/env.conf"
+	}
+
 	entries := []RestoreAction{
 		{
 			Type:   "copy",
 			Source: srcFile,
-			Target: "%ENDSTATE_TARGET_ENV_TEST%/env.conf",
+			Target: targetPath,
 			ID:     "env-target-test",
 		},
 	}

--- a/openspec/changes/nix-realizer-backend/design.md
+++ b/openspec/changes/nix-realizer-backend/design.md
@@ -1,0 +1,98 @@
+## Context
+
+`platform-backend-foundation` left `selectBackend(goos)` returning `ErrNoBackend` on non-Windows hosts. The pipeline above the driver layer (planner, events, envelope, manifest) is platform-agnostic, but the install path is per-package: `apply`/`verify` loop over apps calling `driver.Driver.Detect(ref)` / `Install(ref)` and emit one item event per app. Nix's model is the opposite — **whole-set declarative**: you state the desired set, Nix computes a closure and commits it as one **profile generation**, atomically.
+
+The spike (Determinate Nix 3.21.0) validated the load-bearing premise and was **re-confirmed against live Nix during this change** (isolated `/tmp` profiles, `--log-format internal-json`):
+
+**Atomicity — confirmed.** A generation advances only on full success.
+
+| Probe | exit | generation |
+|-------|------|-----------|
+| `nix profile add nixpkgs#hello` (success) | 0 | 0 → **1** |
+| `nix profile add nixpkgs#hello nixpkgs#<bad-attr>` (partial) | 1 | 0 → **0** (valid pkg NOT partially applied) |
+| permission failure at commit (after a successful build) | 1 | 0 → **0** (prior generation intact) |
+
+**Failure classification — anchor map (re-harvested verbatim from Nix 3.21.0):**
+
+| Class | Structural signal | Anchor (real text) | Engine code |
+|-------|-------------------|--------------------|-------------|
+| eval / bad attr | no build activity | `does not provide attribute` | `INSTALL_FAILED` (subcode `eval`) |
+| network / fetch | `FileTransfer`, no build | `unable to download` / `HTTP error` / `while fetching` | `INSTALL_FAILED` (subcode `network`) |
+| daemon / store unavailable | no real activity | `opening a connection to remote store` (lvl 0) / `cannot connect to socket` (lvl 1) | **`REALIZER_UNAVAILABLE`** |
+| permission | build runs, **commit fails** | `Permission denied` / `read-only file system` | `PERMISSION_DENIED` |
+| collision | build runs, gen does **not** advance | `an existing package already provides the following file` *(see note)* | `INSTALL_FAILED` (subcode `collision`) |
+| spawn (nix missing/unrunnable) | — | — | **`REALIZER_UNAVAILABLE`** |
+| _unrecognised_ | — | — | `INSTALL_FAILED`, raw text → `error.detail` |
+
+> **Collision note:** at default priority Determinate Nix **auto-resolves** colliding paths (re-confirmed: `coreutils` + `uutils-coreutils-noprefix` → exit 0, gen advanced). A real collision only surfaces at **equal forced priority**; structurally it is `build-without-gen-advance` → `INSTALL_FAILED` regardless. The collision anchor is therefore **spike-sourced and best-effort**; the contract test must **force** an equal-priority collision to harvest it, or rely on the structural signal.
+>
+> **The spike's #1 lesson:** reasoned anchors are wrong (it guessed 0/3 collision anchors correctly). Every anchor is harvested from real pinned-Nix output and locked behind a contract test that re-asserts the mapping; a Nix upgrade that rewords a message fails CI loudly rather than silently mis-classifying.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A real whole-set `Realizer` beside `driver.Driver`; one atomic generation switch per apply.
+- Nix failures → stable engine codes; raw Nix text confined to `error.detail` (the moat: the user never has to read Nix).
+- The per-item event contract (phases, statuses, summaries) is preserved unchanged.
+- **Zero Windows behavior change**, provable by regression tests.
+
+**Non-Goals:**
+- **No config/restore/verify-module changes** — Nix owns packages only in v1; config modules keep their existing (path/verify-based) behavior on Linux.
+- **No uninstall / `Diff.ToRemove`** — v1 is additive (`nix profile add` only). Removal/convergence-to-exact-set is a follow-up.
+- **No rollback / restore-as-generation-switch yet** — atomicity makes it a clean later addition.
+- **No per-manifest pin override and no channel→rev resolution** — a single engine-owned pinned revision in v1.
+- **No `App.Driver` per-app backend override**, no bootstrap/release changes, no GUI changes.
+
+## Decisions
+
+1. **`Realizer` lives in a new package `internal/realizer`, not in `driver`** (decision 3: *beside* `Driver`). It is **not** a `driver.Driver` — Nix is never shoehorned into `Driver.Install`. Putting it in its own package keeps the `driver` package (which the Windows binary compiles) free of Nix-shaped types.
+
+   ```go
+   type Installable struct { ID, Ref string }           // App.ID + pinned flake installable
+   type Element     struct { Name, AttrPath string; StorePaths []string }
+   type Set         struct { Generation int; Elements map[string]Element } // parsed `nix profile list --json`
+   type Diff        struct { ToAdd, Present []Installable }                  // Plan output
+   type Result      struct { Advanced bool; FromGeneration, ToGeneration int; After Set; Err *Error }
+   type Error       struct { Code envelope.ErrorCode; Subcode, Stage, Raw string } // Raw → error.detail ONLY
+
+   type Realizer interface {
+       Name() string                                  // "nix"
+       Current() (Set, error)                         // `nix profile list --json`
+       Plan(desired []Installable) (Diff, error)      // diff desired vs Current; NO mutation
+       Realize(toAdd []Installable) (Result, error)   // ONE `nix profile add <toAdd...>`; atomic gen switch
+   }
+   ```
+
+2. **`Realize` operates on `ToAdd` (the diff), never the whole desired set.** `nix profile add` is *append*, not set-reconcile; re-adding already-present installables risks a collision that would fail the entire atomic switch. `Plan` computes `ToAdd = desired − Current`; `Realize(diff.ToAdd)` adds only those.
+
+3. **`internal/realizer/nix` implements `Realizer`** via an injected runner (`Run func(args ...string) (stdout, stderr []byte, exit int, err error)`) so tests are hermetic — mirroring winget's `ExecCommand` seam. It calls `nix profile add <toAdd...> --log-format internal-json` (decision 1: supported verb, not the deprecated `install` alias) and parses `nix profile list --json` (version 3 name-keyed object; legacy array tolerated). Build-tag split `nix_other.go` (`//go:build !windows`, real exec) / `nix_windows.go` (`//go:build windows`, stub returning `REALIZER_UNAVAILABLE`) — following `keychain_windows.go`/`keychain_other.go` — so windows-latest links the package without ever spawning `nix`.
+
+4. **`classify(exitCode, events, generationAdvanced) → *realizer.Error` is the single source of the code** — including the spawn/binary-missing → `REALIZER_UNAVAILABLE` path (so the one contract test covers every path; decision 5). Two tiers: **structural** signals (ActivityType + gen-advanced) decide the pipeline stage (`fetch`/`build`/`commit`) and the `network`/`collision` subcodes without msg text; **anchors** (msg-text substrings, priority-ordered) carry the top-level class only for the daemon/permission/eval classes the spike proved are not structurally separable. The anchor table is locked by a hermetic contract test over `testdata/*.stderr` captured from real Nix 3.21.0 (runs on windows-latest too — canned input, no real nix).
+
+5. **Selection: `selectBackend(goos)` is byte-unchanged; a sibling `selectRealizer(goos)` returns the realizer** (linux/darwin → `nix.New()`; else `ErrNoRealizer`), with a `newRealizerFn` injection seam beside `newDriverFn`. *Reconciliation:* the handoff suggested wiring Nix into `selectBackend`, but because decision 3 keeps Nix off `driver.Driver`, selection stays GOOS-keyed and centralized in `select.go` via a sibling selector rather than overloading `selectBackend`'s return type — honoring the intent (one place decides the backend) without a leaky union type.
+
+6. **Strict ref resolution on the realizer path.** Resolve `App.Refs[runtime.GOOS]` **directly**; an app with no `linux`/`darwin` ref is **skipped** (status `skipped`) — it must never fall back to the first-non-empty ref, which would feed a winget id like `Mozilla.Firefox` to `nix profile add`. A **bare attribute** (`ripgrep`) is expanded against an engine-owned pinned revision into `github:NixOS/nixpkgs/<pinned-rev>#ripgrep`; a string already in flakeref form passes through verbatim (power-user escape hatch). Manifest authors write `"ripgrep"`, never Nix syntax (the moat).
+
+7. **`apply`/`verify`/`plan` fork early on backend kind; the whole-set result fans out into the existing per-item event stream.** New `*_realizer.go` files hold the fan-out so the originals' diffs stay tiny (an early `if r,err := newRealizerFn(); err == nil { return runXxxRealizer(...) }`). On Windows `selectRealizer` errors, so the existing winget loop runs byte-identically. Fan-out rules:
+   - **Plan:** `Plan(desired)` once → emit `present` for `Diff.Present`, `to_install` for `Diff.ToAdd`; one `plan` summary. Dry-run stops here.
+   - **Apply:** emit `installing` for each `ToAdd`, call `Realize(ToAdd)` **once**. On `Advanced` → each `ToAdd` emits `installed`. On failure (gen not advanced → nothing installed) → **every** `ToAdd` emits `failed`; naming the single culprit is **best-effort** (it depends on unstable attr-path text), not guaranteed.
+   - **Verify:** re-read `Current()`; present → `present`, absent → `failed`/`missing`.
+   - Item `message` fields are **engine-authored**; raw Nix text lands **only** in `error.detail` (decision 8). For systemic classes (`REALIZER_UNAVAILABLE`, `PERMISSION_DENIED`) the command returns a top-level `*envelope.Error`; this **truncates** the per-item stream (no further item/summary events) — specced explicitly.
+
+8. **`capabilities.driversFor` consults `selectRealizer`** → `["nix"]` on linux/darwin, byte-identical `["winget"]` on Windows. `PlatformInfo` shape is unchanged (the `drivers` value `"nix"` is additive).
+
+9. **Additive `ErrRealizerUnavailable = "REALIZER_UNAVAILABLE"`** in `envelope/errors.go`, beside `ErrWingetNotAvailable`. Distinct from `WINGET_NOT_AVAILABLE` so the GUI can give Nix-specific remediation without leaking Nix internals beyond `error.detail`.
+
+## Alternatives Considered
+
+- **Driver-adapter (minimal-diff):** wrap Nix so `Driver.Install(ref)` does a per-ref `nix profile add`, reusing the existing loop untouched. *Rejected:* gives per-**add** atomicity (N generations per run; a mid-run failure leaves a partial multi-generation state), not the whole-**set** atomic switch decision 7 requires, and it shoehorns Nix into `Driver.Install` (decision 3). Smallest diff, wrong invariant.
+- **Unified `Realizer` as an optional interface on `driver.Driver`** (discovered by type-assertion like `BatchDetector`): nix.New satisfies `Driver`+`Realizer`; `selectBackend` and `driversFor` stay byte-identical; apply branches on `d.(Realizer)`. *Strong* (idiomatic, structural Windows guard) and documented here as the runner-up — but it forces Nix to implement a **vestigial** `Driver.Install` and couples the `driver` package to Nix-shaped types, both of which decision 3 argues against. The chosen design keeps the whole-set model fully separate at the cost of a sibling selector and `*_realizer.go` files. **If the reviewer prefers the smaller diff over interface purity, this is the swap.**
+
+## Risks / Trade-offs
+
+- **[Risk] Anchor drift across Nix versions** → Mitigation: structural-first classification; anchors only for non-separable classes; locked contract test over real fixtures; unrecognised → `INSTALL_FAILED` + raw detail (a degraded-but-safe moat, never a confidently-wrong code).
+- **[Risk] Coarser progress cadence** — one `Realize` over the set means per-item spinners flip together (a long `installing`, then a burst), unlike winget's sequential installs. Contract-legal (no `installing`-per-item is mandated) but a GUI UX delta. *Accepted for v1;* intermediate progress events from internal-json activity are a follow-up.
+- **[Risk] Lossy failure attribution** — atomic failure means nothing installed, so all `ToAdd` are `failed`; the offender is named best-effort only. Specced as `failed`-for-all + raw-in-detail, with offender-naming a `MAY`.
+- **[Risk] Ref-keying mismatch** — matching a flake ref against `nix profile list --json` element names is heuristic (URL/attr normalization); a mismatch causes a false `missing` → spurious reinstall. Mitigated by idempotency (non-destructive) and a real-output fixture test.
+- **[Risk] More new plumbing than the unified alternative** (sibling selector, `newRealizerFn`, three `*_realizer.go`, `driversFor` edit). *Accepted* as the cost of honoring decision 3; each touched original file keeps a minimal early-return diff.
+- **[Risk] Windows leak** → Mitigation: `selectBackend` untouched and reached first; the realizer fork is a leading early-return never taken on Windows; the nix package is build-tag-split and never spawned on Windows; `REALIZER_UNAVAILABLE` is an inert const there. Regression tests assert capabilities, selection, and the winget apply path are byte-identical.

--- a/openspec/changes/nix-realizer-backend/proposal.md
+++ b/openspec/changes/nix-realizer-backend/proposal.md
@@ -1,0 +1,41 @@
+## Why
+
+The `platform-backend-foundation` change made backend selection, ref resolution, capabilities, and paths platform-aware, leaving a single explicit insertion point — non-Windows hosts return `ErrNoBackend` — with **zero Windows behavior change**. This change fills that gap with a **Nix package backend** for Linux and macOS, so the engine can install packages on those hosts.
+
+The validation spike (Determinate Nix 3.21.0, verdict **YELLOW**) confirmed the realizer model is viable: a `nix profile` generation advances **only on full success** (atomicity holds), and every observed failure class is translatable to a stable engine `error.code` via a small, contract-tested anchor map. Nix's whole-set declarative model does not fit the per-package `Driver` interface, so this change introduces a **`Realizer` interface beside `Driver`** (never shoehorned into `Driver.Install`) and wires it into the pipeline behind the existing per-item event contract.
+
+In v1, **Nix owns packages only** — the module/restore/verify/capture layers are untouched and keep owning configuration.
+
+## What Changes
+
+- Add a **`Realizer` interface** (`internal/realizer`) beside `driver.Driver`: `Plan(desired) → generation diff`, `Realize(toAdd) → generation result`, `Current() → installed set`. The whole-set model is first-class; it is **not** a `Driver`.
+- Add a **Nix realizer** (`internal/realizer/nix`) that shells out to `nix profile add` (the supported verb; **not** the deprecated `install` alias) with `--log-format internal-json`, and reads `nix profile list --json` (version 3, name-keyed object; legacy array tolerated). Build-tag split (`nix_other.go` / `nix_windows.go`) per repo convention.
+- Add `classify(exitCode, internal-json events, generationAdvanced) → engine error.code` — the **single** source of the code. Structural signals carry the pipeline stage/subcode; a **locked anchor table** carries the top-level class for the daemon/permission/eval classes the spike proved are not structurally separable. Anchors are harvested from real pinned-Nix output and **locked behind a hermetic contract test**.
+- Add a GOOS-keyed **`selectRealizer(goos)`** (linux/darwin → Nix; else `ErrNoRealizer`) and a `newRealizerFn` injection seam beside `newDriverFn`. `selectBackend` (winget) is unchanged.
+- `apply` / `verify` / `plan` gain an early backend-kind fork: when a realizer is selected, a whole-set path computes one plan, performs **one atomic generation switch**, and **fans the single result back into the existing per-item event stream** (same phases, statuses, and summaries the GUI consumes). Raw Nix text appears **only** in `error.detail`.
+- `capabilities` reports `drivers: ["nix"]` on Linux/macOS via `driversFor`.
+- Map `App.Refs["linux"]`/`["darwin"]` to a **pinned** nixpkgs installable; bare attributes (`ripgrep`) are expanded against an engine-owned pinned revision, explicit flakerefs pass through. On the realizer path, an app with no Nix ref is **skipped** (never falls back to a winget id).
+- Add additive error code **`REALIZER_UNAVAILABLE`** (the Nix analogue of `WINGET_NOT_AVAILABLE`).
+
+## Capabilities
+
+### New Capabilities
+
+- `nix-package-backend`: install/detect packages on Linux and macOS through a whole-set Nix `Realizer`, classify Nix failures to stable engine error codes with raw text confined to `error.detail`, map pinned nixpkgs refs, and preserve the per-item event contract — all with no Windows behavior change.
+
+### Modified Capabilities
+
+(none — Windows behavior is invariant; every addition is platform-gated and additive. The foundation's `platform-backend-selection` requirements remain true: Linux/macOS simply move from "no backend" to "the Nix backend".)
+
+## Impact
+
+- `internal/realizer/realizer.go` (new) — `Realizer` interface + `Installable`/`Set`/`Diff`/`Result`/`Error` types.
+- `internal/realizer/nix/` (new) — Nix backend (`nix profile add`/`list`), `classify`, internal-json + profile-list parsers, locked anchor contract test, real-Nix-3.21.0 fixtures under `testdata/`.
+- `internal/commands/select.go` — add `selectRealizer(goos)` + `ErrNoRealizer`.
+- `internal/commands/verify.go` — add `newRealizerFn` seam; early realizer fork in `RunVerify` (+ `RunPlan`).
+- `internal/commands/apply.go` — ~3-line early realizer fork delegating to `runApplyRealizer`.
+- `internal/commands/{apply,verify,plan}_realizer.go` (new) — whole-set fan-out keeping the originals' diffs minimal.
+- `internal/commands/capabilities.go` — `driversFor` consults `selectRealizer`.
+- `internal/envelope/errors.go` — add `ErrRealizerUnavailable`.
+- `docs/contracts/cli-json-contract.md` — **PROTECTED**: additive `REALIZER_UNAVAILABLE` error-code row + one-line clarification that `platform.drivers` is `["nix"]` on Linux/macOS. **Flagged for explicit go-ahead at implementation time.**
+- No schema version bump: `refs["linux"]`/`refs["darwin"]` keys are additive per `schema-versioning`; the `drivers` array gains the value `"nix"` (no new field).

--- a/openspec/changes/nix-realizer-backend/specs/nix-package-backend/spec.md
+++ b/openspec/changes/nix-realizer-backend/specs/nix-package-backend/spec.md
@@ -1,0 +1,146 @@
+## ADDED Requirements
+
+### Requirement: Nix backend is selected on Linux and macOS
+The engine SHALL select a Nix package realizer on Linux and macOS hosts, and SHALL leave winget selection on Windows unchanged.
+
+#### Scenario: Linux selects the Nix realizer
+- **WHEN** the engine selects a backend on a Linux host
+- **THEN** the Nix realizer SHALL be used
+- **AND** no winget driver SHALL be selected
+
+#### Scenario: macOS selects the Nix realizer
+- **WHEN** the engine selects a backend on a macOS host
+- **THEN** the Nix realizer SHALL be used
+
+#### Scenario: Windows selection unchanged
+- **WHEN** the engine selects a backend on a Windows host
+- **THEN** the winget driver SHALL be used
+- **AND** the Nix realizer SHALL NOT be selected
+
+### Requirement: Apply realizes the desired package set as one atomic generation switch
+Apply SHALL compute a single plan over the desired Nix package set and SHALL realize the packages to add with one operation that advances the profile generation only on full success, using `nix profile add` (not the deprecated `install` alias).
+
+#### Scenario: Full success advances the generation
+- **WHEN** every package to add builds and commits successfully
+- **THEN** the profile generation SHALL advance
+- **AND** each added package SHALL be reported with status `installed`
+
+#### Scenario: Any failure leaves the prior generation intact
+- **WHEN** at least one package in the operation fails
+- **THEN** the profile generation SHALL NOT advance
+- **AND** no package SHALL be installed by that run
+- **AND** the prior generation SHALL remain the current generation
+
+#### Scenario: Already-present packages are not re-added
+- **WHEN** a desired package is already in the current generation
+- **THEN** it SHALL be reported with status `present` and reason `already_installed`
+- **AND** it SHALL NOT be passed to `nix profile add`
+
+#### Scenario: Dry run makes no changes
+- **WHEN** apply runs with `--dry-run`
+- **THEN** the plan SHALL be emitted
+- **AND** no generation switch SHALL be performed
+
+### Requirement: The realizer result is fanned into the per-item event stream
+The realizer apply path SHALL emit plan, apply, and verify phase events and one item event per package using the existing item-event vocabulary, so the event contract is preserved.
+
+#### Scenario: Per-item plan events
+- **WHEN** the realizer plan is computed
+- **THEN** one item event SHALL be emitted per package with status `present` or `to_install`
+- **AND** exactly one `plan` summary event SHALL be emitted
+
+#### Scenario: Installing precedes a terminal status
+- **WHEN** a package is applied
+- **THEN** an `installing` item event SHALL precede its terminal `installed` or `failed` item event
+- **AND** the item `driver` field SHALL be `nix`
+
+#### Scenario: One summary per phase
+- **WHEN** a phase completes
+- **THEN** exactly one summary event SHALL be emitted for that phase
+- **AND** the last event in the stream SHALL be a summary event, except when a systemic error truncates the stream
+
+### Requirement: Nix package references resolve to pinned installables
+The engine SHALL resolve `App.Refs["linux"]`/`App.Refs["darwin"]` to a pinned nixpkgs installable on the realizer path, and SHALL skip apps that have no Nix reference rather than passing a non-Nix reference to Nix.
+
+#### Scenario: Bare attribute is pinned
+- **WHEN** a Nix ref is a bare attribute name
+- **THEN** it SHALL resolve to a pinned nixpkgs flake installable
+
+#### Scenario: Explicit flakeref passes through
+- **WHEN** a Nix ref is already a flakeref installable
+- **THEN** it SHALL be passed to `nix profile add` unmodified
+
+#### Scenario: App with no Nix ref is skipped
+- **WHEN** an app has no `linux`/`darwin` ref on the realizer path
+- **THEN** the app SHALL be skipped
+- **AND** no winget-style reference SHALL be passed to `nix profile add`
+
+### Requirement: Nix failures translate to stable engine error codes
+The engine SHALL classify Nix outcomes into stable engine error codes from the process exit code, internal-json activity, and whether the generation advanced, and SHALL place raw Nix text only in `error.detail`.
+
+#### Scenario: Daemon or store unavailable
+- **WHEN** the Nix daemon or store is unreachable
+- **THEN** the engine SHALL return error code `REALIZER_UNAVAILABLE`
+- **AND** the engine SHALL surface remediation without requiring the user to interpret Nix output
+
+#### Scenario: Nix binary missing or unrunnable
+- **WHEN** the `nix` binary cannot be spawned
+- **THEN** the engine SHALL return error code `REALIZER_UNAVAILABLE`
+
+#### Scenario: Permission or read-only store failure
+- **WHEN** Nix reports a permission-denied or read-only-store failure
+- **THEN** the engine SHALL return error code `PERMISSION_DENIED`
+
+#### Scenario: Evaluation or attribute failure
+- **WHEN** a Nix attribute is undefined or a package is not found
+- **THEN** the package SHALL fail with error code `INSTALL_FAILED`
+- **AND** the detail SHALL carry subcode `eval`
+
+#### Scenario: Unrecognised failure
+- **WHEN** no anchor matches the Nix output
+- **THEN** the error code SHALL be `INSTALL_FAILED`
+- **AND** the raw Nix message SHALL appear only in `error.detail`
+- **AND** the raw Nix message SHALL NOT appear in `error.message` or any item-event `message`
+
+### Requirement: Nix error classification is locked by a contract test
+The engine SHALL derive the top-level error class from a fixed anchor table validated against captured real-Nix output, and SHALL derive subcode and pipeline stage from structural signals.
+
+#### Scenario: Anchors are validated against real output
+- **WHEN** the classifier is tested
+- **THEN** each anchor SHALL be asserted against a captured real-Nix stderr fixture for its expected code and subcode
+- **AND** the test SHALL fail if an anchor stops matching its fixture or its class changes
+
+#### Scenario: Structural signal carries the stage
+- **WHEN** Nix emits build or fetch activity
+- **THEN** the pipeline stage and subcode SHALL be derived from activity type and generation-advance without relying on message text
+
+### Requirement: Verify reflects the current generation
+Verify on the realizer path SHALL report each desired package present or missing by reading the current profile generation.
+
+#### Scenario: Present package passes verify
+- **WHEN** a desired package is in the current generation during verify
+- **THEN** it SHALL be reported `present`
+
+#### Scenario: Missing package fails verify
+- **WHEN** a desired package is absent from the current generation during verify
+- **THEN** it SHALL be reported `failed` with reason `missing`
+
+### Requirement: Capabilities advertises the Nix backend on Linux and macOS
+The `capabilities` data SHALL include `nix` among the available drivers on Linux and macOS, and SHALL remain unchanged on Windows.
+
+#### Scenario: Nix advertised on Linux and macOS
+- **WHEN** `capabilities` runs on a Linux or macOS host
+- **THEN** the drivers list SHALL include `nix`
+
+#### Scenario: Windows capabilities unchanged
+- **WHEN** `capabilities` runs on a Windows host
+- **THEN** the operating system SHALL be `windows`
+- **AND** the drivers list SHALL be `["winget"]`
+
+### Requirement: Nix selection does not change Windows behavior
+The introduction of the Nix backend SHALL NOT alter Windows package selection, installation, verification, or the per-item event stream.
+
+#### Scenario: Windows runs the existing per-package path
+- **WHEN** apply or verify runs on a Windows host
+- **THEN** no Nix code path SHALL execute
+- **AND** the winget per-package install/detect path SHALL run unchanged

--- a/openspec/changes/nix-realizer-backend/tasks.md
+++ b/openspec/changes/nix-realizer-backend/tasks.md
@@ -1,0 +1,60 @@
+> TDD: write each test RED first, then implement to green. All CI tests are hermetic (no real `nix`). The single real-Nix step is the anchor harvest (a merge gate), not a CI gate.
+
+## 0. Toolchain (this WSL box)
+
+- [ ] 0.1 Install Go via Nix (`nix profile add nixpkgs#go`) so `cd go-engine && go test ./...` and `GOOS=windows go build ./...` run on Linux
+- [ ] 0.2 Confirm `npm run openspec:validate` (strict) passes for this change before implementing
+
+## 1. Error code (additive)
+
+- [ ] 1.1 RED test: `envelope.ErrRealizerUnavailable == "REALIZER_UNAVAILABLE"` → add const beside `ErrWingetNotAvailable`
+
+## 2. Realizer interface (beside Driver)
+
+- [ ] 2.1 `internal/realizer/realizer.go` — `Realizer` interface (`Name`/`Current`/`Plan`/`Realize`) + `Installable`/`Element`/`Set`/`Diff`/`Result`/`Error` types; `Realize` takes `ToAdd` only
+- [ ] 2.2 Compile-time assertion test: nix backend satisfies `realizer.Realizer`; assert nix does **not** implement `driver.Driver` (it is beside, not a driver)
+
+## 3. Nix backend internals (hermetic, injected runner)
+
+- [ ] 3.1 `internal/realizer/nix/profile.go` + RED tests: parse `nix profile list --json` v3 name-keyed object **and** legacy array → `Set`; compute `Diff` (desired − Current)
+- [ ] 3.2 `internal/realizer/nix/internaljson.go` + RED tests: parse `@nix {...}` internal-json stderr lines → events; track started activities + `generationAdvanced`
+- [ ] 3.3 **Harvest real anchors (merge gate):** capture Nix 3.21.0 stderr for eval / network / daemon / permission into `testdata/*.stderr`; **force** an equal-priority collision to capture (or document the structural-only path)
+- [ ] 3.4 `internal/realizer/nix/classify.go` + RED contract test `classify_contract_test.go`: feed each `testdata/*.stderr` (+ exit, gen-advanced) → assert exact `(Code, Subcode)`. `classify` is the **single** source of the code incl. spawn → `REALIZER_UNAVAILABLE`. Structural-first; anchors only for daemon/permission/eval
+- [ ] 3.5 `internal/realizer/nix/nix_other.go` (`//go:build !windows`) real exec of `nix profile add <toAdd...> --log-format internal-json` / `nix profile list --json`; `nix_windows.go` (`//go:build windows`) stub returning `REALIZER_UNAVAILABLE`
+- [ ] 3.6 Ref resolution + pinning + RED tests: bare attr → `github:NixOS/nixpkgs/<pinned-rev>#attr`; explicit flakeref passthrough; pin constant chosen and documented
+- [ ] 3.7 `Realize`/`Current`/`Plan` RED tests via injected runner: success advances gen; partial/commit failure leaves gen intact; `Current` round-trips the list fixture
+
+## 4. Selection seam
+
+- [ ] 4.1 `internal/commands/select.go` — add `selectRealizer(goos)` (linux/darwin → `nix.New()`; else `ErrNoRealizer`); `selectBackend` byte-unchanged
+- [ ] 4.2 `internal/commands/verify.go` — add `newRealizerFn` injection seam beside `newDriverFn`
+- [ ] 4.3 RED tests: `selectRealizer("linux"/"darwin")` non-nil; `selectRealizer("windows") == ErrNoRealizer`; `selectBackend("windows")` still winget
+
+## 5. Apply / verify / plan fan-out
+
+- [ ] 5.1 `internal/commands/apply_realizer.go` — `runApplyRealizer`: plan (`present`/`to_install`) → `installing` per `ToAdd` → one `Realize(ToAdd)` → fan out terminal events; engine-authored messages; raw text → `error.detail` only; systemic codes (`REALIZER_UNAVAILABLE`/`PERMISSION_DENIED`) return a top-level `*envelope.Error`
+- [ ] 5.2 `internal/commands/apply.go` — ~3-line early fork: `if r, err := newRealizerFn(); err == nil { return runApplyRealizer(...) }` (winget loop below untouched)
+- [ ] 5.3 `internal/commands/verify_realizer.go` + `plan_realizer.go` — fan-out using `Current()`/`Plan`; `plan_realizer.go` populates `planner.PlanResult` (Plan + Actions) from the `Diff`
+- [ ] 5.4 RED tests (injected realizer fake): whole-set apply emits one `installing` + one terminal per ref and one summary; atomic failure → all `ToAdd` `failed`; `--dry-run` calls `Plan` not `Realize`; app with no Nix ref is `skipped`
+
+## 6. Capabilities
+
+- [ ] 6.1 `internal/commands/capabilities.go` — `driversFor` consults `selectRealizer` → `["nix"]` on linux/darwin
+- [ ] 6.2 RED tests: `driversFor("linux") == ["nix"]`; `driversFor("windows") == ["winget"]`
+
+## 7. Windows no-regression
+
+- [ ] 7.1 `TestSelectBackend_WindowsUnchanged` (winget; not a realizer) + `TestDriversFor_WindowsWinget` + golden `TestPlatformInfo_WindowsByteIdentical`
+- [ ] 7.2 `TestApply_WindowsTakesDriverPath` — mock driver (not a realizer) → existing per-item winget event sequence unchanged
+- [ ] 7.3 `GOOS=windows go build ./...` green; existing `winget_test.go` untouched and green
+
+## 8. Contract documentation (PROTECTED — needs explicit go-ahead)
+
+- [ ] 8.1 `docs/contracts/cli-json-contract.md` §"Standard Error Codes" — add `REALIZER_UNAVAILABLE` row (additive)
+- [ ] 8.2 `docs/contracts/cli-json-contract.md` capabilities note — one-line clarification that `platform.drivers` is `["nix"]` on Linux/macOS (additive)
+
+## 9. Verification
+
+- [ ] 9.1 `cd go-engine && go test ./...` green on Linux
+- [ ] 9.2 `npm run openspec:validate` (strict) passes
+- [ ] 9.3 Manual real-Nix smoke (not CI): `apply` a small manifest (e.g. `ripgrep`) on this WSL box; confirm install, `present` on re-run (idempotent), and `REALIZER_UNAVAILABLE`/`PERMISSION_DENIED` surfacing via the provocations


### PR DESCRIPTION
## What

A whole-set, declarative **Nix package backend** for Linux and macOS, beside the per-package winget `Driver`. The engine installs packages on Unix via `nix profile add` into an Endstate-managed profile, selected by `GOOS`. **Zero Windows behavior change.**

> **Re-targeted to `main`.** The original PR #48 was stacked on the foundation branch and (with #44's squash-merge) merged into that branch rather than `main`, so the Nix work never landed on `main`. This PR re-applies the identical Nix delta on top of the now-merged foundation. Supersedes #48.

## How it works

- `internal/realizer` — `Realizer` interface (`Current`/`Plan`/`Realize`) + types, beside `driver.Driver` (not shoehorned into `Driver.Install`).
- `internal/realizer/nix` — backend over `nix profile add` / `nix profile list --json` (v3 name-keyed; legacy array tolerated); internal-json parser; `classify()` mapping `(exit, activity, generation-advanced)` → engine error code via a **contract-tested anchor table harvested from real Determinate Nix 3.21.0 output**. Raw Nix text confined to `error.detail`.
- `internal/commands` — `selectRealizer` + `newRealizerFn` seam; `apply`/`verify`/`plan` fork to a whole-set path that fans one atomic generation switch into the existing per-item event stream; `driversFor` → `["nix"]` on linux/darwin.
- Additive `REALIZER_UNAVAILABLE` error code; `PERMISSION_DENIED` for read-only/permission failures.
- Pre-existing **Windows-assumption unit tests made host-aware** so the suite is green on Linux *and* Windows.
- `docs/contracts/cli-json-contract.md`: additive `REALIZER_UNAVAILABLE` row + `drivers=["nix"]` note.
- OpenSpec change `nix-realizer-backend` (validates `--strict`).

## Verification

- `cd go-engine && go test ./...` — green on Linux (23 pkgs, 0 failures)
- `GOOS=windows go build ./...` + `go vet ./...` — clean
- Real `nix profile add` on Determinate Nix 3.21.0: install → idempotent re-apply → bad attr `INSTALL_FAILED` → daemon-down `REALIZER_UNAVAILABLE`

Phase 1 of 5 (engine-owned Provisioning Generation → Unix rollback → winget rollback → convergence to follow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)