### PR TITLE
refactor(modules): rename module 'sensitive' block to 'secrets'

### DIFF
--- a/.claude/agents/module-author.md
+++ b/.claude/agents/module-author.md
@@ -35,7 +35,7 @@ Every module.jsonc MUST include:
   "verify": [],     // Array of verification steps
   "restore": [],    // Array of restore entries
   "capture": {},    // Capture definition with files and excludeGlobs
-  "sensitive": {},  // Optional. Files that MUST NOT be auto-restored
+  "secrets": {},  // Optional. Files that MUST NOT be auto-restored
   "notes": "",      // Human-readable notes about scope and exclusions
   "curation": {}    // Optional. Seed script and snapshot configuration
 }
@@ -100,7 +100,7 @@ For directory copy with exclusions:
 ## Security Rules (Non-Negotiable)
 
 - NEVER include browser profiles, auth tokens, password databases, or license blobs in capture/restore
-- The `sensitive` section documents paths that MUST NOT be restored; set `"restorer": "warn-only"`
+- The `secrets` section documents paths that MUST NOT be restored; set `"restorer": "warn-only"`
 - Apps with `sensitivity: "high"` require explicit justification in `notes`
 - `excludeGlobs` MUST exclude: Cache, Logs, Temp, lock files, crash reports, GPU cache, state databases (`.vscdb`)
 

--- a/docs/contracts/capture-artifact-contract.md
+++ b/docs/contracts/capture-artifact-contract.md
@@ -91,7 +91,7 @@ $env:ENDSTATE_PROVISIONING_CLI = "C:\nonexistent\cli.ps1"
 - Output path: `Documents\Endstate\Profiles\<ProfileName>.zip`
 - Zip contains at minimum: `manifest.jsonc` + `metadata.json`
 - Config payloads are automatically bundled when config modules match captured apps
-- Sensitive files (listed in `module.sensitive.files`) are NEVER included in the zip
+- Sensitive files (listed in `module.secrets.files`) are NEVER included in the zip
 
 ### INV-CAPTURE-6: Config Capture Failures Don't Block
 

--- a/docs/prompts/capture-bundle-zip.md
+++ b/docs/prompts/capture-bundle-zip.md
@@ -29,7 +29,7 @@ Capture currently produces a bare `.jsonc` manifest. Config export is a separate
 - If a config module matches (via `matches.winget` or `matches.exe`), its `capture.files` are copied into the zip under `configs/<module-id>/`
 - No `--include-config` flag needed — configs are always included when available
 - If no config modules match any apps, zip still contains manifest + metadata (install-only profile — valid and successful)
-- Sensitive files listed in module `sensitive.files` are NEVER included
+- Sensitive files listed in module `secrets.files` are NEVER included
 - `capture.excludeGlobs` are respected
 
 ### AC-3: Metadata file
@@ -86,7 +86,7 @@ Capture currently produces a bare `.jsonc` manifest. Config export is a separate
 - No external file references — all config payloads are embedded
 
 ### INV-BUNDLE-2: Sensitive files never bundled
-- Files listed in `module.sensitive.files` MUST NOT appear in the zip
+- Files listed in `module.secrets.files` MUST NOT appear in the zip
 - Credentials, tokens, session data — always excluded
 - This is enforced at capture time, not at restore time
 
@@ -123,7 +123,7 @@ Capture currently produces a bare `.jsonc` manifest. Config export is a separate
 - Match via `matches.winget` array against captured app's winget ID
 - If match found, iterate `capture.files` and copy source → `configs/<module-id>/<dest>`
 - Skip files matching `capture.excludeGlobs`
-- Skip files in `sensitive.files`
+- Skip files in `secrets.files`
 
 ### Zip Creation
 - Use PowerShell `Compress-Archive` or .NET `System.IO.Compression.ZipFile`
@@ -150,7 +150,7 @@ Before implementation, verify:
 - [ ] `export-config` command unaffected
 - [ ] Profile discovery handles all three formats without regression
 - [ ] Config module matching logic handles missing modules gracefully
-- [ ] Sensitive file exclusion works for all modules with `sensitive` blocks
+- [ ] Sensitive file exclusion works for all modules with `secrets` blocks
 
 ---
 

--- a/go-engine/internal/modules/catalog_secrets_guard_test.go
+++ b/go-engine/internal/modules/catalog_secrets_guard_test.go
@@ -1,0 +1,31 @@
+// Copyright 2025 Substrate Systems OU
+// SPDX-License-Identifier: Apache-2.0
+
+package modules
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+)
+
+// TestCatalogIntegrity_NoLegacySensitiveKey guards against reintroducing the
+// old module-level "sensitive" block key, which was renamed to "secrets".
+// The regex matches the block key (`"sensitive":`) but NOT the unrelated tier
+// field `"sensitivity":`, which is a different field and remains valid.
+func TestCatalogIntegrity_NoLegacySensitiveKey(t *testing.T) {
+	root := productionModulesRoot()
+	dirs := diskModuleDirs(t, root)
+	legacy := regexp.MustCompile(`"sensitive"\s*:`)
+	for _, d := range dirs {
+		b, err := os.ReadFile(filepath.Join(root, d, "module.jsonc"))
+		if err != nil {
+			t.Fatalf("read %s: %v", d, err)
+		}
+		if legacy.Match(b) {
+			t.Errorf("%s/module.jsonc uses the legacy \"sensitive\" block key — rename it to \"secrets\" "+
+				"(the tier field \"sensitivity\" is a different field and is fine).", d)
+		}
+	}
+}

