### PR TITLE
feat(engine): engine-owned provisioning generation for both backends

### DIFF
--- a/docs/contracts/cli-json-contract.md
+++ b/docs/contracts/cli-json-contract.md
@@ -441,6 +441,42 @@ endstate report --run-id 20241220-143052 --json
 
 ---
 
+## Command: `generations`
+
+Lists recorded Provisioning Generations, newest first. Read-only. Additive in schema 1.x.
+
+### Response
+
+```json
+{
+  "schemaVersion": "1.0",
+  "cliVersion": "0.1.0",
+  "command": "generations",
+  "runId": "20241220-143052",
+  "timestampUtc": "2024-12-20T14:30:52Z",
+  "success": true,
+  "data": {
+    "generations": [
+      {
+        "schemaVersion": "1.0",
+        "number": 2,
+        "runId": "apply-20241220-143052",
+        "timestamp": "2024-12-20T14:30:52Z",
+        "backend": "nix",
+        "items": [
+          { "id": "ripgrep", "ref": "nixpkgs#ripgrep", "status": "installed" }
+        ],
+        "addedRefs": ["nixpkgs#ripgrep"],
+        "native": "2",
+        "partial": false
+      }
+    ]
+  }
+}
+```
+
+`backend` is `"nix"` or `"winget"`. `native` is the backend-native generation number (the Nix generation) or empty for non-atomic backends. `partial` is true when a non-atomic backend (winget) committed only a subset of the requested set. `addedRefs` lists only refs installed in that run (status `installed`); already-present refs appear in `items` but not `addedRefs`. A generation is recorded only when at least one package was installed in the run.
+
 ## Versioning Rules
 
 ### Semantic Versioning

--- a/go-engine/cmd/endstate/main.go
+++ b/go-engine/cmd/endstate/main.go
@@ -34,6 +34,7 @@ Commands:
   export-config   Export configuration files from system
   validate-export Validate export completeness
   report          Retrieve run history
+  generations     List provisioning generations
   doctor          Run diagnostics
   bootstrap       Bootstrap Endstate installation
   backup          Hosted Backup commands (login, logout, status, ...)
@@ -439,6 +440,11 @@ func dispatch(p parsedArgs) (interface{}, *envelope.Error) {
 			Latest: p.latest,
 			Last:   p.last,
 			RunID:  p.runID,
+			Events: p.events,
+		})
+
+	case "generations":
+		return commands.RunGenerations(commands.GenerationsFlags{
 			Events: p.events,
 		})
 

--- a/go-engine/internal/commands/apply.go
+++ b/go-engine/internal/commands/apply.go
@@ -364,6 +364,11 @@ func RunApply(flags ApplyFlags) (interface{}, *envelope.Error) {
 		applyTotal := successCount + skippedCount + failedCount
 		emitter.EmitSummary("apply", applyTotal, successCount, skippedCount, failedCount)
 
+		// Record a Provisioning Generation for the install stage (best-effort,
+		// install-only). Written only when >=1 package was installed this run;
+		// Partial when any attempted install failed. Never touches restore state.
+		writeProvisioningGeneration(runID, d.Name(), finalActions, "", failedCount > 0)
+
 		// ----------------------------------------------------------------
 		// Phase 2b: Restore  (when --enable-restore and manifest has entries)
 		// ----------------------------------------------------------------

--- a/go-engine/internal/commands/apply_generation.go
+++ b/go-engine/internal/commands/apply_generation.go
@@ -1,0 +1,55 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"time"
+
+	"github.com/Artexis10/endstate/go-engine/internal/provision"
+)
+
+// writeProvisioningGeneration records a Provisioning Generation for a successful
+// apply, but only when the committed package set advanced — i.e. at least one
+// ref was installed this run. Idempotent re-runs (nothing newly installed) write
+// no generation. It is best-effort: a write error never fails the apply,
+// mirroring run-history persistence.
+//
+// Separation of concerns: this records package facts only (the installed and
+// already-present refs). It never touches the config backup directory
+// (state/backups/) or the restore revert journal.
+func writeProvisioningGeneration(runID, backend string, actions []ApplyAction, native string, partial bool) {
+	items := make([]provision.ProvItem, 0, len(actions))
+	added := make([]string, 0)
+	for _, a := range actions {
+		switch a.Status {
+		case "installed":
+			ref := derefRef(a.Ref)
+			items = append(items, provision.ProvItem{ID: a.ID, Ref: ref, Status: "installed"})
+			added = append(added, ref)
+		case "present":
+			items = append(items, provision.ProvItem{ID: a.ID, Ref: derefRef(a.Ref), Status: "present"})
+		}
+	}
+	if len(added) == 0 {
+		return // nothing newly installed → no new generation
+	}
+	_ = provision.Write(&provision.Generation{
+		RunID:     runID,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Backend:   backend,
+		Items:     items,
+		AddedRefs: added,
+		Native:    native,
+		Partial:   partial,
+	})
+}
+
+// derefRef returns the value of an ApplyAction ref pointer, or "" when nil
+// (e.g. manual apps carry no package ref).
+func derefRef(ref *string) string {
+	if ref == nil {
+		return ""
+	}
+	return *ref
+}

