### PR TITLE
fix(capture): enforce module secrets.files exclusion at capture time

### DIFF
--- a/go-engine/internal/bundle/bundle_test.go
+++ b/go-engine/internal/bundle/bundle_test.go
@@ -325,7 +325,7 @@ func TestCollectConfigFiles_OptionalMissing(t *testing.T) {
 		},
 	}
 
-	collected, err := CollectConfigFiles(mod, stagingDir)
+	collected, _, err := CollectConfigFiles(mod, stagingDir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -350,7 +350,7 @@ func TestCollectConfigFiles_RequiredMissing(t *testing.T) {
 		},
 	}
 
-	_, err := CollectConfigFiles(mod, stagingDir)
+	_, _, err := CollectConfigFiles(mod, stagingDir)
 	if err == nil {
 		t.Fatal("expected error for required missing file, got nil")
 	}
@@ -388,7 +388,7 @@ func TestCollectConfigFiles_ExcludeGlobs(t *testing.T) {
 		},
 	}
 
-	collected, err := CollectConfigFiles(mod, stagingDir)
+	collected, _, err := CollectConfigFiles(mod, stagingDir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -429,7 +429,7 @@ func TestCollectConfigFiles_SingleFile(t *testing.T) {
 		},
 	}
 
-	collected, err := CollectConfigFiles(mod, stagingDir)
+	collected, _, err := CollectConfigFiles(mod, stagingDir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -453,7 +453,7 @@ func TestCollectConfigFiles_NoCaptureSection(t *testing.T) {
 		ID: "apps.no-capture",
 	}
 
-	collected, err := CollectConfigFiles(mod, t.TempDir())
+	collected, _, err := CollectConfigFiles(mod, t.TempDir())
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -971,7 +971,7 @@ func TestCollectConfigFiles_ExcludeGlobs_VENPrefix(t *testing.T) {
 		},
 	}
 
-	collected, err := CollectConfigFiles(mod, stagingDir)
+	collected, _, err := CollectConfigFiles(mod, stagingDir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1018,7 +1018,7 @@ func TestCollectConfigFiles_StripsAppsPrefix(t *testing.T) {
 		},
 	}
 
-	_, err := CollectConfigFiles(mod, stagingDir)
+	_, _, err := CollectConfigFiles(mod, stagingDir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -1061,7 +1061,7 @@ func TestCollectConfigFiles_MultipleFiles(t *testing.T) {
 		},
 	}
 