--- a/go-engine/internal/modules/types.go
+++ b/go-engine/internal/modules/types.go
@@ -16,7 +16,7 @@ type Module struct {
 	Verify      []VerifyDef   `json:"verify,omitempty"`
 	Restore     []RestoreDef  `json:"restore,omitempty"`
 	Capture     *CaptureDef   `json:"capture,omitempty"`
-	Sensitive   *SensitiveDef `json:"sensitive,omitempty"`
+	Secrets     *SecretsDef   `json:"secrets,omitempty"`
 	Notes       string        `json:"notes,omitempty"`
 
 	// FilePath is the absolute path to the module.jsonc file (set at load time).
@@ -74,8 +74,8 @@ type CaptureRegistryKey struct {
 	Optional bool   `json:"optional,omitempty"`
 }
 
-// SensitiveDef describes files that must never be bundled or auto-restored.
-type SensitiveDef struct {
+// SecretsDef describes files that must never be bundled or auto-restored.
+type SecretsDef struct {
 	Files    []string `json:"files,omitempty"`
 	Warning  string   `json:"warning,omitempty"`
 	Restorer string   `json:"restorer,omitempty"`

--- a/modules/apps/ableton-live/module.jsonc
+++ b/modules/apps/ableton-live/module.jsonc
@@ -62,7 +62,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Ableton\\Live*\\Unlock*"
     ],

--- a/modules/apps/acrobat-reader/module.jsonc
+++ b/modules/apps/acrobat-reader/module.jsonc
@@ -62,7 +62,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "HKCU\\Software\\Adobe\\Acrobat Reader\\DC\\Adobe Cloud",
       "%APPDATA%\\Adobe\\Acrobat\\DC\\Security\\addressbook.acrodata"

--- a/modules/apps/android-studio/module.jsonc
+++ b/modules/apps/android-studio/module.jsonc
@@ -80,7 +80,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Google\\AndroidStudio*\\options\\security.xml",
       "%APPDATA%\\Google\\AndroidStudio*\\options\\github.xml"

--- a/modules/apps/anki/module.jsonc
+++ b/modules/apps/anki/module.jsonc
@@ -69,7 +69,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Anki2\\prefs.db",
       "%APPDATA%\\Anki2\\prefs21.db"

--- a/modules/apps/anydesk/module.jsonc
+++ b/modules/apps/anydesk/module.jsonc
@@ -53,7 +53,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\AnyDesk\\service.conf",
       "%APPDATA%\\AnyDesk\\system.conf",

--- a/modules/apps/aria2/module.jsonc
+++ b/modules/apps/aria2/module.jsonc
@@ -52,7 +52,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "~/.netrc",
       "~/.aria2/cookies.txt"

--- a/modules/apps/aws-cli/module.jsonc
+++ b/modules/apps/aws-cli/module.jsonc
@@ -47,7 +47,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%USERPROFILE%\\.aws\\credentials",
       "%USERPROFILE%\\.aws\\sso\\cache",

--- a/modules/apps/azure-data-studio/module.jsonc
+++ b/modules/apps/azure-data-studio/module.jsonc
@@ -65,7 +65,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\azuredatastudio\\User\\globalStorage\\state.vscdb",
       "%APPDATA%\\azuredatastudio\\User\\globalStorage\\state.vscdb.backup"

--- a/modules/apps/bash-profile/module.jsonc
+++ b/modules/apps/bash-profile/module.jsonc
@@ -157,7 +157,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "~/.bash_history",
       "~/.zsh_history",

--- a/modules/apps/beekeeper-studio/module.jsonc
+++ b/modules/apps/beekeeper-studio/module.jsonc
@@ -61,7 +61,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\beekeeper-studio\\app.db"
     ],

--- a/modules/apps/betterbird/module.jsonc
+++ b/modules/apps/betterbird/module.jsonc
@@ -75,7 +75,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Thunderbird\\Profiles\\*\\key4.db",
       "%APPDATA%\\Thunderbird\\Profiles\\*\\key3.db",

--- a/modules/apps/bitwig-studio/module.jsonc
+++ b/modules/apps/bitwig-studio/module.jsonc
@@ -63,7 +63,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\Bitwig Studio\\.activation-1-1",
       "%LOCALAPPDATA%\\Bitwig Studio\\activation.bwreg",

--- a/modules/apps/bizhawk/module.jsonc
+++ b/modules/apps/bizhawk/module.jsonc
@@ -25,7 +25,7 @@
     "files": []
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [],
     "warning": "BizHawk is a fully portable emulator. Every setting (hotkeys, controller bindings, core/path/firmware config, recent-ROM list) is written to config.ini in the SAME folder as EmuHawk.exe (source: Program.cs resolves the config path as Path.Combine(PathUtils.ExeDirectoryPath, \"config.ini\")). The install folder is chosen by the user and may be moved or renamed to any drive, so its location cannot be expressed with %APPDATA%/%LOCALAPPDATA%/%USERPROFILE%/~ or the registry. BizHawk does not use AppData, the user profile, or HKCU for settings.",
     "restorer": "warn-only"

--- a/modules/apps/brave/module.jsonc
+++ b/modules/apps/brave/module.jsonc
@@ -20,7 +20,7 @@
   "restore": [],
   "capture": { "files": [], "excludeGlobs": [] },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\BraveSoftware\\Brave-Browser\\User Data\\**"
     ],

--- a/modules/apps/bruno/module.jsonc
+++ b/modules/apps/bruno/module.jsonc
@@ -59,7 +59,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\bruno\\cookies.json",
       "%APPDATA%\\bruno\\env-secrets.json",

--- a/modules/apps/btop/module.jsonc
+++ b/modules/apps/btop/module.jsonc
@@ -25,7 +25,7 @@
     "files": []
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [],
     "warning": "btop4win stores no credentials. Its config is non-sensitive but is not capturable here because it lives in the install directory rather than a user-profile path.",
     "restorer": "warn-only"

--- a/modules/apps/capture-one/module.jsonc
+++ b/modules/apps/capture-one/module.jsonc
@@ -70,7 +70,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\CaptureOne\\License*"
     ],

--- a/modules/apps/ccleaner/module.jsonc
+++ b/modules/apps/ccleaner/module.jsonc
@@ -36,7 +36,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "HKCU\\Software\\Piriform\\CCleaner\\Name",
       "HKCU\\Software\\Piriform\\CCleaner\\License"

--- a/modules/apps/cemu/module.jsonc
+++ b/modules/apps/cemu/module.jsonc
@@ -85,7 +85,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Cemu\\keys.txt",
       "%APPDATA%\\Cemu\\otp.bin",

--- a/modules/apps/claude-code/module.jsonc
+++ b/modules/apps/claude-code/module.jsonc
@@ -63,7 +63,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%USERPROFILE%\\.claude\\.credentials.json",
       "%USERPROFILE%\\.claude.json"

--- a/modules/apps/claude-desktop/module.jsonc
+++ b/modules/apps/claude-desktop/module.jsonc
@@ -56,7 +56,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Claude\\Cookies",
       "%APPDATA%\\Claude\\Local Storage\\*",

--- a/modules/apps/claws-mail/module.jsonc
+++ b/modules/apps/claws-mail/module.jsonc
@@ -132,7 +132,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Claws-mail\\passwordstorerc"
     ],

--- a/modules/apps/clementine/module.jsonc
+++ b/modules/apps/clementine/module.jsonc
@@ -43,7 +43,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "registryKeys": [
       "HKCU\\Software\\Clementine\\Clementine"
     ],

--- a/modules/apps/clion/module.jsonc
+++ b/modules/apps/clion/module.jsonc
@@ -79,7 +79,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\JetBrains\\CLion*\\options\\security.xml",
       "%APPDATA%\\JetBrains\\CLion*\\options\\github.xml"

--- a/modules/apps/conda/module.jsonc
+++ b/modules/apps/conda/module.jsonc
@@ -67,7 +67,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "~/.anaconda/config.toml",
       "~/.continuum/anaconda-client/tokens"

--- a/modules/apps/copyq/module.jsonc
+++ b/modules/apps/copyq/module.jsonc
@@ -60,7 +60,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\copyq\\*.dat",
       "%APPDATA%\\copyq\\items"

--- a/modules/apps/cryptomator/module.jsonc
+++ b/modules/apps/cryptomator/module.jsonc
@@ -49,7 +49,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Cryptomator\\keychain.json"
     ],

--- a/modules/apps/cursor/module.jsonc
+++ b/modules/apps/cursor/module.jsonc
@@ -78,7 +78,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Cursor\\User\\globalStorage\\state.vscdb",
       "%APPDATA%\\Cursor\\User\\globalStorage\\state.vscdb.backup"