--- a/go-engine/internal/commands/apply_generation_test.go
+++ b/go-engine/internal/commands/apply_generation_test.go
@@ -1,0 +1,173 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/events"
+	"github.com/Artexis10/endstate/go-engine/internal/manifest"
+	"github.com/Artexis10/endstate/go-engine/internal/provision"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+// --- writeProvisioningGeneration: record-building logic (backend-agnostic) ---
+
+func TestWriteProvisioningGeneration_RecordsInstalledOnly(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	actions := []ApplyAction{
+		{ID: "ripgrep", Ref: stringPtr("nixpkgs#ripgrep"), Status: "installed"},
+		{ID: "jq", Ref: stringPtr("nixpkgs#jq"), Status: "present"},
+		{ID: "bad", Ref: stringPtr("nixpkgs#bad"), Status: "failed"},
+	}
+	writeProvisioningGeneration("apply-x", "nix", actions, "7", false)
+
+	gens, err := provision.List()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gens) != 1 {
+		t.Fatalf("want 1 generation, got %d", len(gens))
+	}
+	g := gens[0]
+	if g.Backend != "nix" || g.Native != "7" || g.Partial {
+		t.Fatalf("unexpected header: %+v", g)
+	}
+	if len(g.AddedRefs) != 1 || g.AddedRefs[0] != "nixpkgs#ripgrep" {
+		t.Fatalf("addedRefs should be installed-only: %v", g.AddedRefs)
+	}
+	if len(g.Items) != 2 { // installed + present, NOT failed
+		t.Fatalf("items should be installed+present only: %+v", g.Items)
+	}
+}
+
+func TestWriteProvisioningGeneration_NoInstallsNoGeneration(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	actions := []ApplyAction{{ID: "jq", Ref: stringPtr("nixpkgs#jq"), Status: "present"}}
+	writeProvisioningGeneration("apply-x", "nix", actions, "", false)
+
+	gens, _ := provision.List()
+	if len(gens) != 0 {
+		t.Fatalf("idempotent run must write no generation, got %d", len(gens))
+	}
+}
+
+func TestWriteProvisioningGeneration_WingetPartialSubset(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	actions := []ApplyAction{
+		{ID: "a", Ref: stringPtr("A.A"), Status: "installed"},
+		{ID: "b", Ref: stringPtr("B.B"), Status: "failed"},
+	}
+	writeProvisioningGeneration("apply-x", "winget", actions, "", true)
+
+	gens, _ := provision.List()
+	if len(gens) != 1 {
+		t.Fatalf("want 1 generation, got %d", len(gens))
+	}
+	g := gens[0]
+	if g.Backend != "winget" || g.Native != "" || !g.Partial {
+		t.Fatalf("unexpected winget header: %+v", g)
+	}
+	if len(g.AddedRefs) != 1 || g.AddedRefs[0] != "A.A" {
+		t.Fatalf("addedRefs should be the installed subset: %v", g.AddedRefs)
+	}
+}
+
+// --- Realizer (nix) apply path wiring ---
+
+func TestRunApplyRealizer_WritesGenerationOnFullSuccess(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	r := &fakeRealizer{
+		planDiff:      realizer.Diff{ToAdd: []realizer.Installable{{ID: "ripgrep", Ref: "nixpkgs#ripgrep"}}},
+		realizeResult: realizer.Result{Advanced: true, ToGeneration: 3},
+	}
+	mf := &manifest.Manifest{Apps: []manifest.App{nixApp("ripgrep", "nixpkgs#ripgrep")}}
+	emitter := events.NewEmitter("apply-test", false)
+
+	_, eerr := runApplyRealizer(ApplyFlags{Manifest: "m.jsonc"}, mf, r, emitter, "apply-test", nil, nil)
+	if eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+
+	gens, _ := provision.List()
+	if len(gens) != 1 {
+		t.Fatalf("want 1 generation, got %d", len(gens))
+	}
+	g := gens[0]
+	if g.Backend != "nix" || g.Native != "3" || g.Partial {
+		t.Fatalf("unexpected nix generation: %+v", g)
+	}
+	if len(g.AddedRefs) != 1 || g.AddedRefs[0] != "nixpkgs#ripgrep" {
+		t.Fatalf("addedRefs: %v", g.AddedRefs)
+	}
+}
+
+func TestRunApplyRealizer_NoGenerationWhenGenerationDidNotAdvance(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	// Realize returns success but the profile generation did not advance: an
+	// atomic backend must NOT record a generation.
+	r := &fakeRealizer{
+		planDiff:      realizer.Diff{ToAdd: []realizer.Installable{{ID: "ripgrep", Ref: "nixpkgs#ripgrep"}}},
+		realizeResult: realizer.Result{Advanced: false},
+	}
+	mf := &manifest.Manifest{Apps: []manifest.App{nixApp("ripgrep", "nixpkgs#ripgrep")}}
+	emitter := events.NewEmitter("apply-test", false)
+
+	_, _ = runApplyRealizer(ApplyFlags{Manifest: "m.jsonc"}, mf, r, emitter, "apply-test", nil, nil)
+
+	gens, _ := provision.List()
+	if len(gens) != 0 {
+		t.Fatalf("no generation expected when not advanced, got %d", len(gens))
+	}
+}
+
+// --- Driver (winget) apply path wiring ---
+
+func TestRunApply_DriverPathWritesGeneration(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	// Nothing pre-installed: the mock driver installs the ref this run.
+	md := &mockDriver{installed: map[string]bool{}}
+
+	manifestContent := `{
+		"name": "gen-driver-test",
+		"apps": [
+			{ "id": "a", "refs": { "windows": "Vendor.A" } }
+		]
+	}`
+	manifestPath := filepath.Join(t.TempDir(), "m.jsonc")
+	if err := os.WriteFile(manifestPath, []byte(manifestContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var eerr *envelope.Error
+	withMockDriver(md, func() {
+		_, eerr = RunApply(ApplyFlags{Manifest: manifestPath})
+	})
+	if eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+
+	gens, _ := provision.List()
+	if len(gens) != 1 {
+		t.Fatalf("want 1 generation, got %d", len(gens))
+	}
+	g := gens[0]
+	// Backend is taken from the driver's Name() (the mock reports "mock"),
+	// proving the wiring is backend-agnostic. Native is empty (non-atomic).
+	if g.Backend != "mock" || g.Native != "" || g.Partial {
+		t.Fatalf("unexpected driver generation: %+v", g)
+	}
+	if len(g.AddedRefs) != 1 || g.AddedRefs[0] != "Vendor.A" {
+		t.Fatalf("addedRefs: %v", g.AddedRefs)
+	}
+}

--- a/go-engine/internal/commands/apply_realizer.go
+++ b/go-engine/internal/commands/apply_realizer.go
@@ -227,6 +227,11 @@ func runApplyRealizer(flags ApplyFlags, mf *manifest.Manifest, r realizer.Realiz
 				}
 				successCount++
 			}
+			// Record a Provisioning Generation: the atomic switch committed (full
+			// success advanced the profile generation). Install-only, best-effort.
+			if res.Advanced {
+				writeProvisioningGeneration(runID, driverName, actions, fmt.Sprintf("%d", res.ToGeneration), false)
+			}
 		}
 	}
 	// Already-present nix packages count as skipped in the apply phase.

--- a/go-engine/internal/commands/generations.go
+++ b/go-engine/internal/commands/generations.go
@@ -1,0 +1,35 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/provision"
+)
+
+// GenerationsFlags holds the parsed CLI flags for the generations command.
+type GenerationsFlags struct {
+	// Events controls streaming event output. "jsonl" enables it; "" disables.
+	Events string
+}
+
+// GenerationsResult is the data payload for the generations command JSON
+// envelope.
+type GenerationsResult struct {
+	Generations []*provision.Generation `json:"generations"`
+}
+
+// RunGenerations lists the recorded Provisioning Generations, newest first. It
+// is read-only: it inspects state and writes nothing.
+func RunGenerations(flags GenerationsFlags) (interface{}, *envelope.Error) {
+	_ = flags
+	gens, err := provision.List()
+	if err != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, err.Error())
+	}
+	if gens == nil {
+		gens = []*provision.Generation{}
+	}
+	return &GenerationsResult{Generations: gens}, nil
+}