-	collected, err := CollectConfigFiles(mod, stagingDir)
+	collected, _, err := CollectConfigFiles(mod, stagingDir)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/go-engine/internal/bundle/collect.go
+++ b/go-engine/internal/bundle/collect.go
@@ -25,10 +25,15 @@ import (
 // source paths are expanded. Optional files that don't exist are skipped.
 // ExcludeGlobs filter out matching paths during collection.
 //
-// Returns the list of relative paths (under stagingDir) that were collected.
-func CollectConfigFiles(module *modules.Module, stagingDir string) ([]string, error) {
+// Files matching the module's secrets.files patterns are NEVER bundled — this
+// enforces the secrets-exclusion invariant (INV-BUNDLE-2) at capture time,
+// independent of excludeGlobs.
+//
+// Returns the list of relative paths (under stagingDir) that were collected and
+// the number of files excluded because they matched the module's secrets.files.
+func CollectConfigFiles(module *modules.Module, stagingDir string) ([]string, int, error) {
 	if module.Capture == nil || len(module.Capture.Files) == 0 {
-		return nil, nil
+		return nil, 0, nil
 	}
 
 	// Determine the module directory name (strip "apps." prefix if present).
@@ -38,23 +43,25 @@ func CollectConfigFiles(module *modules.Module, stagingDir string) ([]string, er
 	}
 
 	excludeGlobs := module.Capture.ExcludeGlobs
+	var secretsFiles []string
+	if module.Secrets != nil {
+		secretsFiles = module.Secrets.Files
+	}
 	var collected []string
+	secretsExcluded := 0
 
 	for _, fileEntry := range module.Capture.Files {
-		sourcePath := config.ExpandEnvVars(fileEntry.Source)
-		sourcePath = os.ExpandEnv(sourcePath)
-
-		// Expand ~ to home directory.
-		if strings.HasPrefix(sourcePath, "~/") || strings.HasPrefix(sourcePath, "~\\") {
-			home, err := os.UserHomeDir()
-			if err == nil {
-				sourcePath = filepath.Join(home, sourcePath[2:])
-			}
-		}
+		sourcePath := expandPath(fileEntry.Source)
 
 		destFileName := filepath.Base(fileEntry.Dest)
 		destPath := filepath.Join(stagingDir, "configs", moduleDirName, destFileName)
 		relativePath := filepath.ToSlash(filepath.Join("configs", moduleDirName, destFileName))
+
+		// Secret files declared in the module's secrets block are never bundled.
+		if matchesSecrets(sourcePath, secretsFiles) {
+			secretsExcluded++
+			continue
+		}
 
 		// Check if source matches exclude globs.
 		if matchesExcludeGlobs(sourcePath, excludeGlobs) {
@@ -67,31 +74,33 @@ func CollectConfigFiles(module *modules.Module, stagingDir string) ([]string, er
 			if fileEntry.Optional {
 				continue
 			}
-			return collected, fmt.Errorf("missing required file: %s (module: %s)", sourcePath, module.ID)
+			return collected, secretsExcluded, fmt.Errorf("missing required file: %s (module: %s)", sourcePath, module.ID)
 		}
 
 		// Ensure destination directory exists.
 		destDir := filepath.Dir(destPath)
 		if err := os.MkdirAll(destDir, 0755); err != nil {
-			return collected, fmt.Errorf("failed to create directory %s: %w", destDir, err)
+			return collected, secretsExcluded, fmt.Errorf("failed to create directory %s: %w", destDir, err)
 		}
 
 		if info.IsDir() {
-			// Copy directory recursively.
-			if err := copyDir(sourcePath, destPath, excludeGlobs); err != nil {
-				return collected, fmt.Errorf("failed to copy directory %s: %w", sourcePath, err)
+			// Copy directory recursively, excluding secret files within.
+			n, err := copyDir(sourcePath, destPath, excludeGlobs, secretsFiles)
+			if err != nil {
+				return collected, secretsExcluded, fmt.Errorf("failed to copy directory %s: %w", sourcePath, err)
 			}
+			secretsExcluded += n
 		} else {
 			// Copy single file.
 			if err := copyFile(sourcePath, destPath); err != nil {
-				return collected, fmt.Errorf("failed to copy file %s: %w", sourcePath, err)
+				return collected, secretsExcluded, fmt.Errorf("failed to copy file %s: %w", sourcePath, err)
 			}
 		}
 
 		collected = append(collected, relativePath)
 	}
 
-	return collected, nil
+	return collected, secretsExcluded, nil
 }
 
 // CollectRegistryKeys exports Windows registry keys defined in module.Capture.RegistryKeys
@@ -197,18 +206,30 @@ func copyFile(src, dst string) error {
 	return out.Close()
 }
 
-// copyDir recursively copies a directory, respecting excludeGlobs.
-func copyDir(src, dst string, excludeGlobs []string) error {
+// copyDir recursively copies a directory, respecting excludeGlobs and the
+// module's secrets.files patterns. Returns the number of entries skipped
+// because they matched a secrets pattern.
+func copyDir(src, dst string, excludeGlobs, secretsFiles []string) (int, error) {
 	// Remove existing destination to prevent nesting (matches PS behaviour).
 	if _, err := os.Stat(dst); err == nil {
 		if err := os.RemoveAll(dst); err != nil {
-			return err
+			return 0, err
 		}
 	}
 
-	return filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
+	secretsExcluded := 0
+	err := filepath.Walk(src, func(path string, info os.FileInfo, err error) error {
 		if err != nil {
 			return err
+		}
+
+		// Secret files/dirs declared in the module's secrets block are never bundled.
+		if matchesSecrets(path, secretsFiles) {
+			secretsExcluded++
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
 		}
 
 		// Check exclude globs.
@@ -231,4 +252,72 @@ func copyDir(src, dst string, excludeGlobs []string) error {
 
 		return copyFile(path, destPath)
 	})
+	return secretsExcluded, err
+}
+
+// expandPath expands %VAR% / $VAR environment variables and a leading ~ in a path.
+func expandPath(p string) string {
+	s := config.ExpandEnvVars(p)
+	s = os.ExpandEnv(s)
+	if strings.HasPrefix(s, "~/") || strings.HasPrefix(s, "~\\") {
+		if home, err := os.UserHomeDir(); err == nil {
+			s = filepath.Join(home, s[2:])
+		}
+	}
+	return s
+}
+
+// matchesSecrets reports whether path matches any of the module's secrets.files
+// patterns. Patterns may be absolute (env- or ~-rooted) file/dir paths, single-
+// glob patterns (*, ?, []), or contain "**" wildcards. Matching is
+// case-insensitive (Windows paths are case-insensitive).
+func matchesSecrets(path string, patterns []string) bool {
+	if len(patterns) == 0 {
+		return false
+	}
+	target := strings.ToLower(filepath.ToSlash(path))
+	for _, raw := range patterns {
+		p := strings.ToLower(filepath.ToSlash(expandPath(raw)))
+		if p == "" {
+			continue
+		}
+		switch {
+		case strings.Contains(p, "**"):
+			// Ordered-substring match of the literal parts around "**".
+			if containsOrdered(target, strings.Split(p, "**")) {
+				return true
+			}
+		case strings.ContainsAny(p, "*?["):
+			if m, _ := filepath.Match(p, target); m {
+				return true
+			}
+			if m, _ := filepath.Match(filepath.Base(p), filepath.Base(target)); m {
+				return true
+			}
+		default:
+			// Literal file, or directory prefix (path lives under the secret dir).
+			if target == p || strings.HasPrefix(target, p+"/") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// containsOrdered reports whether target contains each trimmed, non-empty part
+// in order — used to evaluate "**"-separated secret patterns.
+func containsOrdered(target string, parts []string) bool {
+	idx := 0
+	for _, part := range parts {
+		part = strings.Trim(part, "/")
+		if part == "" {
+			continue
+		}
+		j := strings.Index(target[idx:], part)
+		if j < 0 {
+			return false
+		}
+		idx += j + len(part)
+	}
+	return true
 }

--- a/go-engine/internal/bundle/collect_secrets_test.go
+++ b/go-engine/internal/bundle/collect_secrets_test.go
@@ -1,0 +1,123 @@
+// Copyright 2025 Substrate Systems OU
+// SPDX-License-Identifier: Apache-2.0
+
+package bundle
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/modules"
+)
+
+// TestCollectConfigFiles_ExcludesSecretFile verifies that a top-level capture
+// file listed in the module's secrets block is never staged, and is counted.
+func TestCollectConfigFiles_ExcludesSecretFile(t *testing.T) {
+	src := t.TempDir()
+	settings := filepath.Join(src, "settings.json")
+	secret := filepath.Join(src, "secret.token")
+	if err := os.WriteFile(settings, []byte(`{"a":1}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(secret, []byte("TOKEN"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mod := &modules.Module{
+		ID: "apps.testsecrets",
+		Capture: &modules.CaptureDef{
+			Files: []modules.CaptureFile{
+				{Source: settings, Dest: "apps/testsecrets/settings.json", Optional: true},
+				{Source: secret, Dest: "apps/testsecrets/secret.token", Optional: true},
+			},
+		},
+		Secrets: &modules.SecretsDef{Files: []string{secret}},
+	}
+
+	staging := t.TempDir()
+	collected, n, err := CollectConfigFiles(mod, staging)
+	if err != nil {
+		t.Fatalf("CollectConfigFiles: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("secretsExcluded = %d, want 1", n)
+	}
+	if len(collected) != 1 {
+		t.Errorf("collected = %v, want 1 entry (settings only)", collected)
+	}
+	if _, err := os.Stat(filepath.Join(staging, "configs", "testsecrets", "settings.json")); err != nil {
+		t.Errorf("settings.json should be staged: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(staging, "configs", "testsecrets", "secret.token")); !os.IsNotExist(err) {
+		t.Errorf("secret.token must NOT be staged (got err=%v)", err)
+	}
+}
+
+// TestCollectConfigFiles_ExcludesSecretInDir verifies that a secret file living
+// inside a captured directory is excluded during the recursive copy.
+func TestCollectConfigFiles_ExcludesSecretInDir(t *testing.T) {
+	src := t.TempDir()
+	cfgDir := filepath.Join(src, "cfg")
+	if err := os.MkdirAll(cfgDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	keep := filepath.Join(cfgDir, "config.json")
+	env := filepath.Join(cfgDir, ".env")
+	if err := os.WriteFile(keep, []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(env, []byte("API_KEY=secret"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mod := &modules.Module{
+		ID: "apps.testsecretsdir",
+		Capture: &modules.CaptureDef{
+			Files: []modules.CaptureFile{
+				{Source: cfgDir, Dest: "apps/testsecretsdir/cfg", Optional: true},
+			},
+		},
+		Secrets: &modules.SecretsDef{Files: []string{env}},
+	}
+
+	staging := t.TempDir()
+	_, n, err := CollectConfigFiles(mod, staging)
+	if err != nil {
+		t.Fatalf("CollectConfigFiles: %v", err)
+	}
+	if n != 1 {
+		t.Errorf("secretsExcluded = %d, want 1", n)
+	}
+	if _, err := os.Stat(filepath.Join(staging, "configs", "testsecretsdir", "cfg", "config.json")); err != nil {
+		t.Errorf("config.json should be staged: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(staging, "configs", "testsecretsdir", "cfg", ".env")); !os.IsNotExist(err) {
+		t.Errorf(".env must NOT be staged (got err=%v)", err)
+	}
+}
+
+// TestMatchesSecrets covers literal, directory-prefix, glob, and ** patterns.
+func TestMatchesSecrets(t *testing.T) {
+	cases := []struct {
+		name     string
+		path     string
+		patterns []string
+		want     bool
+	}{
+		{"literal file", "C:/Users/a/AppData/state.vscdb", []string{"C:/Users/a/AppData/state.vscdb"}, true},
+		{"case-insensitive", "C:/Users/A/State.VSCDB", []string{"c:/users/a/state.vscdb"}, true},
+		{"dir prefix", "C:/Users/a/secure/key.pem", []string{"C:/Users/a/secure"}, true},
+		{"doublestar", "C:/Users/a/app/.env", []string{"**/.env"}, true},
+		{"glob basename", "C:/Users/a/x.credential.json", []string{"*.credential*"}, true},
+		{"no match", "C:/Users/a/settings.json", []string{"**/.env", "*.token", "C:/Users/a/other"}, false},
+		{"empty patterns", "C:/Users/a/settings.json", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := matchesSecrets(c.path, c.patterns); got != c.want {
+				t.Errorf("matchesSecrets(%q, %v) = %v, want %v", c.path, c.patterns, got, c.want)
+			}
+		})
+	}
+}

--- a/go-engine/internal/bundle/create.go
+++ b/go-engine/internal/bundle/create.go
@@ -72,7 +72,7 @@ func CreateBundle(manifestPath string, matchedModules []*modules.Module, outputP
 			moduleDirName = moduleDirName[5:]
 		}
 
-		fileCollected, err := CollectConfigFiles(mod, stagingDir)
+		fileCollected, _, err := CollectConfigFiles(mod, stagingDir)
 		if err != nil {
 			captureWarnings = append(captureWarnings, fmt.Sprintf("module %s: %v", mod.ID, err))
 			skipped = append(skipped, moduleDirName)

--- a/go-engine/internal/commands/capture.go
+++ b/go-engine/internal/commands/capture.go
@@ -410,6 +410,7 @@ func RunCapture(flags CaptureFlags) (interface{}, *envelope.Error) {
 	configsIncluded := []string{}
 	configsSkipped := []string{}
 	configsCaptureErrors := []string{}
+	configSecretsExcluded := 0
 
 	outputFormat := "jsonc"
 	finalOutputPath := absPath
@@ -461,7 +462,7 @@ func RunCapture(flags CaptureFlags) (interface{}, *envelope.Error) {
 
 					// Build per-module results using a fresh staging pass so we
 					// have accurate file counts and paths.
-					configModules, configsIncluded, configsSkipped, configsCaptureErrors =
+					configModules, configsIncluded, configsSkipped, configsCaptureErrors, configSecretsExcluded =
 						buildConfigModuleResults(matchedModules, configsCaptureErrors)
 				}
 			}
@@ -501,7 +502,7 @@ func RunCapture(flags CaptureFlags) (interface{}, *envelope.Error) {
 			FilteredRuntimes:       filteredRuntimes,
 			Included:               included,
 			TotalFound:             totalFound,
-			SensitiveExcludedCount: 0,
+			SensitiveExcludedCount: configSecretsExcluded,
 			FilteredStoreApps:      filteredStore,
 			Skipped:                skipped,
 		},
@@ -561,6 +562,7 @@ func buildConfigModuleResults(matchedModules []*modules.Module, existingErrors [
 	included []string,
 	skipped []string,
 	captureErrors []string,
+	sensitiveExcluded int,
 ) {
 	captureErrors = existingErrors
 
@@ -591,7 +593,8 @@ func buildConfigModuleResults(matchedModules []*modules.Module, existingErrors [
 	for _, mod := range matchedModules {
 		dirName := moduleDirName(mod.ID)
 
-		fileCollected, collectErr := bundle.CollectConfigFiles(mod, stagingDir)
+		fileCollected, secretsN, collectErr := bundle.CollectConfigFiles(mod, stagingDir)
+		sensitiveExcluded += secretsN
 		if collectErr != nil {
 			captureErrors = append(captureErrors, fmt.Sprintf("module %s: %v", mod.ID, collectErr))
 			moduleErrors[dirName] = true


### PR DESCRIPTION
## Summary

Re-lands the `secrets.files` capture-time enforcement onto `main`. The original fix (#55) was stacked on #53 and merged into the **#53 branch**, not `main` — so it never reached `main`: `matchesSecrets` was absent and `sensitiveExcludedCount` stayed hardcoded `0`. This applies the same change directly off `main`.

## What

- **`bundle/collect.go`** — `CollectConfigFiles`/`copyDir` skip files matching `module.secrets.files` (absolute env/`~`-rooted paths, `*`/`?`/`[]` globs, and `**`), independent of `excludeGlobs`; returns the excluded count.
- **`commands/capture.go`** — the real count populates `sensitiveExcludedCount` (was hardcoded `0`) → the GUI's "sensitive excluded (security)" stat works.
- **Tests** — top-level / in-directory / glob / `**` / case-insensitive exclusion.

## Why

Implements spec **INV-BUNDLE-2** (`secrets.files` MUST NOT be bundled, enforced at capture), which the engine never honored — exclusion previously depended solely on `excludeGlobs`, and a declared secret was only protected if duplicated there. Now `secrets` is a real, enforced safety net.

The **GUI needs no change** — verified `endstate-gui` does not consume the module block (its sensitive UI is driven by separate runtime events/counts).

## Validation

- `go test ./...` — all pass (incl. new `bundle` tests) · `go vet ./...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