--- a/modules/apps/datagrip/module.jsonc
+++ b/modules/apps/datagrip/module.jsonc
@@ -83,7 +83,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\JetBrains\\DataGrip*\\options\\security.xml",
       "%APPDATA%\\JetBrains\\DataGrip*\\options\\github.xml",

--- a/modules/apps/dbeaver/module.jsonc
+++ b/modules/apps/dbeaver/module.jsonc
@@ -69,7 +69,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\DBeaverData\\workspace6\\General\\.dbeaver\\credentials-config.json",
       "%APPDATA%\\DBeaverData\\secure"

--- a/modules/apps/deluge/module.jsonc
+++ b/modules/apps/deluge/module.jsonc
@@ -96,7 +96,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\deluge\\auth",
       "%APPDATA%\\deluge\\hostlist.conf",

--- a/modules/apps/directory-opus/module.jsonc
+++ b/modules/apps/directory-opus/module.jsonc
@@ -40,7 +40,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\GPSoftware\\Directory Opus\\ConfigFiles\\dopus.cert",
       "%APPDATA%\\GPSoftware\\Directory Opus\\ConfigFiles\\license*"

--- a/modules/apps/discord/module.jsonc
+++ b/modules/apps/discord/module.jsonc
@@ -19,7 +19,7 @@
   "restore": [],
   "capture": { "files": [], "excludeGlobs": [] },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\discord\\Local Storage\\**"
     ],

--- a/modules/apps/displayfusion/module.jsonc
+++ b/modules/apps/displayfusion/module.jsonc
@@ -54,7 +54,7 @@
     "excludeGlobs": []
   },
 
-  "sensitive": {
+  "secrets": {
     "registryKeys": [
       "HKCU\\Software\\Binary Fortress Software\\DisplayFusion"
     ],

--- a/modules/apps/ditto/module.jsonc
+++ b/modules/apps/ditto/module.jsonc
@@ -38,7 +38,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Ditto\\Ditto.db"
     ],

--- a/modules/apps/drawio-desktop/module.jsonc
+++ b/modules/apps/drawio-desktop/module.jsonc
@@ -76,7 +76,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\draw.io\\Local Storage",
       "%APPDATA%\\draw.io\\Cookies",

--- a/modules/apps/duckstation/module.jsonc
+++ b/modules/apps/duckstation/module.jsonc
@@ -120,7 +120,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\DuckStation\\bios",
       "%USERPROFILE%\\Documents\\DuckStation\\bios"

--- a/modules/apps/duplicati/module.jsonc
+++ b/modules/apps/duplicati/module.jsonc
@@ -40,7 +40,7 @@
     "files": []
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\Duplicati\\Duplicati-server.sqlite",
       "%LOCALAPPDATA%\\Duplicati\\Duplicati-server.sqlite-wal",

--- a/modules/apps/dxo-photolab/module.jsonc
+++ b/modules/apps/dxo-photolab/module.jsonc
@@ -54,7 +54,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\DxO\\DxO PhotoLab*\\License*"
     ],

--- a/modules/apps/em-client/module.jsonc
+++ b/modules/apps/em-client/module.jsonc
@@ -122,7 +122,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\eM Client\\accounts.dat",
       "%APPDATA%\\eM Client\\main.dat",

--- a/modules/apps/emacs/module.jsonc
+++ b/modules/apps/emacs/module.jsonc
@@ -115,7 +115,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\.emacs.d\\.authinfo",
       "%APPDATA%\\.emacs.d\\.authinfo.gpg",

--- a/modules/apps/fancontrol/module.jsonc
+++ b/modules/apps/fancontrol/module.jsonc
@@ -31,7 +31,7 @@
     "files": []
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [],
     "warning": "FanControl is a portable app that keeps userConfig.json, the Configurations\\ profile folder, and Plugins\\ inside its own install directory (next to FanControl.exe), not in any standard env-rooted location or the registry. The install path is non-deterministic (a hashed winget Packages folder, or an arbitrary user-chosen extract directory), so there is no portable path to capture. Back up userConfig.json and the Configurations folder manually from the FanControl install folder.",
     "restorer": "warn-only"

--- a/modules/apps/fences/module.jsonc
+++ b/modules/apps/fences/module.jsonc
@@ -68,7 +68,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Stardock\\Fences\\License.sig"
     ],

--- a/modules/apps/ferdium/module.jsonc
+++ b/modules/apps/ferdium/module.jsonc
@@ -77,7 +77,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Ferdium\\Partitions",
       "%APPDATA%\\Ferdium\\service-partitions",

--- a/modules/apps/filebot/module.jsonc
+++ b/modules/apps/filebot/module.jsonc
@@ -65,7 +65,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\FileBot\\license.txt"
     ],

--- a/modules/apps/filezilla/module.jsonc
+++ b/modules/apps/filezilla/module.jsonc
@@ -53,7 +53,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\FileZilla\\recentservers.xml"
     ],

--- a/modules/apps/fl-studio/module.jsonc
+++ b/modules/apps/fl-studio/module.jsonc
@@ -64,7 +64,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%USERPROFILE%\\Documents\\Image-Line\\FL Studio\\Settings\\RegInfo*"
     ],

--- a/modules/apps/flycast/module.jsonc
+++ b/modules/apps/flycast/module.jsonc
@@ -35,7 +35,7 @@
     "files": []
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [],
     "warning": "Flycast is portable on Windows: emu.cfg, the mappings\\ folder, and the data\\ folder all live beside flycast.exe at a user-chosen extraction path (e.g. C:\\flycast\\). There is no env-var-rooted location to capture without hardcoding an absolute drive path, so this module is install-only. To preserve settings, manually back up the Flycast folder.",
     "restorer": "warn-only"

--- a/modules/apps/free-download-manager/module.jsonc
+++ b/modules/apps/free-download-manager/module.jsonc
@@ -29,7 +29,7 @@
     "files": []
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\Softdeluxe\\Free Download Manager\\db.sqlite",
       "%LOCALAPPDATA%\\Softdeluxe\\Free Download Manager\\fdm.sqlite",

--- a/modules/apps/freecommander/module.jsonc
+++ b/modules/apps/freecommander/module.jsonc
@@ -66,7 +66,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\FreeCommanderXE\\Settings\\FreeCommander.ftp",
       "%LOCALAPPDATA%\\FreeCommanderXE\\Settings\\FreeCommander.ftp.ini"

--- a/modules/apps/freefilesync/module.jsonc
+++ b/modules/apps/freefilesync/module.jsonc
@@ -55,7 +55,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\FreeFileSync\\GlobalSettings.xml",
       "%APPDATA%\\FreeFileSync\\LastRun.ffs_gui"

--- a/modules/apps/gajim/module.jsonc
+++ b/modules/apps/gajim/module.jsonc
@@ -78,7 +78,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Gajim\\settings.sqlite",
       "%APPDATA%\\Gajim\\logs.db",

--- a/modules/apps/git-bash/module.jsonc
+++ b/modules/apps/git-bash/module.jsonc
@@ -108,7 +108,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "~/.bash_history",
       "~/.git-credentials"