--- a/go-engine/internal/commands/generations_test.go
+++ b/go-engine/internal/commands/generations_test.go
@@ -1,0 +1,49 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/provision"
+)
+
+func TestRunGenerations_ListsNewestFirst(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	if err := provision.Write(&provision.Generation{Backend: "nix", RunID: "r1"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := provision.Write(&provision.Generation{Backend: "winget", RunID: "r2"}); err != nil {
+		t.Fatal(err)
+	}
+
+	res, eerr := RunGenerations(GenerationsFlags{})
+	if eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+	gr, ok := res.(*GenerationsResult)
+	if !ok {
+		t.Fatalf("want *GenerationsResult, got %T", res)
+	}
+	if len(gr.Generations) != 2 {
+		t.Fatalf("want 2 generations, got %d", len(gr.Generations))
+	}
+	if gr.Generations[0].Number != 2 || gr.Generations[1].Number != 1 {
+		t.Fatalf("not newest-first: %d, %d", gr.Generations[0].Number, gr.Generations[1].Number)
+	}
+}
+
+func TestRunGenerations_EmptyIsNotAnError(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	res, eerr := RunGenerations(GenerationsFlags{})
+	if eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+	gr := res.(*GenerationsResult)
+	if gr.Generations == nil || len(gr.Generations) != 0 {
+		t.Fatalf("want empty non-nil slice, got %#v", gr.Generations)
+	}
+}

--- a/go-engine/internal/commands/main_test.go
+++ b/go-engine/internal/commands/main_test.go
@@ -1,0 +1,28 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"os"
+	"testing"
+)
+
+// TestMain keeps the commands package tests hermetic. Several tests drive a
+// successful apply, which records a Provisioning Generation under the resolved
+// state directory. Without an explicit ENDSTATE_ROOT those writes would land in
+// ./state under the package directory; routing them to a throwaway directory
+// keeps the working tree clean. Tests that set their own ENDSTATE_ROOT via
+// t.Setenv still override this per-test.
+func TestMain(m *testing.M) {
+	cleanup := func() {}
+	if os.Getenv("ENDSTATE_ROOT") == "" {
+		if dir, err := os.MkdirTemp("", "endstate-commands-test-*"); err == nil {
+			_ = os.Setenv("ENDSTATE_ROOT", dir)
+			cleanup = func() { _ = os.RemoveAll(dir) }
+		}
+	}
+	code := m.Run()
+	cleanup()
+	os.Exit(code)
+}

--- a/go-engine/internal/driver/winget/capabilities.go
+++ b/go-engine/internal/driver/winget/capabilities.go
@@ -1,0 +1,14 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package winget
+
+import "github.com/Artexis10/endstate/go-engine/internal/provision"
+
+// Capabilities reports the winget driver's capabilities. winget installs
+// per-package and non-atomically, with no native rollback and no whole-set
+// transaction, so every capability is false. It satisfies
+// provision.CapabilityReporter for symmetry with the realizer.
+func (w *WingetDriver) Capabilities() provision.Capabilities {
+	return provision.Capabilities{}
+}

--- a/go-engine/internal/driver/winget/capabilities_test.go
+++ b/go-engine/internal/driver/winget/capabilities_test.go
@@ -1,0 +1,19 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package winget
+
+import (
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/provision"
+)
+
+var _ provision.CapabilityReporter = (*WingetDriver)(nil)
+
+func TestCapabilities_WingetIsAllFalse(t *testing.T) {
+	c := New().Capabilities()
+	if c.AtomicSet || c.NativeRollback || c.Transactional || c.BatchInstall {
+		t.Fatalf("winget capabilities should all be false, got %+v", c)
+	}
+}

--- a/go-engine/internal/provision/provision.go
+++ b/go-engine/internal/provision/provision.go
@@ -1,0 +1,66 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+// Package provision owns the engine's Provisioning Generation: a numbered,
+// inspectable, install-only record of the package set committed by a successful
+// apply, written for both package backends (the winget driver and the Nix
+// realizer). It is the unification layer above the two backends — the engine
+// owns the state and UX; backends differ only in advertised capabilities.
+//
+// Separation of concerns (inviolable): this package records package facts only.
+// It MUST NOT read or write the config backup directory (state/backups/) or the
+// restore revert journal, and it MUST NOT import internal/restore. A guard test
+// enforces the import constraint.
+package provision
+
+// SchemaVersion is the schema version of the Generation record. It is owned by
+// the provisioning layer and is independent of the manifest and envelope schema
+// versions, so the record format can migrate on its own cadence.
+const SchemaVersion = "1.0"
+
+// ProvItem is a single package fact within a Generation.
+type ProvItem struct {
+	ID      string `json:"id"`
+	Ref     string `json:"ref"`
+	Status  string `json:"status"`            // "installed" | "present"
+	Version string `json:"version,omitempty"` // best-effort; "" when the backend exposes none
+}
+
+// Generation is an engine-owned record of the package set committed by a
+// successful apply. AddedRefs lists only the refs installed this run (status
+// "installed"); already-present refs are recorded in Items but never in
+// AddedRefs.
+type Generation struct {
+	SchemaVersion string     `json:"schemaVersion"`
+	Number        int        `json:"number"`
+	RunID         string     `json:"runId"`
+	Timestamp     string     `json:"timestamp,omitempty"`
+	Backend       string     `json:"backend"` // "nix" | "winget"
+	Items         []ProvItem `json:"items"`
+	AddedRefs     []string   `json:"addedRefs"`
+	Native        string     `json:"native,omitempty"` // backend-native anchor (nix generation number); "" if none
+	Partial       bool       `json:"partial"`          // true when a non-atomic backend committed a partial set
+}
+
+// Capabilities describes what a package backend can do. It is discovered at
+// runtime by type-asserting a backend to CapabilityReporter, exactly like
+// driver.BatchDetector.
+type Capabilities struct {
+	AtomicSet      bool
+	NativeRollback bool
+	Transactional  bool
+	BatchInstall   bool
+}
+
+// CapabilityReporter is implemented by backends that advertise their
+// capabilities.
+type CapabilityReporter interface {
+	Capabilities() Capabilities
+}
+
+// Rollbacker is implemented by backends that can roll back to a prior
+// generation. It is declared here to pin the contract for a later phase; no
+// backend implements it yet (native rollback is out of scope for this change).
+type Rollbacker interface {
+	Rollback(to int) error
+}

--- a/go-engine/internal/provision/provision_test.go
+++ b/go-engine/internal/provision/provision_test.go
@@ -1,0 +1,124 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package provision
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWriteTo_AssignsMonotonicNumbersAndDefaultsSchema(t *testing.T) {
+	dir := t.TempDir()
+
+	g1 := &Generation{RunID: "apply-1", Backend: "nix", AddedRefs: []string{"nixpkgs#ripgrep"}}
+	if err := WriteTo(dir, g1); err != nil {
+		t.Fatalf("write g1: %v", err)
+	}
+	if g1.Number != 1 {
+		t.Fatalf("g1.Number = %d, want 1", g1.Number)
+	}
+	if g1.SchemaVersion != SchemaVersion {
+		t.Fatalf("g1.SchemaVersion = %q, want %q", g1.SchemaVersion, SchemaVersion)
+	}
+
+	g2 := &Generation{RunID: "apply-2", Backend: "winget"}
+	if err := WriteTo(dir, g2); err != nil {
+		t.Fatalf("write g2: %v", err)
+	}
+	if g2.Number != 2 {
+		t.Fatalf("g2.Number = %d, want 2", g2.Number)
+	}
+
+	if _, err := os.Stat(filepath.Join(dir, "000001.json")); err != nil {
+		t.Fatalf("expected 000001.json: %v", err)
+	}
+	// No temp file should survive a successful write.
+	entries, _ := os.ReadDir(dir)
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".tmp") {
+			t.Fatalf("leftover temp file: %s", e.Name())
+		}
+	}
+}
+
+func TestListFrom_NewestFirstAndIgnoresNonRecords(t *testing.T) {
+	dir := t.TempDir()
+	for i := 0; i < 3; i++ {
+		if err := WriteTo(dir, &Generation{Backend: "nix"}); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Stray files that must be ignored.
+	if err := os.WriteFile(filepath.Join(dir, "000099.json.tmp"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	gens, err := ListFrom(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gens) != 3 {
+		t.Fatalf("len = %d, want 3", len(gens))
+	}
+	if gens[0].Number != 3 || gens[1].Number != 2 || gens[2].Number != 1 {
+		t.Fatalf("not newest-first: %d, %d, %d", gens[0].Number, gens[1].Number, gens[2].Number)
+	}
+}
+
+func TestListFrom_MissingDirIsEmptyNoError(t *testing.T) {
+	gens, err := ListFrom(filepath.Join(t.TempDir(), "absent"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(gens) != 0 {
+		t.Fatalf("len = %d, want 0", len(gens))
+	}
+}
+
+func TestNextNumber_EmptyDirIsOne(t *testing.T) {
+	n, err := nextNumber(t.TempDir())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("nextNumber = %d, want 1", n)
+	}
+}
+
+func TestDir_ResolvesUnderStateDirNeverHardcoded(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("ENDSTATE_ROOT", root)
+	want := filepath.Join(root, "state", "generations")
+	if got := Dir(); got != want {
+		t.Fatalf("Dir() = %q, want %q", got, want)
+	}
+}
+
+// TestPackageStaysInstallOnly enforces the separation-of-concerns invariant in
+// code: the provision package must never import the config/restore layer.
+func TestPackageStaysInstallOnly(t *testing.T) {
+	fset := token.NewFileSet()
+	files, err := filepath.Glob("*.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, f := range files {
+		af, err := parser.ParseFile(fset, f, nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("parse %s: %v", f, err)
+		}
+		for _, imp := range af.Imports {
+			if strings.Contains(imp.Path.Value, "internal/restore") {
+				t.Fatalf("%s imports %s; the provisioning generation must stay install-only", f, imp.Path.Value)
+			}
+		}
+	}
+}

--- a/go-engine/internal/provision/store.go
+++ b/go-engine/internal/provision/store.go
@@ -1,0 +1,120 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package provision
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/Artexis10/endstate/go-engine/internal/state"
+)
+
+// Dir returns the directory where Provisioning Generations are stored. It is
+// resolved under the engine state directory via the config path resolver and is
+// never hardcoded.
+func Dir() string {
+	return filepath.Join(state.StateDir(), "generations")
+}
+
+// Write assigns the next generation number and writes g to the default
+// generations directory. See WriteTo.
+func Write(g *Generation) error {
+	return WriteTo(Dir(), g)
+}
+
+// List returns all Provisioning Generations from the default directory, newest
+// first. A missing directory yields an empty slice and no error.
+func List() ([]*Generation, error) {
+	return ListFrom(Dir())
+}
+
+// WriteTo assigns g.Number = one greater than the highest existing number in
+// dir, defaults g.SchemaVersion, and writes g to
+// dir/<zero-padded number>.json using the atomic temp-file + rename pattern
+// (matching internal/state). The directory is created if it does not exist.
+func WriteTo(dir string, g *Generation) error {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+	n, err := nextNumber(dir)
+	if err != nil {
+		return err
+	}
+	g.Number = n
+	if g.SchemaVersion == "" {
+		g.SchemaVersion = SchemaVersion
+	}
+	data, err := json.MarshalIndent(g, "", "  ")
+	if err != nil {
+		return err
+	}
+	path := filepath.Join(dir, fmt.Sprintf("%06d.json", n))
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// ListFrom returns all Provisioning Generations in dir, newest first (highest
+// number first). A missing directory yields an empty slice and no error; .tmp
+// and non-.json files are ignored. Mirrors state.ListRunHistory.
+func ListFrom(dir string) ([]*Generation, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return []*Generation{}, nil
+		}
+		return nil, err
+	}
+
+	var names []string
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() {
+			continue
+		}
+		if strings.HasSuffix(name, ".json") && !strings.HasSuffix(name, ".tmp") {
+			names = append(names, name)
+		}
+	}
+
+	// Zero-padded numeric names: reverse lexical sort == newest (highest) first.
+	sort.Sort(sort.Reverse(sort.StringSlice(names)))
+
+	gens := make([]*Generation, 0, len(names))
+	for _, name := range names {
+		data, err := os.ReadFile(filepath.Join(dir, name))
+		if err != nil {
+			return nil, err
+		}
+		var g Generation
+		if err := json.Unmarshal(data, &g); err != nil {
+			return nil, err
+		}
+		gens = append(gens, &g)
+	}
+	return gens, nil
+}
+
+// nextNumber returns one greater than the highest existing generation number in
+// dir, or 1 when none exist. Numbering is engine-owned and independent of any
+// backend-native generation number.
+func nextNumber(dir string) (int, error) {
+	gens, err := ListFrom(dir)
+	if err != nil {
+		return 0, err
+	}
+	max := 0
+	for _, g := range gens {
+		if g.Number > max {
+			max = g.Number
+		}
+	}
+	return max + 1, nil
+}

--- a/go-engine/internal/realizer/nix/capabilities.go
+++ b/go-engine/internal/realizer/nix/capabilities.go
@@ -1,0 +1,20 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package nix
+
+import "github.com/Artexis10/endstate/go-engine/internal/provision"
+
+// Capabilities reports the Nix realizer's capabilities. Nix realizes a whole set
+// as one atomic profile generation, supports native rollback (`nix profile
+// rollback`), and installs the set in a single transaction. It satisfies
+// provision.CapabilityReporter so a later phase can discover rollback
+// eligibility by type-assertion.
+func (b *Backend) Capabilities() provision.Capabilities {
+	return provision.Capabilities{
+		AtomicSet:      true,
+		NativeRollback: true,
+		Transactional:  true,
+		BatchInstall:   true,
+	}
+}

--- a/go-engine/internal/realizer/nix/capabilities_test.go
+++ b/go-engine/internal/realizer/nix/capabilities_test.go
@@ -1,0 +1,19 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package nix
+
+import (
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/provision"
+)
+
+var _ provision.CapabilityReporter = (*Backend)(nil)
+
+func TestCapabilities_NixIsAtomicAndRollbackable(t *testing.T) {
+	c := New().Capabilities()
+	if !c.AtomicSet || !c.NativeRollback || !c.Transactional || !c.BatchInstall {
+		t.Fatalf("nix capabilities should all be true, got %+v", c)
+	}
+}

--- a/openspec/changes/provisioning-generation/design.md
+++ b/openspec/changes/provisioning-generation/design.md
@@ -1,0 +1,117 @@
+## Context
+
+After `nix-realizer-backend` (Phase 1), the engine has two package backends: the winget
+`driver.Driver` (per-package `Detect`/`Install`) and the Nix `realizer.Realizer`
+(whole-set `Plan`/`Realize`/`Current`). Both converge a package set, but neither leaves a
+durable, inspectable record of what was committed. `apply` already threads a `runID` and
+writes run history (`state.SaveRunHistory` → `state/runs/<runID>.json`) via the atomic
+temp-file + rename idiom (`internal/state`), and resolves paths via
+`config.ResolveRepoRoot()` / `state.StateDir()`.
+
+This change adds an engine-owned **Provisioning Generation** above both backends — the
+unification layer. It is install-only and additive; it does not touch the config/restore
+layers and introduces no rollback.
+
+## Goals / Non-Goals
+
+**Goals:**
+- One numbered, versioned, install-only Generation record written after a successful
+  `apply`, identically shaped for both backends.
+- Backends differ only in advertised **capabilities** (discovered by type-assertion, like
+  `driver.BatchDetector`); the engine owns the unified state and the `generations` UX.
+- Pin the Generation format now so a later rollback phase writes against a stable schema.
+- **Zero Windows behavior regression**, provable by host-aware tests + `GOOS=windows` build.
+
+**Non-Goals:**
+- **No rollback** (`Rollbacker` is declared, not implemented).
+- **No folding** of winget into a single converge interface — dual `Driver`+`Realizer`
+  stays; only state/UX is unified.
+- **No config/restore changes** — the Generation never reads/writes `state/backups/` or the
+  revert journal (enforced by the `separation-of-concerns` delta + a guard test).
+- **No version pinning** — `Items.version` is best-effort; recorded where the backend
+  exposes it (Nix), empty on winget until the driver is enriched.
+
+## Decisions
+
+### The record (`internal/provision`)
+
+```go
+const SchemaVersion = "1.0" // OWN version, independent of manifest/envelope
+
+type ProvItem struct {
+    ID      string `json:"id"`
+    Ref     string `json:"ref"`
+    Status  string `json:"status"`            // installed | present
+    Version string `json:"version,omitempty"` // best-effort
+}
+
+type Generation struct {
+    SchemaVersion string     `json:"schemaVersion"`
+    Number        int        `json:"number"`
+    RunID         string     `json:"runId"`
+    Timestamp     string     `json:"timestamp"`
+    Backend       string     `json:"backend"`   // "nix" | "winget"
+    Items         []ProvItem `json:"items"`
+    AddedRefs     []string   `json:"addedRefs"` // status=installed this run only
+    Native        string     `json:"native,omitempty"` // nix gen number; "" otherwise
+    Partial       bool       `json:"partial"`
+}
+
+type Capabilities struct{ AtomicSet, NativeRollback, Transactional, BatchInstall bool }
+type CapabilityReporter interface{ Capabilities() Capabilities }
+type Rollbacker interface{ Rollback(to int) error } // declared; implemented in a later phase
+```
+
+### Persistence
+- Location: `provision.Dir()` = `filepath.Join(state.StateDir(), "generations")` — resolved
+  via the existing resolver, **never hardcoded**.
+- File per generation: `state/generations/<zero-padded-number>.json` (e.g. `000001.json`),
+  so lexical sort == numeric sort.
+- Write: `json.MarshalIndent` → `<path>.tmp` → `os.Rename` (the `state.SaveRunHistory`
+  idiom; dirs `0755`, files `0644`).
+- `List()` reads the dir, excludes `.tmp`, returns newest-first (mirrors
+  `state.ListRunHistory`). Missing dir → empty slice, no error.
+- `nextNumber()` = highest existing `Number` + 1 (engine-owned; independent of `Native`).
+
+### Write timing (the only behavioral fork)
+| Backend | When a generation is written | `Partial` | `Native` |
+|---------|------------------------------|-----------|----------|
+| Nix (atomic) | only when the profile generation advanced (`Result.Advanced`) | `false` | `ToGeneration` |
+| winget (non-atomic) | when ≥1 ref was `installed` this run | `true` iff any attempted install failed | `""` |
+
+A generation is **never** written when nothing was newly installed (idempotent re-run).
+This matches Nix's no-advance-on-no-op semantics and keeps generations meaningful as
+(future) rollback points; run history already records every `apply`.
+
+### `AddedRefs`
+Only refs whose per-item status this run was `installed`. `present`/`skipped`/`failed`
+refs are excluded. `Items` carries the full host-matching declared set with status.
+
+### Capabilities
+- Nix realizer reports `{AtomicSet:true, NativeRollback:true, Transactional:true,
+  BatchInstall:true}`.
+- winget driver reports all-false.
+- Discovered via `if cr, ok := backend.(provision.CapabilityReporter); ok { ... }`. No
+  Phase-2 consumer beyond tests; previews Phase-3 rollback eligibility.
+
+### `generations` command
+Read-only list, modeled on `report.go` / `state.ListRunHistory`. Returns a result struct
+for the JSON envelope (`data.generations`) and a human summary. Empty list when none.
+
+## Separation of concerns (inviolable)
+`internal/provision` MUST NOT import `internal/restore` and MUST NOT reference
+`state/backups/` or the revert journal. A guard test asserts the package's import set
+excludes `restore`. `rollback` (packages, future) and `revert` (configs) remain distinct
+commands over distinct logs.
+
+## Risks / limitations (documented, not blockers)
+- winget exposes no installed **version** today → `Items.version` is empty on Windows until
+  the driver is enriched (future).
+- GUI is Windows-only and not wired to `generations` in this phase (CLI-first by design).
+- Retention: **keep all** generations; no auto-pruning in this phase (records are tiny and
+  must persist as future rollback points). A prune policy can be added later.
+
+## Migration
+Purely additive. No manifest/envelope schema-version bump (the record carries its own
+version; the command and its fields are additive per `schema-versioning`). Existing state,
+run history, and Windows behavior are unchanged.

--- a/openspec/changes/provisioning-generation/proposal.md
+++ b/openspec/changes/provisioning-generation/proposal.md
@@ -1,0 +1,85 @@
+## Why
+
+`apply` converges the declared package set but leaves **no durable, inspectable record of
+what it committed**. There is run history (`state/runs/`), but no numbered package-set
+record that can be listed and (in a later phase) rolled back. Phase 1 (`nix-realizer-backend`,
+PR #50) added a Nix `Realizer` beside the winget `Driver`, so two package backends now
+exist with **no shared state or UX layer** above them.
+
+This change adds an **engine-owned Provisioning Generation**: a numbered, self-describing
+record of the committed package set, written for **both** backends after a successful
+`apply`. It is the unification layer where the cross-OS model becomes concrete — and where
+**Windows gains an install audit trail for the first time**. No rollback is introduced here
+(that is a later phase); this change pins the generation format so it is stable before a
+rollback phase writes against it.
+
+This overrules the previously implicit assumption that `apply` leaves no durable package
+record. It also makes two `AI_CONTRACT.md` Non-Goals partially outdated — **#2 "No
+cross-platform parity yet"** and **#4 "No automatic rollback"** (this change is a
+prerequisite for the later, opt-in, `--confirm`-gated rollback). `AI_CONTRACT.md` is a
+PROTECTED file; this is **flagged for the maintainer**, not edited here.
+
+## What Changes
+
+- Add a new package **`internal/provision`** that owns the `Generation` record (with its
+  **own** `SchemaVersion`, mirroring `internal/state`), a `Capabilities` value, and the
+  optional `CapabilityReporter` / `Rollbacker` interfaces (discovered by type-assertion
+  exactly like `driver.BatchDetector`). `Rollbacker` is **declared but not implemented**
+  in this change.
+- `apply` writes a Provisioning Generation after a successful run, for **both** backends,
+  under `state/generations/` resolved via the config path resolver (never hardcoded), using
+  the existing atomic temp-file + rename idiom.
+  - **Atomic backend (Nix):** commit a generation **only on full success** (the profile
+    generation advanced); `Partial=false`; `Native` = the Nix generation number.
+  - **Non-atomic backend (winget):** record the successfully-installed subset;
+    `Partial=true` when any attempted install failed; `Native=""`.
+  - A generation is written **only when the committed set advanced** (at least one ref
+    installed this run). Idempotent re-runs add nothing.
+- `AddedRefs` records **only** refs whose status this run was `installed` (never `present`).
+- Add a read-only **`generations`** command that lists recorded generations (newest first).
+- Implement `CapabilityReporter` on the Nix realizer (atomic + native-rollback +
+  batch-install) and the winget driver (all false), so a later phase can discover rollback
+  eligibility by type-assertion.
+
+The dual `Driver` + `Realizer` interfaces are **kept beside each other**; only the
+state/UX is unified here. Folding winget into a single converge interface is explicitly out
+of scope (later, riskier phase).
+
+## Capabilities
+
+### New Capabilities
+
+- `provisioning-generation`: `apply` persists a numbered, versioned, install-only
+  Provisioning Generation for both backends under the resolved state directory; a read-only
+  `generations` command lists them. Atomic backends commit only on full success; non-atomic
+  backends record the installed subset and mark it partial.
+
+### Modified Capabilities
+
+- `separation-of-concerns`: the *Distinct Pipeline Stages* requirement gains a scenario
+  asserting the Provisioning Generation is **install-only** — it records package state only
+  and never reads or writes `state/backups/` or the restore revert journal, and the verify
+  stage never writes generations. This keeps `rollback` (packages, future) and `revert`
+  (configs) distinct over distinct logs.
+
+## Impact
+
+- `internal/provision/` (new) — `Generation` + `ProvItem` types, `SchemaVersion` const,
+  `Capabilities` + `CapabilityReporter` + `Rollbacker` interfaces, `Dir()` (resolved via
+  `state.StateDir()`), `Write`/`List`/`nextNumber` (atomic temp+rename; `.tmp`-excluded
+  listing — mirrors `state.SaveRunHistory` / `state.ListRunHistory`).
+- `internal/commands/apply_realizer.go` — write a generation at the successful-apply return
+  site (Nix path) when `Result.Advanced`.
+- `internal/commands/apply.go` — write a generation at the driver-path return site (winget)
+  when ≥1 ref was installed this run; set `Partial` from per-item failures.
+- `internal/commands/generations.go` (new) — `RunGenerations` + `runGenerationsList`,
+  modeled on `report.go`.
+- `internal/realizer/nix/nix.go` + `internal/driver/winget/` — implement
+  `provision.CapabilityReporter`.
+- `cmd/endstate/main.go` — **PROTECTED**: add `case "generations"` in `dispatch()` + a
+  usage line, mirroring `report`/`profile`. **Flagged for explicit go-ahead.**
+- `docs/contracts/cli-json-contract.md` — **PROTECTED**: additive `generations` command +
+  envelope `data` rows for the generation list. **Flagged for explicit go-ahead.**
+- No manifest/envelope schema-version bump: the `Generation` record carries its **own**
+  schema version, and the `generations` command + its fields are additive per
+  `schema-versioning`.

--- a/openspec/changes/provisioning-generation/specs/provisioning-generation/spec.md
+++ b/openspec/changes/provisioning-generation/specs/provisioning-generation/spec.md
@@ -1,0 +1,89 @@
+## ADDED Requirements
+
+### Requirement: Apply persists a Provisioning Generation
+
+After a successful `apply` that advances the committed package set, the engine SHALL write a numbered Provisioning Generation that records what was committed, for **both** package backends (the Nix realizer and the winget driver). A Provisioning Generation is an install-stage record only; it does not represent configuration or restore state.
+
+#### Scenario: Successful apply commits a Provisioning Generation
+
+- **WHEN** `apply` completes a non-dry-run that newly installs at least one package
+- **THEN** the engine SHALL write a numbered Provisioning Generation under the resolved state directory
+- **AND** the record SHALL include the committed package set, the run identifier, and the backend name
+
+#### Scenario: Atomic backend writes a generation only on full success
+
+- **WHEN** an `apply` through the Nix realizer does not advance the profile generation (the atomic switch did not commit)
+- **THEN** no Provisioning Generation SHALL be written
+- **AND** the failure SHALL be surfaced through the existing error path
+
+#### Scenario: Non-atomic backend records the installed subset
+
+- **WHEN** an `apply` through the winget driver installs some packages and fails others
+- **THEN** the engine SHALL write a Provisioning Generation containing the successfully installed subset
+- **AND** the generation SHALL be marked partial
+
+#### Scenario: Idempotent re-run writes no new generation
+
+- **WHEN** `apply` runs and installs no new packages because every declared package is already present
+- **THEN** no new Provisioning Generation SHALL be written
+
+#### Scenario: Added references record only packages installed this run
+
+- **WHEN** a Provisioning Generation is written
+- **THEN** its added references SHALL contain only packages whose status this run was "installed"
+- **AND** packages that were already present SHALL NOT appear in the added references
+
+### Requirement: Provisioning Generation record format
+
+A Provisioning Generation SHALL be a self-describing, versioned record stored as an individual file, written with the same durability guarantees as other engine state.
+
+#### Scenario: Generation carries its own schema version
+
+- **WHEN** a Provisioning Generation is written
+- **THEN** the record SHALL include a schema version owned by the provisioning layer
+- **AND** that schema version SHALL be independent of the manifest and envelope schema versions
+
+#### Scenario: Generation is numbered monotonically by the engine
+
+- **WHEN** a new Provisioning Generation is written
+- **THEN** its number SHALL be one greater than the highest existing Provisioning Generation number on the host
+- **AND** the number SHALL be owned by the engine, independent of any backend-native generation number recorded alongside it
+
+#### Scenario: Generations are stored via the resolved state path
+
+- **WHEN** the engine writes a Provisioning Generation
+- **THEN** it SHALL resolve the storage location under the state directory via the configuration path resolver
+- **AND** it SHALL NOT use a hardcoded absolute path
+
+#### Scenario: Generation writes are atomic
+
+- **WHEN** the engine writes a Provisioning Generation file
+- **THEN** it SHALL write to a temporary file and rename it into place
+- **AND** no partially written record SHALL ever be observable
+
+#### Scenario: Generation records package facts only
+
+- **WHEN** a Provisioning Generation is written
+- **THEN** it SHALL record package facts: identifiers, references, status, and version when the backend exposes it
+- **AND** it SHALL NOT record config-module identifiers, restore results, or backup state
+
+### Requirement: The generations command lists Provisioning Generations
+
+The engine SHALL provide a read-only `generations` command that lists the recorded Provisioning Generations.
+
+#### Scenario: generations lists committed generations newest first
+
+- **WHEN** `generations` is run on a host with one or more recorded Provisioning Generations
+- **THEN** the engine SHALL list them ordered newest first
+- **AND** each entry SHALL expose its number, run identifier, backend, partial flag, and added references
+
+#### Scenario: generations returns an empty list when none exist
+
+- **WHEN** `generations` is run and no Provisioning Generation has been recorded
+- **THEN** the engine SHALL return an empty list
+- **AND** it SHALL NOT report an error
+
+#### Scenario: generations is read-only
+
+- **WHEN** `generations` is run
+- **THEN** it SHALL NOT create, modify, or delete any package, configuration, or generation state

--- a/openspec/changes/provisioning-generation/specs/separation-of-concerns/spec.md
+++ b/openspec/changes/provisioning-generation/specs/separation-of-concerns/spec.md
@@ -1,0 +1,26 @@
+## MODIFIED Requirements
+
+### Requirement: Distinct Pipeline Stages
+
+The system SHALL maintain clear separation between installation, configuration (restore), and verification as independent stages.
+
+#### Scenario: Install does not configure
+- **WHEN** `apply` runs the install stage for a package
+- **THEN** only package installation is performed
+- **AND** no config files are written or modified during the install stage
+
+#### Scenario: Restore does not install
+- **WHEN** `apply --EnableRestore` runs the restore stage
+- **THEN** restore operates on config files only
+- **AND** no package install or uninstall operations are triggered by the restore stage
+
+#### Scenario: Verify is read-only
+- **WHEN** the verification stage runs
+- **THEN** it inspects system state without modifying it
+- **AND** no files are created, modified, or deleted by verifiers
+
+#### Scenario: Provisioning Generation is install-only
+- **WHEN** `apply` writes a Provisioning Generation for the install stage
+- **THEN** the generation SHALL record package state only
+- **AND** it SHALL NOT read or write the config backup directory (`state/backups/`) or the restore revert journal
+- **AND** the verification stage SHALL NOT write Provisioning Generations

--- a/openspec/changes/provisioning-generation/tasks.md
+++ b/openspec/changes/provisioning-generation/tasks.md
@@ -1,0 +1,77 @@
+> TDD: write each test RED first, then implement to green. All CI tests are hermetic (no
+> real `nix`/`winget`). Host-dependent tests are made host-aware (key fixtures by
+> `runtime.GOOS`, per the Phase-1 `nixApp`/`foreignRefApp` pattern). Verify on Linux:
+> `cd go-engine && go test ./...`; plus `GOOS=windows go build ./...` + `go vet` clean.
+
+## 0. Gate
+
+- [ ] 0.1 `npm run openspec:validate` (strict) passes for this change before implementing
+- [ ] 0.2 **PAUSE for maintainer review of this spec** (Gate A) before any Go is written
+
+## 1. `internal/provision` — record + persistence (new package)
+
+- [ ] 1.1 `provision.go` — `Generation`/`ProvItem` types, `SchemaVersion = "1.0"` const,
+      `Capabilities` struct, `CapabilityReporter` + `Rollbacker` interfaces (Rollbacker
+      declared only)
+- [ ] 1.2 RED tests: `Dir()` resolves under `state.StateDir()` (honors `ENDSTATE_ROOT`,
+      never hardcoded); `nextNumber()` on empty dir → 1, with `000003.json` present → 4
+- [ ] 1.3 `store.go` + RED tests: `Write(gen)` uses `.tmp`+`os.Rename`, `MarshalIndent`,
+      `0644`/`0755`; round-trips; never leaves a `.tmp` on success
+- [ ] 1.4 `List()` + RED tests: newest-first, `.tmp`-excluded; missing dir → empty slice,
+      no error (mirror `state.ListRunHistory`)
+- [ ] 1.5 Guard test: `internal/provision` import set excludes `internal/restore`
+      (separation-of-concerns enforced in code)
+
+## 2. Write hook — realizer (nix) path
+
+- [ ] 2.1 RED test (injected `fakeRealizer`, host-aware): a full-success apply that installs
+      ≥1 ref writes one generation with `Partial=false`, `Native=ToGeneration`,
+      `AddedRefs` = installed refs only, `Backend="nix"`
+- [ ] 2.2 RED test: an apply that does not advance the generation writes **no** generation
+- [ ] 2.3 RED test: idempotent re-run (all present, nothing to add) writes **no** generation
+- [ ] 2.4 Implement at the `runApplyRealizer` success return site; reuse `runID`
+
+## 3. Write hook — driver (winget) path
+
+- [ ] 3.1 RED test (mock driver, host-aware): apply installing ≥1 ref writes a generation
+      with `Backend="winget"`, `Native=""`, `AddedRefs` = `status=installed` only
+- [ ] 3.2 RED test: partial install (some installed, some failed) → generation written with
+      `Partial=true` and only the installed subset in `AddedRefs`
+- [ ] 3.3 RED test: all-present / all-failed → **no** generation written
+- [ ] 3.4 Implement at the driver-path success return site in `apply.go`
+
+## 4. Capabilities reporting
+
+- [ ] 4.1 RED + impl: nix realizer implements `provision.CapabilityReporter` →
+      `{AtomicSet, NativeRollback, Transactional, BatchInstall} = true`
+- [ ] 4.2 RED + impl: winget driver implements `provision.CapabilityReporter` → all false
+- [ ] 4.3 RED test: discovery by type-assertion works for both backends (no Rollbacker yet)
+
+## 5. `generations` command (read-only, list)
+
+- [ ] 5.1 `internal/commands/generations.go` + RED tests: `RunGenerations` →
+      `runGenerationsList` reads `provision.List()`; newest-first; empty list (no error)
+      when none; result struct populates `data.generations`
+- [ ] 5.2 `cmd/endstate/main.go` (**PROTECTED — needs go-ahead**): add `case "generations"`
+      in `dispatch()` + usage line, mirroring `report`/`profile`
+- [ ] 5.3 RED test: command is read-only (writes/deletes nothing)
+
+## 6. Windows no-regression
+
+- [ ] 6.1 `TestApply_WindowsWritesWingetGeneration` — driver path on a Windows fixture
+      writes a `winget` generation; existing per-item event sequence unchanged
+- [ ] 6.2 `GOOS=windows go build ./...` + `go vet ./...` clean; existing winget tests green
+
+## 7. Contract documentation (PROTECTED — needs explicit go-ahead)
+
+- [ ] 7.1 `docs/contracts/cli-json-contract.md` — additive `generations` command row +
+      `data.generations` envelope fields
+
+## 8. Verification
+
+- [ ] 8.1 `cd go-engine && go test ./...` green on Linux
+- [ ] 8.2 `GOOS=windows go build ./...` + `go vet ./...` clean
+- [ ] 8.3 `npm run openspec:validate` (strict) passes
+- [ ] 8.4 Real-nix smoke (not CI): `apply` a small manifest (e.g. `ripgrep`) on this WSL
+      box → `generations` lists the committed generation; re-run is idempotent (no new
+      generation)


### PR DESCRIPTION
## Summary

Phase 2 of the unified cross-OS provisioning effort. Introduces an **engine-owned Provisioning Generation**: a numbered, inspectable, install-only record of the package set committed by a successful `apply`, written for **both** backends (Nix realizer + winget driver) under `state/generations/`. This is the unification layer where **Windows gains an install audit trail** for the first time. **No rollback** (Phase 3/4). **Zero Windows behavior regression.**

Builds on Phase 1 (`nix-realizer-backend`, #50). Base: `main` (not stacked).

## What changed

- **`internal/provision/`** (new): `Generation`/`ProvItem` with its own `SchemaVersion`; `Capabilities` + `CapabilityReporter`/`Rollbacker` interfaces (`Rollbacker` declared, not implemented — pins the contract for Phase 3); atomic `Write`/`List`/`nextNumber` reusing the `internal/state` temp+rename idiom; `Dir()` resolved via `state.StateDir()` (never hardcoded). A guard test fails the build if the package ever imports `internal/restore` — the generation is **install-only**.
- **Write hooks** in both apply paths:
  - **nix** (atomic): writes only on full success (generation advanced); `Native` = nix generation, `Partial=false`.
  - **winget** (non-atomic): records the successfully-installed subset; `Partial=true` when any attempted install failed; `Native=""`.
  - `AddedRefs` = refs `status=installed` this run only. Idempotent re-runs (nothing newly installed) write **no** generation.
- **`generations` command** (read-only, newest-first list) + dispatch + usage line.
- **`CapabilityReporter`** on nix (atomic + native-rollback + batch) and winget (all false), discovered by type-assertion like `driver.BatchDetector`.
- **Contract** (`docs/contracts/cli-json-contract.md`): additive `generations` command + `data.generations` shape.

## OpenSpec

`openspec/changes/provisioning-generation/` — new `provisioning-generation` capability (ADDED) + `separation-of-concerns` (MODIFIED: generation records package facts only and never touches `state/backups/` or the revert journal). `npm run openspec:validate --strict` passes (53/53).

## Verification

- `cd go-engine && go test ./...` green on Linux.
- `GOOS=windows go build ./...` + `go vet ./...` clean (both OSes).
- `openspec validate --all --strict` → 53 passed, 0 failed.
- Real-nix smoke (Determinate Nix 3.21.0): `apply` ripgrep → generation `000001.json` written; `generations` lists it (`backend:nix, native:"1", addedRefs:[nixpkgs#ripgrep], partial:false`); idempotent re-run → `present`, no new generation.

## Notes

- `AI_CONTRACT.md` Non-Goals #2 (no cross-platform parity) and #4 (no auto-rollback) are now partially outdated by this direction; left unedited (PROTECTED) and tracked in the proposal per maintainer decision.
- No manifest/envelope schema bump — the record carries its own `schemaVersion`; the command and its fields are additive per `schema-versioning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)