--- a/modules/apps/git/module.jsonc
+++ b/modules/apps/git/module.jsonc
@@ -75,7 +75,7 @@
     ]
   },
   
-  "sensitive": {
+  "secrets": {
     "files": [
       "~/.git-credentials",
       "~/.config/git/credentials",

--- a/modules/apps/github-cli/module.jsonc
+++ b/modules/apps/github-cli/module.jsonc
@@ -37,7 +37,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\GitHub CLI\\hosts.yml"
     ],

--- a/modules/apps/goland/module.jsonc
+++ b/modules/apps/goland/module.jsonc
@@ -79,7 +79,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\JetBrains\\GoLand*\\options\\security.xml",
       "%APPDATA%\\JetBrains\\GoLand*\\options\\github.xml"

--- a/modules/apps/goodsync/module.jsonc
+++ b/modules/apps/goodsync/module.jsonc
@@ -74,7 +74,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\GoodSync\\accounts.tgs",
       "%APPDATA%\\GoodSync\\accounts.tgs"

--- a/modules/apps/gpg4win/module.jsonc
+++ b/modules/apps/gpg4win/module.jsonc
@@ -122,7 +122,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\gnupg\\private-keys-v1.d",
       "%APPDATA%\\gnupg\\openpgp-revocs.d",

--- a/modules/apps/gradle/module.jsonc
+++ b/modules/apps/gradle/module.jsonc
@@ -77,7 +77,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%USERPROFILE%\\.gradle\\gradle.properties",
       "%USERPROFILE%\\.gradle\\init.gradle",

--- a/modules/apps/heidisql/module.jsonc
+++ b/modules/apps/heidisql/module.jsonc
@@ -54,7 +54,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "HKCU\\Software\\HeidiSQL",
       "HKCU\\Software\\HeidiSQL\\Servers"

--- a/modules/apps/helm/module.jsonc
+++ b/modules/apps/helm/module.jsonc
@@ -47,7 +47,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\helm\\registry\\config.json"
     ],

--- a/modules/apps/hexchat/module.jsonc
+++ b/modules/apps/hexchat/module.jsonc
@@ -158,7 +158,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\HexChat\\servlist.conf",
       "%APPDATA%\\HexChat\\certs"

--- a/modules/apps/insomnia/module.jsonc
+++ b/modules/apps/insomnia/module.jsonc
@@ -167,7 +167,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Insomnia\\insomnia.Environment.db",
       "%APPDATA%\\Insomnia\\insomnia.Session.db",

--- a/modules/apps/intellij-idea-ultimate/module.jsonc
+++ b/modules/apps/intellij-idea-ultimate/module.jsonc
@@ -82,7 +82,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\JetBrains\\IntelliJIdea*\\options\\security.xml",
       "%APPDATA%\\JetBrains\\IntelliJIdea*\\options\\github.xml"

--- a/modules/apps/intellij-idea/module.jsonc
+++ b/modules/apps/intellij-idea/module.jsonc
@@ -69,7 +69,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\JetBrains\\IntelliJIdea*\\options\\security.xml",
       "%APPDATA%\\JetBrains\\IntelliJIdea*\\options\\github.xml"

--- a/modules/apps/internet-download-manager/module.jsonc
+++ b/modules/apps/internet-download-manager/module.jsonc
@@ -24,7 +24,7 @@
     "files": []
   },
 
-  "sensitive": {
+  "secrets": {
     "warning": "IDM stores all settings (categories, connections, scheduler, file types, proxy, browser integration) AND the purchased license/activation data (the 'Serial' value plus the 'FName'/'LName'/'Email' registration fields) as flat sibling values directly under the single registry key HKCU\\Software\\DownloadManager. Registry capture exports an entire key, so there is no way to capture preferences without also capturing the license/registration blob. This key MUST NOT be auto-captured or auto-restored.",
     "restorer": "warn-only"
   },

--- a/modules/apps/itunes/module.jsonc
+++ b/modules/apps/itunes/module.jsonc
@@ -23,7 +23,7 @@
     "files": []
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Apple Computer\\Preferences\\ByHost",
       "HKCU\\Software\\Apple Computer, Inc.\\iTunes",

--- a/modules/apps/jdownloader/module.jsonc
+++ b/modules/apps/jdownloader/module.jsonc
@@ -83,7 +83,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\JDownloader 2.0\\cfg\\org.jdownloader.settings.AccountSettings.accounts.ejs",
       "%LOCALAPPDATA%\\JDownloader 2.0\\cfg\\org.jdownloader.api.myjdownloader.MyJDownloaderSettings.json"

--- a/modules/apps/jellyfin-server/module.jsonc
+++ b/modules/apps/jellyfin-server/module.jsonc
@@ -123,7 +123,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\jellyfin\\data\\jellyfin.db",
       "%LOCALAPPDATA%\\jellyfin\\data\\library.db",

--- a/modules/apps/joplin/module.jsonc
+++ b/modules/apps/joplin/module.jsonc
@@ -88,7 +88,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%USERPROFILE%\\.config\\joplin-desktop\\database.sqlite",
       "%USERPROFILE%\\.config\\joplin-desktop\\log.txt",

--- a/modules/apps/keepass/module.jsonc
+++ b/modules/apps/keepass/module.jsonc
@@ -48,7 +48,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "**\\*.kdbx",
       "**\\*.kdb",

--- a/modules/apps/keepassxc/module.jsonc
+++ b/modules/apps/keepassxc/module.jsonc
@@ -41,7 +41,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\KeePassXC\\*.kdbx",
       "%APPDATA%\\KeePassXC\\*.keyx",

--- a/modules/apps/kleopatra/module.jsonc
+++ b/modules/apps/kleopatra/module.jsonc
@@ -120,7 +120,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\gnupg\\private-keys-v1.d",
       "%APPDATA%\\gnupg\\pubring.kbx",

--- a/modules/apps/kopia/module.jsonc
+++ b/modules/apps/kopia/module.jsonc
@@ -55,7 +55,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\kopia\\repository.config.kopia-password"
     ],

--- a/modules/apps/kubeconfig/module.jsonc
+++ b/modules/apps/kubeconfig/module.jsonc
@@ -64,7 +64,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%USERPROFILE%\\.kube\\config",
       "%USERPROFILE%\\.kube\\cache",

--- a/modules/apps/kubectl/module.jsonc
+++ b/modules/apps/kubectl/module.jsonc
@@ -44,7 +44,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%USERPROFILE%\\.kube\\config",
       "~/.kube/config"

--- a/modules/apps/kvirc/module.jsonc
+++ b/modules/apps/kvirc/module.jsonc
@@ -61,7 +61,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       // Local-directory config files store server, proxy, SSL and NickServ
       // passwords as PLAINTEXT interleaved with preferences (kvirc/KVIrc#1294).

--- a/modules/apps/libreoffice/module.jsonc
+++ b/modules/apps/libreoffice/module.jsonc
@@ -131,7 +131,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\LibreOffice\\4\\user\\registrymodifications.xcu",
       "%APPDATA%\\LibreOffice\\4\\user\\database"

--- a/modules/apps/macrium-reflect/module.jsonc
+++ b/modules/apps/macrium-reflect/module.jsonc
@@ -68,7 +68,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [],
     "registryKeys": [
       "HKCU\\Software\\Macrium\\Reflect"

--- a/modules/apps/mailbird/module.jsonc
+++ b/modules/apps/mailbird/module.jsonc
@@ -28,7 +28,7 @@
     "files": []
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\Mailbird\\Store\\Store.db",
       "%LOCALAPPDATA%\\Mailbird\\Store\\Store.db-wal",

--- a/modules/apps/mailspring/module.jsonc
+++ b/modules/apps/mailspring/module.jsonc
@@ -74,7 +74,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Mailspring\\config.json"
     ],

--- a/modules/apps/makemkv/module.jsonc
+++ b/modules/apps/makemkv/module.jsonc
@@ -25,7 +25,7 @@
     "files": []
   },
 
-  "sensitive": {
+  "secrets": {
     "registryKeys": [
       "HKCU\\Software\\MakeMKV"
     ],

--- a/modules/apps/malwarebytes/module.jsonc
+++ b/modules/apps/malwarebytes/module.jsonc
@@ -26,7 +26,7 @@
     "files": []
   },
 
-  "sensitive": {
+  "secrets": {
     "registryKeys": [
       "HKLM\\SOFTWARE\\Malwarebytes"
     ],

--- a/modules/apps/mediamonkey/module.jsonc
+++ b/modules/apps/mediamonkey/module.jsonc
@@ -60,7 +60,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\MediaMonkey5\\MediaMonkey.ini"
     ],

--- a/modules/apps/microsoft-office/module.jsonc
+++ b/modules/apps/microsoft-office/module.jsonc
@@ -86,7 +86,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "HKCU\\Software\\Microsoft\\Office\\16.0\\Common\\Identity",
       "HKCU\\Software\\Microsoft\\Office\\16.0\\Outlook\\Profiles"

--- a/modules/apps/mirc/module.jsonc
+++ b/modules/apps/mirc/module.jsonc
@@ -101,7 +101,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\mIRC\\servers.ini"
     ],

--- a/modules/apps/mixxx/module.jsonc
+++ b/modules/apps/mixxx/module.jsonc
@@ -92,7 +92,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\Mixxx\\broadcast_profiles"
     ],

--- a/modules/apps/mobaxterm/module.jsonc
+++ b/modules/apps/mobaxterm/module.jsonc
@@ -55,7 +55,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%USERPROFILE%\\Documents\\MobaXterm\\MobaXterm.ini",
       "%APPDATA%\\MobaXterm\\MobaXterm.ini"

--- a/modules/apps/mongodb-compass/module.jsonc
+++ b/modules/apps/mongodb-compass/module.jsonc
@@ -85,7 +85,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\MongoDB Compass\\IndexedDB",
       "%APPDATA%\\MongoDB Compass\\Local Storage",

--- a/modules/apps/mremoteng/module.jsonc
+++ b/modules/apps/mremoteng/module.jsonc
@@ -46,7 +46,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\mRemoteNG\\confCons.xml"
     ],

--- a/modules/apps/mullvad-vpn/module.jsonc
+++ b/modules/apps/mullvad-vpn/module.jsonc
@@ -58,7 +58,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       // The daemon's settings.json (tunnel protocol, relay/location, DNS, kill switch,
       // allow_lan), account-history.json and device.json are written by the daemon, which

--- a/modules/apps/mysql-workbench/module.jsonc
+++ b/modules/apps/mysql-workbench/module.jsonc
@@ -107,7 +107,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\MySQL\\Workbench\\workbench_user_data.dat"
     ],

--- a/modules/apps/nextcloud/module.jsonc
+++ b/modules/apps/nextcloud/module.jsonc
@@ -58,7 +58,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       // Credentials are stored by QtKeychain in Windows Credential Manager,
       // not in a portable file. Listed here for documentation/awareness.

--- a/modules/apps/npm/module.jsonc
+++ b/modules/apps/npm/module.jsonc
@@ -48,7 +48,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "~/.npmrc"
     ],

--- a/modules/apps/obs-studio/module.jsonc
+++ b/modules/apps/obs-studio/module.jsonc
@@ -57,7 +57,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\obs-studio\\basic\\profiles\\*\\service.json"
     ],

--- a/modules/apps/obsidian/module.jsonc
+++ b/modules/apps/obsidian/module.jsonc
@@ -43,7 +43,7 @@
     ]
   },
   
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\obsidian\\obsidian-sync-*.json"
     ],

--- a/modules/apps/onlyoffice-desktop/module.jsonc
+++ b/modules/apps/onlyoffice-desktop/module.jsonc
@@ -26,7 +26,7 @@
     "files": []
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\ONLYOFFICE\\DesktopEditors\\data\\sdkjs-plugins\\cloud_crypto.xml",
       "%LOCALAPPDATA%\\ONLYOFFICE\\DesktopEditors\\data\\Local Storage"

--- a/modules/apps/openvpn-connect/module.jsonc
+++ b/modules/apps/openvpn-connect/module.jsonc
@@ -41,7 +41,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\OpenVPN Connect\\config.json",
       "%APPDATA%\\OpenVPN Connect\\profiles"

--- a/modules/apps/owncloud/module.jsonc
+++ b/modules/apps/owncloud/module.jsonc
@@ -56,7 +56,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\ownCloud\\cookies*.db"
     ],

--- a/modules/apps/pcsx2/module.jsonc
+++ b/modules/apps/pcsx2/module.jsonc
@@ -96,7 +96,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%USERPROFILE%\\Documents\\PCSX2\\bios",
       "%USERPROFILE%\\Documents\\PCSX2\\inis\\secrets.ini"

--- a/modules/apps/pdf-xchange-editor/module.jsonc
+++ b/modules/apps/pdf-xchange-editor/module.jsonc
@@ -35,7 +35,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "registryKeys": [
       "HKCU\\Software\\Tracker Software\\Registration"
     ],

--- a/modules/apps/pgadmin/module.jsonc
+++ b/modules/apps/pgadmin/module.jsonc
@@ -55,7 +55,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\pgadmin\\azurecredentialcache",
       "%APPDATA%\\pgadmin\\sessions"

--- a/modules/apps/phpstorm/module.jsonc
+++ b/modules/apps/phpstorm/module.jsonc
@@ -79,7 +79,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\JetBrains\\PhpStorm*\\options\\security.xml",
       "%APPDATA%\\JetBrains\\PhpStorm*\\options\\github.xml"

--- a/modules/apps/picgo/module.jsonc
+++ b/modules/apps/picgo/module.jsonc
@@ -39,7 +39,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\picgo\\data.json",
       "%APPDATA%\\picgo\\external-picgo-cfg.json"

--- a/modules/apps/picpick/module.jsonc
+++ b/modules/apps/picpick/module.jsonc
@@ -43,7 +43,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\picpick\\picpick.ini"
     ],

--- a/modules/apps/pidgin/module.jsonc
+++ b/modules/apps/pidgin/module.jsonc
@@ -96,7 +96,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\.purple\\accounts.xml"
     ],

--- a/modules/apps/pip/module.jsonc
+++ b/modules/apps/pip/module.jsonc
@@ -55,7 +55,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\pip\\pip.ini",
       "~/pip/pip.ini"

--- a/modules/apps/playnite/module.jsonc
+++ b/modules/apps/playnite/module.jsonc
@@ -85,7 +85,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Playnite\\Extensions",
       "%APPDATA%\\Playnite\\ExtensionsData"

--- a/modules/apps/plex/module.jsonc
+++ b/modules/apps/plex/module.jsonc
@@ -49,7 +49,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\Plex Media Server\\Preferences.xml"
     ],

--- a/modules/apps/pnpm/module.jsonc
+++ b/modules/apps/pnpm/module.jsonc
@@ -42,7 +42,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\pnpm\\config\\rc",
       "%USERPROFILE%\\.npmrc"

--- a/modules/apps/poetry/module.jsonc
+++ b/modules/apps/poetry/module.jsonc
@@ -41,7 +41,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\pypoetry\\auth.toml"
     ],

--- a/modules/apps/putty/module.jsonc
+++ b/modules/apps/putty/module.jsonc
@@ -34,7 +34,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [],
     "warning": "PuTTY saved sessions include hostnames, usernames, and private-key file paths (not passwords). PuTTY does NOT store SSH passwords or .ppk passphrases. The only credential risk: if you use an AUTHENTICATED PROXY, the proxy password is stored in plaintext in each session's ProxyPassword value — review the exported PuTTY.reg before sharing a bundle. SSH private keys (.ppk) live in files, not the registry, and are never captured here.",
     "restorer": "warn-only"

--- a/modules/apps/pycharm-professional/module.jsonc
+++ b/modules/apps/pycharm-professional/module.jsonc
@@ -144,7 +144,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\JetBrains\\PyCharm2026.1\\options\\token",
       "%APPDATA%\\JetBrains\\PyCharm2026.1\\port",

--- a/modules/apps/pycharm/module.jsonc
+++ b/modules/apps/pycharm/module.jsonc
@@ -69,7 +69,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\JetBrains\\PyCharm*\\options\\security.xml",
       "%APPDATA%\\JetBrains\\PyCharm*\\options\\github.xml"

--- a/modules/apps/rancher-desktop/module.jsonc
+++ b/modules/apps/rancher-desktop/module.jsonc
@@ -51,7 +51,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\rancher-desktop\\rd-engine.json",
       "%LOCALAPPDATA%\\rancher-desktop\\credential-server.json"

--- a/modules/apps/rclone/module.jsonc
+++ b/modules/apps/rclone/module.jsonc
@@ -33,7 +33,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\rclone\\rclone.conf"
     ],

--- a/modules/apps/reaper/module.jsonc
+++ b/modules/apps/reaper/module.jsonc
@@ -66,7 +66,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\REAPER\\reaper-reginfo2.ini",
       "%APPDATA%\\REAPER\\reaper-license.rk"

--- a/modules/apps/remmina/module.jsonc
+++ b/modules/apps/remmina/module.jsonc
@@ -27,7 +27,7 @@
     "files": []
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "~/.config/remmina/remmina.pref",
       "~/.local/share/remmina/"

--- a/modules/apps/remote-desktop-manager/module.jsonc
+++ b/modules/apps/remote-desktop-manager/module.jsonc
@@ -77,7 +77,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\Devolutions\\RemoteDesktopManager\\RemoteDesktopManager.enc",
       "%LOCALAPPDATA%\\Devolutions\\RemoteDesktopManager\\RemoteDesktopManager.enb",

--- a/modules/apps/resilio-sync/module.jsonc
+++ b/modules/apps/resilio-sync/module.jsonc
@@ -41,7 +41,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Resilio Sync\\settings.dat",
       "%APPDATA%\\Resilio Sync\\sync.conf",

--- a/modules/apps/retroarch/module.jsonc
+++ b/modules/apps/retroarch/module.jsonc
@@ -93,7 +93,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\RetroArch\\retroarch.cfg"
     ],

--- a/modules/apps/revo-uninstaller/module.jsonc
+++ b/modules/apps/revo-uninstaller/module.jsonc
@@ -41,7 +41,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "HKCU\\Software\\VS Revo Group\\Revo Uninstaller Pro\\License"
     ],

--- a/modules/apps/rider/module.jsonc
+++ b/modules/apps/rider/module.jsonc
@@ -80,7 +80,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\JetBrains\\Rider*\\options\\security.xml",
       "%APPDATA%\\JetBrains\\Rider*\\options\\github.xml"

--- a/modules/apps/royal-ts/module.jsonc
+++ b/modules/apps/royal-ts/module.jsonc
@@ -62,7 +62,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\code4ward\\code4ward.RoyalTS.UserPreferences.config",
       "%USERPROFILE%\\**\\*.rtsz",

--- a/modules/apps/rpcs3/module.jsonc
+++ b/modules/apps/rpcs3/module.jsonc
@@ -24,7 +24,7 @@
     "files": []
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       // dev_hdd0 holds savedata, trophies, and RAP license keys for PSN
       // games/DLC. RAP files are per-machine activation blobs and MUST NOT be

--- a/modules/apps/rubymine/module.jsonc
+++ b/modules/apps/rubymine/module.jsonc
@@ -79,7 +79,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\JetBrains\\RubyMine*\\options\\security.xml",
       "%APPDATA%\\JetBrains\\RubyMine*\\options\\github.xml"

--- a/modules/apps/rustdesk/module.jsonc
+++ b/modules/apps/rustdesk/module.jsonc
@@ -47,7 +47,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\RustDesk\\config\\RustDesk.toml",
       "%APPDATA%\\RustDesk\\config\\*_local.toml"

--- a/modules/apps/rustrover/module.jsonc
+++ b/modules/apps/rustrover/module.jsonc
@@ -79,7 +79,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\JetBrains\\RustRover*\\options\\security.xml",
       "%APPDATA%\\JetBrains\\RustRover*\\options\\github.xml"

--- a/modules/apps/rustup-cargo/module.jsonc
+++ b/modules/apps/rustup-cargo/module.jsonc
@@ -73,7 +73,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "~/.cargo/credentials.toml",
       "~/.cargo/credentials"

--- a/modules/apps/ryujinx/module.jsonc
+++ b/modules/apps/ryujinx/module.jsonc
@@ -67,7 +67,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Ryujinx\\system\\prod.keys",
       "%APPDATA%\\Ryujinx\\system\\title.keys",

--- a/modules/apps/scoop/module.jsonc
+++ b/modules/apps/scoop/module.jsonc
@@ -41,7 +41,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%USERPROFILE%\\.config\\scoop\\config.json"
     ],

--- a/modules/apps/screentogif/module.jsonc
+++ b/modules/apps/screentogif/module.jsonc
@@ -41,7 +41,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\ScreenToGif\\Settings.xaml"
     ],

--- a/modules/apps/sharex/module.jsonc
+++ b/modules/apps/sharex/module.jsonc
@@ -55,7 +55,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%USERPROFILE%\\Documents\\ShareX\\UploadersConfig.json"
     ],

--- a/modules/apps/signal/module.jsonc
+++ b/modules/apps/signal/module.jsonc
@@ -19,7 +19,7 @@
   "restore": [],
   "capture": { "files": [], "excludeGlobs": [] },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Signal\\**"
     ],

--- a/modules/apps/ssh-config/module.jsonc
+++ b/modules/apps/ssh-config/module.jsonc
@@ -42,7 +42,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%USERPROFILE%\\.ssh\\id_rsa",
       "%USERPROFILE%\\.ssh\\id_ed25519",

--- a/modules/apps/ssms/module.jsonc
+++ b/modules/apps/ssms/module.jsonc
@@ -149,7 +149,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Microsoft\\SQL Server Management Studio\\18.0\\SqlStudio.bin",
       "%APPDATA%\\Microsoft\\SQL Server Management Studio\\19.0\\SqlStudio.bin",

--- a/modules/apps/strawberry/module.jsonc
+++ b/modules/apps/strawberry/module.jsonc
@@ -45,7 +45,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "registryKeys": [
       "HKCU\\Software\\Strawberry\\Strawberry"
     ],

--- a/modules/apps/studio-one/module.jsonc
+++ b/modules/apps/studio-one/module.jsonc
@@ -103,7 +103,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%PROGRAMDATA%\\PreSonus\\Studio One 7\\user.license",
       "%PROGRAMDATA%\\PreSonus\\Studio One 6\\user.license",

--- a/modules/apps/sublime-text/module.jsonc
+++ b/modules/apps/sublime-text/module.jsonc
@@ -44,7 +44,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Sublime Text\\Packages\\User\\SFTPBrowser.sublime-settings",
       "%APPDATA%\\Sublime Text\\Packages\\User\\SFTP.sublime-settings"

--- a/modules/apps/sunshine/module.jsonc
+++ b/modules/apps/sunshine/module.jsonc
@@ -60,7 +60,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%ProgramFiles%\\Sunshine\\config\\sunshine_state.json",
       "%ProgramFiles%\\Sunshine\\config\\credentials\\cakey.pem",

--- a/modules/apps/syncbackfree/module.jsonc
+++ b/modules/apps/syncbackfree/module.jsonc
@@ -57,7 +57,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\2BrightSparks\\SyncBackFree"
     ],

--- a/modules/apps/syncthing/module.jsonc
+++ b/modules/apps/syncthing/module.jsonc
@@ -88,7 +88,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\Syncthing\\key.pem",
       "%LOCALAPPDATA%\\Syncthing\\https-key.pem",

--- a/modules/apps/tabby/module.jsonc
+++ b/modules/apps/tabby/module.jsonc
@@ -48,7 +48,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\tabby\\config.yaml"
     ],

--- a/modules/apps/tableplus/module.jsonc
+++ b/modules/apps/tableplus/module.jsonc
@@ -49,7 +49,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "registryKeys": [
       "HKCU\\Software\\TablePlus\\TablePlus\\WinSparkle"
     ],

--- a/modules/apps/telegram/module.jsonc
+++ b/modules/apps/telegram/module.jsonc
@@ -19,7 +19,7 @@
   "restore": [],
   "capture": { "files": [], "excludeGlobs": [] },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Telegram Desktop\\tdata\\**"
     ],

--- a/modules/apps/terraform/module.jsonc
+++ b/modules/apps/terraform/module.jsonc
@@ -41,7 +41,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\terraform.d\\credentials.tfrc.json",
       "%USERPROFILE%\\.terraform.d\\credentials.tfrc.json"

--- a/modules/apps/thunderbird/module.jsonc
+++ b/modules/apps/thunderbird/module.jsonc
@@ -61,7 +61,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Thunderbird\\Profiles\\*\\key4.db",
       "%APPDATA%\\Thunderbird\\Profiles\\*\\logins.json",

--- a/modules/apps/totalcommander/module.jsonc
+++ b/modules/apps/totalcommander/module.jsonc
@@ -40,7 +40,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\GHISLER\\wcx_ftp.ini"
     ],

--- a/modules/apps/transmission/module.jsonc
+++ b/modules/apps/transmission/module.jsonc
@@ -62,7 +62,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\transmission\\settings.json",
       "%LOCALAPPDATA%\\transmission-daemon\\settings.json"

--- a/modules/apps/typora/module.jsonc
+++ b/modules/apps/typora/module.jsonc
@@ -55,7 +55,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Typora\\picgo\\config.json",
       "%USERPROFILE%\\.picgo\\config.json"

--- a/modules/apps/unity-hub/module.jsonc
+++ b/modules/apps/unity-hub/module.jsonc
@@ -77,7 +77,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\UnityHub\\accessToken.json",
       "%APPDATA%\\UnityHub\\refreshToken.json",

--- a/modules/apps/vagrant/module.jsonc
+++ b/modules/apps/vagrant/module.jsonc
@@ -69,7 +69,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%USERPROFILE%\\.vagrant.d\\insecure_private_key",
       "%USERPROFILE%\\.vagrant.d\\insecure_private_keys"

--- a/modules/apps/veracrypt/module.jsonc
+++ b/modules/apps/veracrypt/module.jsonc
@@ -55,7 +55,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\VeraCrypt\\Default Keyfiles.xml",
       "%APPDATA%\\VeraCrypt\\History.xml"

--- a/modules/apps/virtualdj/module.jsonc
+++ b/modules/apps/virtualdj/module.jsonc
@@ -100,7 +100,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\VirtualDJ\\licence.dat",
       "%USERPROFILE%\\Documents\\VirtualDJ\\licence.dat"

--- a/modules/apps/vmware-workstation/module.jsonc
+++ b/modules/apps/vmware-workstation/module.jsonc
@@ -58,7 +58,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\VMware\\preferences-private.ini",
       "%APPDATA%\\VMware\\ace.dat"

--- a/modules/apps/vscode/module.jsonc
+++ b/modules/apps/vscode/module.jsonc
@@ -68,7 +68,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Code\\User\\globalStorage\\state.vscdb",
       "%APPDATA%\\Code\\User\\globalStorage\\state.vscdb.backup"

--- a/modules/apps/vscodium/module.jsonc
+++ b/modules/apps/vscodium/module.jsonc
@@ -73,7 +73,7 @@
     ]
   },
   
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\VSCodium\\User\\globalStorage\\state.vscdb",
       "%APPDATA%\\VSCodium\\User\\globalStorage\\state.vscdb.backup"

--- a/modules/apps/warp-terminal/module.jsonc
+++ b/modules/apps/warp-terminal/module.jsonc
@@ -33,7 +33,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\Warp\\Warp\\data\\dev.warp.Warp-AiApiKeys",
       "%LOCALAPPDATA%\\Warp\\Warp\\data\\dev.warp.Warp-TemplatableMcpCredentials",

--- a/modules/apps/webstorm/module.jsonc
+++ b/modules/apps/webstorm/module.jsonc
@@ -69,7 +69,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\JetBrains\\WebStorm*\\options\\security.xml",
       "%APPDATA%\\JetBrains\\WebStorm*\\options\\github.xml"

--- a/modules/apps/weechat/module.jsonc
+++ b/modules/apps/weechat/module.jsonc
@@ -162,7 +162,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "~/.config/weechat/sec.conf",
       "~/.weechat/sec.conf",

--- a/modules/apps/winbox/module.jsonc
+++ b/modules/apps/winbox/module.jsonc
@@ -41,7 +41,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\MikroTik\\WinBox\\settings.cfg.viw",
       "%APPDATA%\\MikroTik\\WinBox\\Addresses.cdb"

--- a/modules/apps/windsurf/module.jsonc
+++ b/modules/apps/windsurf/module.jsonc
@@ -87,7 +87,7 @@
     ]
   },
   
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Windsurf\\User\\globalStorage\\state.vscdb",
       "%APPDATA%\\Windsurf\\User\\globalStorage\\state.vscdb.backup",

--- a/modules/apps/winrar/module.jsonc
+++ b/modules/apps/winrar/module.jsonc
@@ -54,7 +54,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\WinRAR\\rarreg.key",
       "%ProgramFiles%\\WinRAR\\rarreg.key"

--- a/modules/apps/winscp/module.jsonc
+++ b/modules/apps/winscp/module.jsonc
@@ -35,7 +35,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [],
     "warning": "WinSCP.ini may contain saved session passwords if master password is not set. Review before sharing.",
     "restorer": "warn-only"

--- a/modules/apps/wireguard/module.jsonc
+++ b/modules/apps/wireguard/module.jsonc
@@ -31,7 +31,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\WireGuard\\*.conf"
     ],

--- a/modules/apps/wireshark/module.jsonc
+++ b/modules/apps/wireshark/module.jsonc
@@ -164,7 +164,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Wireshark\\*.key",
       "%APPDATA%\\Wireshark\\*.pem",

--- a/modules/apps/wps-office/module.jsonc
+++ b/modules/apps/wps-office/module.jsonc
@@ -60,7 +60,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%LOCALAPPDATA%\\Kingsoft\\WPS Cloud Files"
     ],

--- a/modules/apps/xyplorer/module.jsonc
+++ b/modules/apps/xyplorer/module.jsonc
@@ -55,7 +55,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\XYplorer\\XYplorer.ini"
     ],

--- a/modules/apps/yarn/module.jsonc
+++ b/modules/apps/yarn/module.jsonc
@@ -53,7 +53,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "~/.yarnrc.yml"
     ],

--- a/modules/apps/yasb/module.jsonc
+++ b/modules/apps/yasb/module.jsonc
@@ -53,7 +53,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%USERPROFILE%\\.config\\yasb\\.env"
     ],

--- a/modules/apps/yt-dlp/module.jsonc
+++ b/modules/apps/yt-dlp/module.jsonc
@@ -73,7 +73,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "~/.netrc",
       "%USERPROFILE%\\.netrc"

--- a/modules/apps/zotero/module.jsonc
+++ b/modules/apps/zotero/module.jsonc
@@ -107,7 +107,7 @@
     ]
   },
 
-  "sensitive": {
+  "secrets": {
     "files": [
       "%APPDATA%\\Zotero\\Zotero\\Profiles\\*\\logins.json",
       "%APPDATA%\\Zotero\\Zotero\\Profiles\\*\\key3.db",

--- a/openspec/specs/capture-bundle-zip.md
+++ b/openspec/specs/capture-bundle-zip.md
@@ -19,7 +19,7 @@ Capture produces a single portable zip artifact containing the app manifest, con
 - Match via `matches.winget` array against captured app's `refs.windows`
 - Matched modules' `capture.files` are copied into zip under `configs/<module-id>/`
 - Files matching `capture.excludeGlobs` are skipped
-- Files listed in `sensitive.files` are NEVER included
+- Files listed in `secrets.files` are NEVER included
 
 ### Profile Discovery
 
@@ -51,7 +51,7 @@ Capture success response includes:
 The zip MUST contain everything needed to restore on another machine. No external file references.
 
 ### INV-BUNDLE-2: Sensitive files never bundled
-Files listed in `module.sensitive.files` MUST NOT appear in the zip. Enforced at capture time.
+Files listed in `module.secrets.files` MUST NOT appear in the zip. Enforced at capture time.
 
 ### INV-BUNDLE-3: Config capture failures don't block app capture
 Missing or inaccessible config files are reported in `captureWarnings` and `metadata.json`. Manifest is always written.


### PR DESCRIPTION
## Summary

Renames the module schema's `sensitive` **block** → `secrets` (and the Go `Sensitive`/`SensitiveDef` identifiers → `Secrets`/`SecretsDef`, plus the json tag). **Pure rename — no behavior change.**

## Why

The module schema had two confusingly-similar fields:
- **`sensitivity`** — a tier (`none`/`low`/`medium`/`high`) classifying how credential-adjacent an app's settings are. It's **GUI metadata** (the engine parses but never acts on it).
- **`sensitive`** — a *block* (`{ files, warning, restorer }`) listing the specific secret files to exclude/guard.

The near-homonym made it easy to conflate the two (the tier reads like it controls the block, which it doesn't). `sensitivity` is the correct name for the tier; the block is renamed to **`secrets`**, which says what it actually holds. Now: `sensitivity` classifies, `secrets` lists the files to never restore.

## Changes

- `go-engine/internal/modules/types.go`: `Sensitive *SensitiveDef` → `Secrets *SecretsDef`, `type SensitiveDef` → `type SecretsDef`, `json:"sensitive"` → `json:"secrets"`. (`restore/CheckSensitivePath` + `sensitiveSegments` are unrelated path-safety code and are untouched.)
- **172 module.jsonc** files: block key `"sensitive":` → `"secrets":` (the tier field `"sensitivity":` is deliberately left alone).
- Docs: `.claude/agents/module-author.md`, `docs/prompts/capture-bundle-zip.md`.
- Contract: `docs/contracts/capture-artifact-contract.md` INV-CAPTURE-5 (`module.sensitive.files` → `module.secrets.files`).
- Spec: `openspec/specs/capture-bundle-zip.md` INV-BUNDLE-2.
- New regression guard: `catalog_secrets_guard_test.go` fails if any module reintroduces the legacy `"sensitive":` block key.

## ⚠️ Breaking schema change — action needed elsewhere

- The **GUI (separate repo)** reads this field for its sensitive-file warnings → it needs a matching `sensitive`→`secrets` update, or those warnings silently stop working.
- External/3rd-party module authors using a `sensitive` block must switch to `secrets`.
- All 315 in-repo modules are already updated here.
- **Consider whether this warrants a major version bump** at merge (it's semver-breaking for the field's consumers).

## Validation

- `go test ./...` — all pass, incl. new `TestCatalogIntegrity_NoLegacySensitiveKey`
- `go vet ./...` — clean
- `npm run openspec:validate` — 52/52

## Side-finding (separate from this rename)

`openspec/specs/capture-bundle-zip.md` INV-BUNDLE-2 states `secrets.files` are "NEVER included… enforced at capture time," but the engine never reads the block (`mod.Secrets`) — exclusion appears to happen only via `excludeGlobs`. Either the block-based exclusion isn't actually enforced, or the invariant is satisfied indirectly. Worth verifying/fixing in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
