### PR TITLE
feat(engine): native Unix rollback via nix profile rollback (Phase 3)

### DIFF
--- a/docs/ai/AI_CONTRACT.md
+++ b/docs/ai/AI_CONTRACT.md
@@ -173,7 +173,7 @@ Breaking changes bump the major version (once past 1.0). Signal them with:
 1. **Not enterprise configuration management** — this is a personal/small-team tool
 2. **No cross-platform parity yet** — Windows/winget is primary; Linux/macOS is future work
 3. **No package version pinning** — MVP does not compare or pin versions
-4. **No automatic rollback** — failed operations do not auto-rollback; manual `revert` exists for restore only
+4. **No automatic rollback** — failed operations do not auto-rollback. All rollback is explicit and opt-in: manual `revert` reverses a restore (configuration), and the manual, `--confirm`-gated `rollback` command reverts the package set to a prior provisioning generation on backends that support it (Nix). Neither runs automatically.
 5. **No GUI business logic** — GUI must not contain provisioning logic; CLI is source of truth
 6. **No GUI-driven installation of manual apps** — manual apps surface instructions only; the GUI never triggers installs for them
 

--- a/docs/contracts/cli-json-contract.md
+++ b/docs/contracts/cli-json-contract.md
@@ -96,6 +96,9 @@ When `success` is `false`, the `error` field contains:
 | `PERMISSION_DENIED` | Insufficient permissions |
 | `INTERNAL_ERROR` | Unexpected internal error |
 | `SCHEMA_INCOMPATIBLE` | Schema version mismatch |
+| `ROLLBACK_UNSUPPORTED` | The host's package backend does not advertise native rollback (e.g. winget on Windows; any host with no realizer). Additive in schema 1.x. |
+| `GENERATION_NOT_FOUND` | The `rollback --to <n>` target generation does not exist, or records no backend-native rollback anchor. Additive in schema 1.x. |
+| `ROLLBACK_FAILED` | The backend rollback failed (non-systemic). Raw backend text is confined to `error.detail`. Additive in schema 1.x. |
 
 #### Hosted Backup error codes
 
@@ -475,7 +478,44 @@ Lists recorded Provisioning Generations, newest first. Read-only. Additive in sc
 }
 ```
 
-`backend` is `"nix"` or `"winget"`. `native` is the backend-native generation number (the Nix generation) or empty for non-atomic backends. `partial` is true when a non-atomic backend (winget) committed only a subset of the requested set. `addedRefs` lists only refs installed in that run (status `installed`); already-present refs appear in `items` but not `addedRefs`. A generation is recorded only when at least one package was installed in the run.
+`backend` is `"nix"` or `"winget"`. `native` is the backend-native generation number (the Nix generation) or empty for non-atomic backends. `partial` is true when a non-atomic backend (winget) committed only a subset of the requested set. `addedRefs` lists only refs installed in that run (status `installed`); already-present refs appear in `items` but not `addedRefs`. A generation is recorded only when at least one package was installed in the run. `rollback` (optional, omitted when false; additive in schema 1.x) is `true` when the generation was produced by a `rollback` rather than an `apply`; such generations snapshot the now-active set and have an empty `addedRefs`.
+
+## Command: `rollback`
+
+Reverts the installed package set to a prior Provisioning Generation. Available only on backends that advertise **native rollback** (the Nix realizer on Linux/macOS); other backends (winget on Windows) refuse with `ROLLBACK_UNSUPPORTED`. Additive in schema 1.x.
+
+The target is identified by **engine generation number** (as listed by `generations`), which the engine maps to the backend-native anchor (`native`) recorded in that generation — callers never reference a backend-native version directly. Package-stage only: rollback never touches configuration restore, `state/backups/`, or the revert journal (that is `revert`'s concern).
+
+### Request
+
+| Flag | Meaning |
+|------|---------|
+| `--to <n>` | Engine Provisioning Generation number to roll back to. Omitted ⇒ the immediately previous version. |
+| `--confirm` | Required to execute (rollback changes the installed set). Without it the command refuses. |
+| `--dry-run` | Resolve and report the target without changing state; does not require `--confirm`. |
+
+### Response
+
+```json
+{
+  "schemaVersion": "1.0",
+  "cliVersion": "0.1.0",
+  "command": "rollback",
+  "runId": "20241220-143052",
+  "timestampUtc": "2024-12-20T14:30:52Z",
+  "success": true,
+  "data": {
+    "dryRun": false,
+    "backend": "nix",
+    "targetGeneration": 2,
+    "fromNative": "5",
+    "toNative": "4",
+    "newGeneration": 4
+  }
+}
+```
+
+`targetGeneration` is the engine generation resolved from `--to` (omitted/0 when rolling back to the previous version). `fromNative`/`toNative` are the backend-native versions before and after (on `--dry-run`, `toNative` is the resolved target, or `"previous"`). `newGeneration` is the number of the new rollback-marked Provisioning Generation appended on success (omitted on `--dry-run`). On failure, raw backend text appears only in `error.detail`.
 
 ## Versioning Rules
 

--- a/go-engine/cmd/endstate/main.go
+++ b/go-engine/cmd/endstate/main.go
@@ -35,6 +35,7 @@ Commands:
   validate-export Validate export completeness
   report          Retrieve run history
   generations     List provisioning generations
+  rollback        Roll back packages to a prior generation (native-rollback backends)
   doctor          Run diagnostics
   bootstrap       Bootstrap Endstate installation
   backup          Hosted Backup commands (login, logout, status, ...)
@@ -65,6 +66,8 @@ Per-command flags:
   --latest             Most recent run (report)
   --last <n>           Last N runs (report)
   --run-id <id>        Specific run ID (report)
+  --to <generation>    Target provisioning generation number (rollback; default: previous)
+  --confirm            Acknowledge a state-changing operation (rollback, backup/account delete)
 
 Subcommands:
   profile list         List discovered profiles
@@ -308,6 +311,8 @@ func commandUsage(cmd string) string {
 		return "Usage: endstate validate-export [--manifest <path>] [--export <path>] [--json] [--events jsonl]\n\nValidate export directory completeness.\n"
 	case "report":
 		return "Usage: endstate report [--latest] [--last <n>] [--run-id <id>] [--json]\n\nRetrieve run history.\n"
+	case "rollback":
+		return "Usage: endstate rollback [--to <generation>] [--confirm] [--dry-run] [--json] [--events jsonl]\n\nRoll back the installed package set to a prior provisioning generation. Available only on backends that advertise native rollback (e.g. Nix on Linux/macOS). With --to, targets that engine generation number (see 'endstate generations'); without it, rolls back to the previous version. Requires --confirm; use --dry-run to preview the target without changing anything.\n"
 	case "doctor":
 		return "Usage: endstate doctor [--json]\n\nRun system diagnostics.\n"
 	case "profile":
@@ -446,6 +451,14 @@ func dispatch(p parsedArgs) (interface{}, *envelope.Error) {
 	case "generations":
 		return commands.RunGenerations(commands.GenerationsFlags{
 			Events: p.events,
+		})
+
+	case "rollback":
+		return commands.RunRollback(commands.RollbackFlags{
+			To:      p.to,
+			Confirm: p.confirm,
+			DryRun:  p.dryRun,
+			Events:  p.events,
 		})
 
 	case "doctor":

--- a/go-engine/internal/commands/apply_realizer_test.go
+++ b/go-engine/internal/commands/apply_realizer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Artexis10/endstate/go-engine/internal/envelope"
 	"github.com/Artexis10/endstate/go-engine/internal/events"
 	"github.com/Artexis10/endstate/go-engine/internal/manifest"
+	"github.com/Artexis10/endstate/go-engine/internal/provision"
 	"github.com/Artexis10/endstate/go-engine/internal/realizer"
 )
 
@@ -39,6 +40,23 @@ type fakeRealizer struct {
 	realizeCalls    int
 	lastPlanArgs    []realizer.Installable
 	lastRealizeArgs []realizer.Installable
+
+	// --- rollback (Phase 3) ---
+	caps            provision.Capabilities // reported via CapabilityReporter
+	rollbackErr     error                  // scripted Rollback return
+	rollbackCalls   int
+	lastRollbackArg int
+}
+
+// Capabilities satisfies provision.CapabilityReporter so the rollback command can
+// discover native-rollback eligibility. Zero value reports all-false.
+func (f *fakeRealizer) Capabilities() provision.Capabilities { return f.caps }
+
+// Rollback satisfies provision.Rollbacker, recording the requested native version.
+func (f *fakeRealizer) Rollback(to int) error {
+	f.rollbackCalls++
+	f.lastRollbackArg = to
+	return f.rollbackErr
 }
 
 func (f *fakeRealizer) Name() string { return "nix" }

--- a/go-engine/internal/commands/rollback.go
+++ b/go-engine/internal/commands/rollback.go
@@ -1,0 +1,212 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/provision"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+// RollbackFlags holds the parsed CLI flags for the rollback command.
+type RollbackFlags struct {
+	// To is the engine Provisioning Generation number to roll back to. Empty
+	// means roll back to the immediately previous version.
+	To string
+	// Confirm gates the (state-changing) rollback; without it the command refuses.
+	Confirm bool
+	// DryRun previews the resolved target without changing any state and without
+	// requiring Confirm.
+	DryRun bool
+	// Events controls streaming event output. Accepted for parity; rollback does
+	// not stream a per-item sequence (it is a single whole-set operation).
+	Events string
+}
+
+// RollbackResult is the data payload for the rollback command JSON envelope.
+type RollbackResult struct {
+	DryRun           bool   `json:"dryRun"`
+	Backend          string `json:"backend"`
+	TargetGeneration int    `json:"targetGeneration,omitempty"` // engine generation resolved from --to; 0 = previous
+	FromNative       string `json:"fromNative,omitempty"`       // backend-native version before rollback
+	ToNative         string `json:"toNative,omitempty"`         // native version targeted (dry-run) or active after
+	NewGeneration    int    `json:"newGeneration,omitempty"`    // appended engine generation number (0 on dry-run)
+}
+
+// RunRollback reverts the installed package set to a prior Provisioning
+// Generation, for backends that advertise native rollback (the Nix realizer
+// today). It is package-stage only: it never touches config restore,
+// state/backups/, or the revert journal. The target is identified by engine
+// generation number and mapped to the backend-native anchor (the user never
+// references a Nix version directly — the moat).
+func RunRollback(flags RollbackFlags) (interface{}, *envelope.Error) {
+	// Acquire the host realizer. Hosts with no realizer (e.g. Windows, which uses
+	// the per-package winget driver) have no native rollback in this phase.
+	r, rerr := newRealizerFn()
+	if rerr != nil {
+		return nil, envelope.NewError(envelope.ErrRollbackUnsupported,
+			"This platform's package backend does not support rollback.").
+			WithRemediation("Native rollback is available on Linux/macOS via the Nix backend.")
+	}
+
+	// Discover rollback eligibility by type-assertion + advertised capability,
+	// exactly like driver.BatchDetector / provision.CapabilityReporter.
+	rb, ok := r.(provision.Rollbacker)
+	if !ok || !nativeRollbackCapable(r) {
+		return nil, envelope.NewError(envelope.ErrRollbackUnsupported,
+			fmt.Sprintf("The %s backend does not support native rollback.", r.Name())).
+			WithRemediation("Rollback requires a backend that advertises native rollback (e.g. Nix).")
+	}
+
+	// Resolve the native target version from the engine generation number.
+	target := -1   // backend-native version; -1 == previous
+	targetGen := 0 // engine generation number; 0 == unspecified (previous)
+	if to := strings.TrimSpace(flags.To); to != "" {
+		n, err := strconv.Atoi(to)
+		if err != nil || n <= 0 {
+			return nil, envelope.NewError(envelope.ErrGenerationNotFound,
+				fmt.Sprintf("Invalid generation number %q.", flags.To)).
+				WithRemediation("Run 'endstate generations' to list available generations.")
+		}
+		gen, gerr := findGeneration(n)
+		if gerr != nil {
+			return nil, gerr
+		}
+		native, nerr := strconv.Atoi(gen.Native)
+		if gen.Native == "" || nerr != nil {
+			return nil, envelope.NewError(envelope.ErrGenerationNotFound,
+				fmt.Sprintf("Generation %d has no native rollback anchor.", n)).
+				WithRemediation("Only generations committed by a native-rollback backend can be rolled back to.")
+		}
+		target = native
+		targetGen = n
+	}
+
+	// Best-effort current native version for reporting.
+	fromNative := ""
+	if cur, err := r.Current(); err == nil {
+		fromNative = strconv.Itoa(cur.Generation)
+	}
+
+	toNative := "previous"
+	if target > 0 {
+		toNative = strconv.Itoa(target)
+	}
+
+	if flags.DryRun {
+		return &RollbackResult{
+			DryRun:           true,
+			Backend:          r.Name(),
+			TargetGeneration: targetGen,
+			FromNative:       fromNative,
+			ToNative:         toNative,
+		}, nil
+	}
+
+	if !flags.Confirm {
+		return nil, envelope.NewError(envelope.ErrInternalError,
+			"rollback requires --confirm to acknowledge that it changes the installed package set").
+			WithRemediation("Re-run with --confirm, or use --dry-run to preview the target.")
+	}
+
+	if err := rb.Rollback(target); err != nil {
+		return nil, rollbackError(err)
+	}
+
+	// Success: append a new Provisioning Generation snapshotting the now-active
+	// set so the append-only history keeps "newest == active" truthful.
+	cur, _ := r.Current()
+	newGen := appendRollbackGeneration(buildRunID("rollback"), r.Name(), cur)
+
+	return &RollbackResult{
+		DryRun:           false,
+		Backend:          r.Name(),
+		TargetGeneration: targetGen,
+		FromNative:       fromNative,
+		ToNative:         strconv.Itoa(cur.Generation),
+		NewGeneration:    newGen,
+	}, nil
+}
+
+// nativeRollbackCapable reports whether r advertises native rollback. A backend
+// that does not report capabilities is treated as not rollback-capable.
+func nativeRollbackCapable(r realizer.Realizer) bool {
+	cr, ok := r.(provision.CapabilityReporter)
+	if !ok {
+		return false
+	}
+	return cr.Capabilities().NativeRollback
+}
+
+// findGeneration returns the recorded Provisioning Generation numbered n, or a
+// GENERATION_NOT_FOUND envelope error when none exists.
+func findGeneration(n int) (*provision.Generation, *envelope.Error) {
+	gens, err := provision.List()
+	if err != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, err.Error())
+	}
+	for _, g := range gens {
+		if g.Number == n {
+			return g, nil
+		}
+	}
+	return nil, envelope.NewError(envelope.ErrGenerationNotFound,
+		fmt.Sprintf("No Provisioning Generation numbered %d.", n)).
+		WithRemediation("Run 'endstate generations' to list available generations.")
+}
+
+// appendRollbackGeneration writes a new Provisioning Generation snapshotting the
+// now-active package set after a successful rollback. AddedRefs is empty (nothing
+// was newly installed) and Rollback is true. It is best-effort: a write error
+// never fails the rollback, mirroring run-history persistence. Returns the
+// assigned generation number, or 0 on write failure.
+//
+// Separation of concerns: this records package facts only — it never touches the
+// config backup directory or the restore revert journal.
+func appendRollbackGeneration(runID, backend string, set realizer.Set) int {
+	items := make([]provision.ProvItem, 0, len(set.Elements))
+	for name, e := range set.Elements {
+		ref := e.AttrPath
+		if ref == "" {
+			ref = name
+		}
+		items = append(items, provision.ProvItem{ID: name, Ref: ref, Status: "present"})
+	}
+	g := &provision.Generation{
+		RunID:     runID,
+		Timestamp: time.Now().UTC().Format(time.RFC3339),
+		Backend:   backend,
+		Items:     items,
+		AddedRefs: []string{},
+		Native:    strconv.Itoa(set.Generation),
+		Rollback:  true,
+	}
+	if err := provision.Write(g); err != nil {
+		return 0
+	}
+	return g.Number
+}
+
+// rollbackError maps a backend rollback failure to an envelope error. Systemic
+// infrastructure failures (REALIZER_UNAVAILABLE / PERMISSION_DENIED) reuse the
+// realizer envelope error; otherwise the (already-classified) ROLLBACK_FAILED
+// code is surfaced with raw backend text confined to error.detail (the moat).
+func rollbackError(err error) *envelope.Error {
+	rerr, ok := err.(*realizer.Error)
+	if !ok {
+		return envelope.NewError(envelope.ErrRollbackFailed, "Rollback failed.").
+			WithDetail(map[string]string{"raw": err.Error()})
+	}
+	if isSystemic(rerr.Code) {
+		return realizerEnvelopeError(rerr)
+	}
+	return envelope.NewError(rerr.Code, "Rollback failed.").
+		WithDetail(map[string]string{"subcode": rerr.Subcode, "stage": rerr.Stage, "raw": rerr.Raw}).
+		WithRemediation("Run 'endstate generations' to inspect available rollback targets.")
+}

--- a/go-engine/internal/commands/rollback_test.go
+++ b/go-engine/internal/commands/rollback_test.go
@@ -1,0 +1,297 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"go/parser"
+	"go/token"
+	"strings"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/provision"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+// capableRealizer returns a fakeRealizer that advertises native rollback, with
+// the given current set.
+func capableRealizer(cur realizer.Set) *fakeRealizer {
+	return &fakeRealizer{
+		caps:       provision.Capabilities{AtomicSet: true, NativeRollback: true, BatchInstall: true},
+		currentSet: cur,
+	}
+}
+
+func setOf(gen int, names ...string) realizer.Set {
+	els := map[string]realizer.Element{}
+	for _, n := range names {
+		els[n] = realizer.Element{Name: n, AttrPath: n}
+	}
+	return realizer.Set{Generation: gen, Elements: els}
+}
+
+// --- ROLLBACK_UNSUPPORTED ----------------------------------------------------
+
+// TestRollback_NoRealizer_Unsupported: a host with no realizer (e.g. Windows)
+// refuses with ROLLBACK_UNSUPPORTED and changes nothing.
+func TestRollback_NoRealizer_Unsupported(t *testing.T) {
+	orig := newRealizerFn
+	newRealizerFn = func() (realizer.Realizer, error) { return nil, ErrNoRealizer }
+	defer func() { newRealizerFn = orig }()
+
+	_, env := RunRollback(RollbackFlags{Confirm: true})
+	if env == nil || env.Code != envelope.ErrRollbackUnsupported {
+		t.Fatalf("want ROLLBACK_UNSUPPORTED, got %+v", env)
+	}
+}
+
+// TestRollback_NotNativeCapable_Unsupported: a realizer that does not advertise
+// NativeRollback refuses with ROLLBACK_UNSUPPORTED without calling Rollback.
+func TestRollback_NotNativeCapable_Unsupported(t *testing.T) {
+	fr := &fakeRealizer{caps: provision.Capabilities{}} // all false
+	withFakeRealizer(fr, func() {
+		_, env := RunRollback(RollbackFlags{Confirm: true})
+		if env == nil || env.Code != envelope.ErrRollbackUnsupported {
+			t.Fatalf("want ROLLBACK_UNSUPPORTED, got %+v", env)
+		}
+	})
+	if fr.rollbackCalls != 0 {
+		t.Errorf("Rollback called %d times, want 0", fr.rollbackCalls)
+	}
+}
+
+// --- target resolution + append ---------------------------------------------
+
+// TestRollback_ToGeneration_MapsNativeAndAppends: --to N maps engine generation
+// N to its Native version, calls Rollback(native), and appends a new
+// rollback-marked Provisioning Generation reflecting the now-active set.
+func TestRollback_ToGeneration_MapsNativeAndAppends(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	// Seed engine generation #1 with Native "4".
+	if err := provision.Write(&provision.Generation{
+		Backend:   "nix",
+		Native:    "4",
+		Items:     []provision.ProvItem{{ID: "jq", Ref: "nixpkgs#jq", Status: "installed"}},
+		AddedRefs: []string{"nixpkgs#jq"},
+	}); err != nil {
+		t.Fatalf("seed generation: %v", err)
+	}
+
+	fr := capableRealizer(setOf(4, "jq"))
+	var result *RollbackResult
+	withFakeRealizer(fr, func() {
+		raw, env := RunRollback(RollbackFlags{To: "1", Confirm: true})
+		if env != nil {
+			t.Fatalf("unexpected envelope error: %+v", env)
+		}
+		result = raw.(*RollbackResult)
+	})
+
+	if fr.rollbackCalls != 1 {
+		t.Fatalf("Rollback called %d times, want 1", fr.rollbackCalls)
+	}
+	if fr.lastRollbackArg != 4 {
+		t.Errorf("Rollback(to) = %d, want 4 (the Native of generation 1)", fr.lastRollbackArg)
+	}
+	if result.TargetGeneration != 1 {
+		t.Errorf("TargetGeneration = %d, want 1", result.TargetGeneration)
+	}
+	if result.NewGeneration != 2 {
+		t.Errorf("NewGeneration = %d, want 2", result.NewGeneration)
+	}
+
+	gens, _ := provision.List()
+	if len(gens) != 2 {
+		t.Fatalf("want 2 generations after rollback, got %d", len(gens))
+	}
+	newest := gens[0] // newest first
+	if newest.Number != 2 || !newest.Rollback {
+		t.Errorf("newest generation = #%d rollback=%v, want #2 rollback=true", newest.Number, newest.Rollback)
+	}
+	if len(newest.AddedRefs) != 0 {
+		t.Errorf("rollback generation AddedRefs = %v, want empty", newest.AddedRefs)
+	}
+}
+
+// TestRollback_Previous_NoTo: bare rollback (no --to) calls Rollback(-1).
+func TestRollback_Previous_NoTo(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	fr := capableRealizer(setOf(3, "ripgrep"))
+	withFakeRealizer(fr, func() {
+		_, env := RunRollback(RollbackFlags{Confirm: true})
+		if env != nil {
+			t.Fatalf("unexpected envelope error: %+v", env)
+		}
+	})
+	if fr.rollbackCalls != 1 || fr.lastRollbackArg != -1 {
+		t.Errorf("want Rollback(-1) once, got calls=%d arg=%d", fr.rollbackCalls, fr.lastRollbackArg)
+	}
+}
+
+// TestRollback_UnknownGeneration_NotFound: --to N with no such generation →
+// GENERATION_NOT_FOUND, no Rollback call.
+func TestRollback_UnknownGeneration_NotFound(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	fr := capableRealizer(setOf(1))
+	withFakeRealizer(fr, func() {
+		_, env := RunRollback(RollbackFlags{To: "99", Confirm: true})
+		if env == nil || env.Code != envelope.ErrGenerationNotFound {
+			t.Fatalf("want GENERATION_NOT_FOUND, got %+v", env)
+		}
+	})
+	if fr.rollbackCalls != 0 {
+		t.Errorf("Rollback called %d times, want 0", fr.rollbackCalls)
+	}
+}
+
+// TestRollback_NoNativeAnchor_NotFound: --to N referencing a generation with no
+// native anchor (e.g. a winget generation) → GENERATION_NOT_FOUND.
+func TestRollback_NoNativeAnchor_NotFound(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	if err := provision.Write(&provision.Generation{
+		Backend:   "winget",
+		Native:    "", // non-atomic backend: no native anchor
+		AddedRefs: []string{"Some.App"},
+	}); err != nil {
+		t.Fatalf("seed generation: %v", err)
+	}
+	fr := capableRealizer(setOf(1))
+	withFakeRealizer(fr, func() {
+		_, env := RunRollback(RollbackFlags{To: "1", Confirm: true})
+		if env == nil || env.Code != envelope.ErrGenerationNotFound {
+			t.Fatalf("want GENERATION_NOT_FOUND, got %+v", env)
+		}
+	})
+	if fr.rollbackCalls != 0 {
+		t.Errorf("Rollback called %d times, want 0", fr.rollbackCalls)
+	}
+}
+
+// --- confirm gate + dry-run --------------------------------------------------
+
+// TestRollback_RequiresConfirm: without --confirm (and not --dry-run) the
+// command refuses, calls nothing, and writes no generation.
+func TestRollback_RequiresConfirm(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	fr := capableRealizer(setOf(2, "jq"))
+	withFakeRealizer(fr, func() {
+		_, env := RunRollback(RollbackFlags{}) // no confirm, no dry-run
+		if env == nil {
+			t.Fatal("expected refusal, got nil error")
+		}
+		if !strings.Contains(env.Message, "--confirm") {
+			t.Errorf("message %q should mention --confirm", env.Message)
+		}
+	})
+	if fr.rollbackCalls != 0 {
+		t.Errorf("Rollback called %d times, want 0", fr.rollbackCalls)
+	}
+	if gens, _ := provision.List(); len(gens) != 0 {
+		t.Errorf("want no generation written on refusal, got %d", len(gens))
+	}
+}
+
+// TestRollback_DryRun_NoMutation: --dry-run resolves and previews the target
+// without confirm, without calling Rollback, and without appending a generation.
+func TestRollback_DryRun_NoMutation(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	if err := provision.Write(&provision.Generation{Backend: "nix", Native: "4", AddedRefs: []string{"nixpkgs#jq"}}); err != nil {
+		t.Fatalf("seed generation: %v", err)
+	}
+	fr := capableRealizer(setOf(5, "jq"))
+	var result *RollbackResult
+	withFakeRealizer(fr, func() {
+		raw, env := RunRollback(RollbackFlags{To: "1", DryRun: true}) // no confirm
+		if env != nil {
+			t.Fatalf("unexpected envelope error: %+v", env)
+		}
+		result = raw.(*RollbackResult)
+	})
+	if !result.DryRun {
+		t.Error("result.DryRun = false, want true")
+	}
+	if result.ToNative != "4" {
+		t.Errorf("result.ToNative = %q, want 4", result.ToNative)
+	}
+	if fr.rollbackCalls != 0 {
+		t.Errorf("Rollback called %d times in dry-run, want 0", fr.rollbackCalls)
+	}
+	if gens, _ := provision.List(); len(gens) != 1 {
+		t.Errorf("dry-run must not append a generation; want 1 (seed), got %d", len(gens))
+	}
+}
+
+// --- failure classification (the moat) ---------------------------------------
+
+// TestRollback_SystemicError_RawInDetailOnly: a systemic backend failure
+// surfaces its code with raw text confined to Detail (never Message).
+func TestRollback_SystemicError_RawInDetailOnly(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	raw := "nix daemon: connection refused at /nix/var/nix/daemon-socket/socket"
+	fr := capableRealizer(setOf(3, "jq"))
+	fr.rollbackErr = &realizer.Error{Code: envelope.ErrRealizerUnavailable, Subcode: "daemon", Stage: "spawn", Raw: raw}
+
+	var env *envelope.Error
+	withFakeRealizer(fr, func() {
+		_, env = RunRollback(RollbackFlags{Confirm: true})
+	})
+	if env == nil || env.Code != envelope.ErrRealizerUnavailable {
+		t.Fatalf("want REALIZER_UNAVAILABLE, got %+v", env)
+	}
+	if strings.Contains(env.Message, raw) {
+		t.Errorf("raw text leaked into Message: %q", env.Message)
+	}
+	dm, ok := env.Detail.(map[string]string)
+	if !ok || dm["raw"] != raw {
+		t.Errorf("raw text not confined to Detail: %+v", env.Detail)
+	}
+	if gens, _ := provision.List(); len(gens) != 0 {
+		t.Errorf("failed rollback must not append a generation, got %d", len(gens))
+	}
+}
+
+// TestRollback_Failed_RawInDetailOnly: a non-systemic backend failure surfaces
+// ROLLBACK_FAILED with raw text confined to Detail.
+func TestRollback_Failed_RawInDetailOnly(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	raw := "error: profile version 99 does not exist"
+	fr := capableRealizer(setOf(3, "jq"))
+	fr.rollbackErr = &realizer.Error{Code: envelope.ErrRollbackFailed, Stage: "rollback", Raw: raw}
+
+	var env *envelope.Error
+	withFakeRealizer(fr, func() {
+		_, env = RunRollback(RollbackFlags{Confirm: true})
+	})
+	if env == nil || env.Code != envelope.ErrRollbackFailed {
+		t.Fatalf("want ROLLBACK_FAILED, got %+v", env)
+	}
+	if strings.Contains(env.Message, raw) {
+		t.Errorf("raw text leaked into Message: %q", env.Message)
+	}
+	dm, ok := env.Detail.(map[string]string)
+	if !ok || dm["raw"] != raw {
+		t.Errorf("raw text not confined to Detail: %+v", env.Detail)
+	}
+	if fr.rollbackCalls != 1 {
+		t.Errorf("Rollback called %d times, want 1", fr.rollbackCalls)
+	}
+}
+
+// --- separation of concerns guard --------------------------------------------
+
+// TestRollbackStaysPackageOnly: the rollback command file must not import the
+// config/restore layer — rollback (packages) is distinct from revert (configs).
+func TestRollbackStaysPackageOnly(t *testing.T) {
+	fset := token.NewFileSet()
+	af, err := parser.ParseFile(fset, "rollback.go", nil, parser.ImportsOnly)
+	if err != nil {
+		t.Fatalf("parse rollback.go: %v", err)
+	}
+	for _, imp := range af.Imports {
+		if strings.Contains(imp.Path.Value, "internal/restore") {
+			t.Fatalf("rollback.go imports %s; rollback must stay package-stage only", imp.Path.Value)
+		}
+	}
+}

--- a/go-engine/internal/envelope/errors.go
+++ b/go-engine/internal/envelope/errors.go
@@ -26,6 +26,13 @@ const (
 	ErrInternalError          ErrorCode = "INTERNAL_ERROR"
 	ErrSchemaIncompatible     ErrorCode = "SCHEMA_INCOMPATIBLE"
 
+	// Provisioning-generation rollback codes (nix-native-rollback). The package
+	// `rollback` command surfaces these; they are distinct from install/restore
+	// codes because rollback is its own pipeline verb.
+	ErrRollbackUnsupported ErrorCode = "ROLLBACK_UNSUPPORTED"
+	ErrGenerationNotFound  ErrorCode = "GENERATION_NOT_FOUND"
+	ErrRollbackFailed      ErrorCode = "ROLLBACK_FAILED"
+
 	// Hosted-backup error codes. Mapped from substrate backend HTTP responses
 	// per docs/contracts/hosted-backup-contract.md and cli-json-contract.md.
 	ErrAuthRequired         ErrorCode = "AUTH_REQUIRED"

--- a/go-engine/internal/provision/provision.go
+++ b/go-engine/internal/provision/provision.go
@@ -40,6 +40,7 @@ type Generation struct {
 	AddedRefs     []string   `json:"addedRefs"`
 	Native        string     `json:"native,omitempty"` // backend-native anchor (nix generation number); "" if none
 	Partial       bool       `json:"partial"`          // true when a non-atomic backend committed a partial set
+	Rollback      bool       `json:"rollback,omitempty"` // true when this generation was produced by a rollback (AddedRefs is empty)
 }
 
 // Capabilities describes what a package backend can do. It is discovered at

--- a/go-engine/internal/realizer/nix/rollback.go
+++ b/go-engine/internal/realizer/nix/rollback.go
@@ -1,0 +1,56 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package nix
+
+import (
+	"strconv"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/provision"
+)
+
+// compile-time assertion: the Nix backend implements provision.Rollbacker, so
+// the rollback command can discover eligibility by type-assertion.
+var _ provision.Rollbacker = (*Backend)(nil)
+
+// Rollback reverts the Endstate-managed profile to a prior version via
+// `nix profile rollback`. A positive `to` selects a specific Nix profile
+// version (`--to <to>`); a non-positive `to` rolls back to the immediately
+// previous version (bare `nix profile rollback`). The mapping from an
+// engine-owned Provisioning Generation number to this Nix version is the
+// caller's responsibility (the command layer reads the generation's Native
+// anchor) — Rollback speaks only Nix versions.
+//
+// Failures are classified through the same anchor path as Realize: spawn and
+// daemon failures surface REALIZER_UNAVAILABLE, permission failures
+// PERMISSION_DENIED, and any other non-zero exit ROLLBACK_FAILED (classify's
+// INSTALL_FAILED fallback is remapped, since this is the rollback verb). Raw
+// Nix text is retained ONLY in Error.Raw, destined for envelope error.detail.
+func (b *Backend) Rollback(to int) error {
+	args := []string{"profile", "rollback", "--profile", b.Profile}
+	if to > 0 {
+		args = append(args, "--to", strconv.Itoa(to))
+	}
+	args = append(args, "--log-format", "internal-json")
+
+	_, stderr, exit, err := b.Run(args...)
+	p := parseInternalJSON(stderr)
+	if err != nil { // spawn failure (binary missing/unrunnable)
+		return classify(-1, p, false)
+	}
+	if exit == 0 {
+		return nil
+	}
+
+	// Non-zero exit: reuse the locked anchor table for systemic classes
+	// (daemon -> REALIZER_UNAVAILABLE, permission -> PERMISSION_DENIED), but
+	// remap the generic INSTALL_FAILED fallback to ROLLBACK_FAILED so the error
+	// names the rollback verb rather than an install.
+	rerr := classify(exit, p, false)
+	if rerr != nil && rerr.Code == envelope.ErrInstallFailed {
+		rerr.Code = envelope.ErrRollbackFailed
+		rerr.Stage = "rollback"
+	}
+	return rerr
+}

--- a/go-engine/internal/realizer/nix/rollback_test.go
+++ b/go-engine/internal/realizer/nix/rollback_test.go
@@ -1,0 +1,133 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package nix
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+// captureRun returns a Runner that records the args of its (single) invocation
+// and replays the scripted stderr/exit/err.
+func captureRun(stderr []byte, exit int, runErr error) (Runner, *[]string) {
+	got := &[]string{}
+	r := func(args ...string) ([]byte, []byte, int, error) {
+		*got = append([]string(nil), args...)
+		return nil, stderr, exit, runErr
+	}
+	return r, got
+}
+
+func asRealizerErr(t *testing.T, err error) *realizer.Error {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected an error, got nil")
+	}
+	rerr, ok := err.(*realizer.Error)
+	if !ok {
+		t.Fatalf("expected *realizer.Error, got %T (%v)", err, err)
+	}
+	return rerr
+}
+
+// TestRollback_Previous: bare rollback (to <= 0) emits `profile rollback
+// --profile <p>` with NO --to, and exit 0 yields no error.
+func TestRollback_Previous(t *testing.T) {
+	run, got := captureRun(nil, 0, nil)
+	b := &Backend{Profile: "/tmp/endstate-nix-test-profile", Run: run}
+
+	if err := b.Rollback(0); err != nil {
+		t.Fatalf("expected nil error on successful rollback, got %v", err)
+	}
+	joined := strings.Join(*got, " ")
+	if !strings.Contains(joined, "profile rollback --profile /tmp/endstate-nix-test-profile") {
+		t.Errorf("args missing rollback invocation: %q", joined)
+	}
+	if strings.Contains(joined, "--to") {
+		t.Errorf("bare rollback must not pass --to, got %q", joined)
+	}
+}
+
+// TestRollback_ToVersion: Rollback(N>0) emits `--to N`.
+func TestRollback_ToVersion(t *testing.T) {
+	run, got := captureRun(nil, 0, nil)
+	b := &Backend{Profile: "/tmp/endstate-nix-test-profile", Run: run}
+
+	if err := b.Rollback(4); err != nil {
+		t.Fatalf("expected nil error, got %v", err)
+	}
+	joined := strings.Join(*got, " ")
+	if !strings.Contains(joined, "--to 4") {
+		t.Errorf("expected --to 4 in args, got %q", joined)
+	}
+}
+
+// TestRollback_Failure_RemapsToRollbackFailed: a non-zero exit whose text
+// matches no systemic anchor classifies as ROLLBACK_FAILED (not INSTALL_FAILED),
+// with the raw text confined to Err.Raw.
+func TestRollback_Failure_RemapsToRollbackFailed(t *testing.T) {
+	raw := "error: profile version 99 does not exist"
+	stderr := mkStderr([]struct {
+		level int
+		text  string
+	}{{0, raw}}, nil)
+	run, _ := captureRun(stderr, 1, nil)
+	b := &Backend{Profile: "/tmp/endstate-nix-test-profile", Run: run}
+
+	rerr := asRealizerErr(t, b.Rollback(99))
+	if rerr.Code != envelope.ErrRollbackFailed {
+		t.Errorf("Code = %q, want ROLLBACK_FAILED", rerr.Code)
+	}
+	if !strings.Contains(rerr.Raw, "does not exist") {
+		t.Errorf("raw text not retained in Err.Raw: %q", rerr.Raw)
+	}
+}
+
+// TestRollback_Daemon_Systemic: a daemon-class anchor surfaces
+// REALIZER_UNAVAILABLE (passed through classify, not remapped).
+func TestRollback_Daemon_Systemic(t *testing.T) {
+	stderr := mkStderr([]struct {
+		level int
+		text  string
+	}{{0, "error: cannot connect to socket at '/nix/var/nix/daemon-socket/socket'"}}, nil)
+	run, _ := captureRun(stderr, 1, nil)
+	b := &Backend{Profile: "/tmp/endstate-nix-test-profile", Run: run}
+
+	rerr := asRealizerErr(t, b.Rollback(0))
+	if rerr.Code != envelope.ErrRealizerUnavailable {
+		t.Errorf("Code = %q, want REALIZER_UNAVAILABLE", rerr.Code)
+	}
+}
+
+// TestRollback_Permission_Systemic: a permission-class anchor surfaces
+// PERMISSION_DENIED.
+func TestRollback_Permission_Systemic(t *testing.T) {
+	stderr := mkStderr([]struct {
+		level int
+		text  string
+	}{{0, "error: opening file: Permission denied"}}, nil)
+	run, _ := captureRun(stderr, 1, nil)
+	b := &Backend{Profile: "/tmp/endstate-nix-test-profile", Run: run}
+
+	rerr := asRealizerErr(t, b.Rollback(0))
+	if rerr.Code != envelope.ErrPermissionDenied {
+		t.Errorf("Code = %q, want PERMISSION_DENIED", rerr.Code)
+	}
+}
+
+// TestRollback_Spawn: a spawn failure (runner returns a non-nil error) surfaces
+// REALIZER_UNAVAILABLE.
+func TestRollback_Spawn(t *testing.T) {
+	run, _ := captureRun(nil, -1, errors.New("exec: nix not found"))
+	b := &Backend{Profile: "/tmp/endstate-nix-test-profile", Run: run}
+
+	rerr := asRealizerErr(t, b.Rollback(0))
+	if rerr.Code != envelope.ErrRealizerUnavailable {
+		t.Errorf("Code = %q, want REALIZER_UNAVAILABLE", rerr.Code)
+	}
+}

--- a/openspec/changes/nix-native-rollback/design.md
+++ b/openspec/changes/nix-native-rollback/design.md
@@ -1,0 +1,123 @@
+## Context
+
+After `provisioning-generation` (Phase 2), the engine writes a numbered Provisioning
+Generation per successful `apply` (both backends) under `state/generations/<n>.json`, lists
+them via the read-only `generations` command, and the Nix realizer advertises
+`Capabilities{NativeRollback: true}`. `provision.Rollbacker` (`Rollback(to int) error`) is
+**declared but unimplemented**. Each Nix-backed generation records `Native` = the Nix profile
+version active when it was committed.
+
+This change implements rollback for native-rollback backends (Nix) and adds the `rollback`
+command. The dual `Driver`+`Realizer` split is unchanged; winget rollback is Phase 4.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A top-level `rollback` command that reverts the package set to a prior Provisioning
+  Generation, identified by **engine generation number** (the moat: never a raw Nix version).
+- `provision.Rollbacker` implemented on the Nix realizer via `nix profile rollback`.
+- `--confirm`-gated with a `--dry-run` preview (non-destructive default).
+- Append a new Provisioning Generation on success (append-only, honest history).
+- **Zero Windows regression** — provable by host-aware tests + `GOOS=windows` build.
+
+**Non-Goals:**
+- **No winget rollback** (Phase 4) — non-native-rollback backends refuse cleanly.
+- **No convergence / uninstall-drift** (Phase 5).
+- **No config/restore involvement** — rollback is package-stage only.
+- **No generation pruning / retention policy change.**
+
+## Decisions
+
+### (a) Target identity = engine generation number
+
+`rollback --to <N>` resolves engine Provisioning Generation N from `provision.List()`, reads
+its `Native` field, and rolls the backend to that native anchor. Bare `rollback` (no `--to`)
+reverts to the immediately previous version. Rationale: `generations` already presents
+engine-owned numbers; mapping `N → Native` keeps the UX in engine terms and preserves the
+"user never learns Nix" moat. `Native` was shipped in Phase 2 for exactly this.
+
+### (b) Append a new Provisioning Generation on success
+
+The engine's generation store is an append-only list with **no HEAD pointer** — `generations`
+simply lists files newest-first. If rollback only repointed the Nix profile and recorded
+nothing, the newest engine generation would still describe the pre-rollback set, so the list
+would no longer reflect what is active. Therefore a successful rollback appends a new
+generation snapshotting the now-active set: `Items` = the current profile set (status
+`present`), `AddedRefs = []`, `Native` = the active Nix version after rollback,
+`RunID = "rollback-<ts>"`, `Rollback = true`.
+
+*Empirical note (Determinate Nix 3.21.0):* `nix profile rollback` switches the profile to an
+**existing** older version (`"switching profile from version 519 to 518"`); it does **not**
+mint a new Nix version. So the appended record is an *engine* generation whose `Native` points
+back at the older Nix version — not a new Nix generation. This corrects the handoff's §4(b)
+parenthetical.
+
+### (c) Require `--confirm`
+
+Rollback changes the installed set, so it is `--confirm`-gated (default refuses; `--dry-run`
+previews without confirmation or mutation). Consistent with `non-destructive-defaults` and
+symmetric with the Phase 4 `--confirm`-gated winget rollback. Nix rollback is atomic and
+reversible (roll forward again with `--to`), but the gate is kept for spec consistency.
+
+### Backend method
+
+`func (b *Backend) Rollback(to int) error` (satisfies `provision.Rollbacker`):
+- `to <= 0` → `nix profile rollback --profile <profile>` (previous).
+- `to > 0`  → `nix profile rollback --profile <profile> --to <to>` (`to` is the **Nix** version).
+- Injected `Runner` seam (hermetic tests). Failures classified via the existing `classify(...)`
+  → `*realizer.Error` (REALIZER_UNAVAILABLE on spawn/daemon, PERMISSION_DENIED, else
+  ROLLBACK_FAILED). Raw text only in `Error.Raw` → `error.detail`.
+
+### Command flow (`RunRollback`)
+
+1. `r, err := newRealizerFn()`; `err != nil` (e.g. Windows) → `ROLLBACK_UNSUPPORTED`.
+2. `rb, ok := r.(provision.Rollbacker)`; require `CapabilityReporter.Capabilities().NativeRollback`.
+   Else → `ROLLBACK_UNSUPPORTED`.
+3. Resolve native target: `--to N` → load gen N (missing/no-`Native` → `GENERATION_NOT_FOUND`),
+   `native = atoi(Native)`; no `--to` → `native = -1` (previous).
+4. `--dry-run` → return resolved-target preview, no mutation. No `--confirm` (and not dry-run)
+   → refuse with remediation, no mutation.
+5. `rb.Rollback(native)`; on `*realizer.Error`: systemic (`isSystemic`) → top-level envelope
+   error; else `ROLLBACK_FAILED`. Raw text confined to detail.
+6. On success: read `r.Current()`, append a rollback-marked Provisioning Generation; return a
+   `RollbackResult` (from/to native versions, new engine generation number).
+
+### Error codes (additive)
+
+| Code | When |
+|------|------|
+| `ROLLBACK_UNSUPPORTED` | Host backend does not advertise native rollback (winget / no realizer) |
+| `GENERATION_NOT_FOUND` | `--to N` references a missing generation, or one with no native anchor |
+| `ROLLBACK_FAILED` | The backend rollback failed (non-systemic); raw text in `error.detail` |
+
+Systemic infrastructure failures during rollback reuse `REALIZER_UNAVAILABLE` /
+`PERMISSION_DENIED` (same classification as `apply`).
+
+### Generation record change
+
+Add optional `Rollback bool \`json:"rollback,omitempty"\`` to `provision.Generation`. Additive;
+older readers ignore it; `SchemaVersion` stays `"1.0"`.
+
+## Separation of concerns (inviolable)
+
+`rollback` operates on the package generation only. It never imports `internal/restore`, never
+reads/writes `state/backups/`, and never touches the revert journal. Asserted as an **ADDED**
+requirement in the `separation-of-concerns` capability ("Rollback operates on packages only") —
+an ADDED (not MODIFIED) requirement so it composes with `provisioning-generation`'s concurrent
+MODIFY of *Distinct Pipeline Stages* without an archive-order conflict — and enforced by a code
+guard test (`TestRollbackStaysPackageOnly`) that scans `rollback.go`'s imports for
+`internal/restore` (mirroring the Phase-2 `internal/provision` guard).
+
+## Risks / limitations (documented, not blockers)
+
+- A target generation written before this change has `Native` set (Nix path) — older `winget`
+  generations have `Native=""` and are correctly rejected with `GENERATION_NOT_FOUND` on Windows
+  (which also has no realizer, so it never reaches that branch in this phase).
+- `nix profile wipe-history` (or GC) can remove the Nix version a generation's `Native` points
+  at; rollback to such a target fails at the backend and surfaces as `ROLLBACK_FAILED` with raw
+  text in detail. Not introduced here; documented.
+
+## Migration
+
+Purely additive. No manifest/envelope schema bump. Existing state, generations, and Windows
+behavior unchanged.

--- a/openspec/changes/nix-native-rollback/proposal.md
+++ b/openspec/changes/nix-native-rollback/proposal.md
@@ -1,0 +1,106 @@
+## Why
+
+Phase 2 (`provisioning-generation`, PR #58, merged) made `apply` commit a numbered,
+inspectable **Provisioning Generation** for both package backends and shipped a read-only
+`generations` command. It deliberately **declared** the `provision.Rollbacker` interface
+but left it unimplemented, and the Nix realizer already advertises
+`Capabilities{NativeRollback: true}`. So the unification layer exists, the capability is
+advertised, and there is a stable, numbered history — but there is **no way to revert** the
+package set to a prior generation.
+
+This change implements **native Unix rollback**: a top-level `rollback` command that reverts
+the installed package set to a prior Provisioning Generation, for backends that advertise
+`NativeRollback` (the Nix realizer today). It implements `provision.Rollbacker` on the Nix
+realizer via `nix profile rollback`. Backends that do not advertise native rollback (the
+winget driver on Windows; any host with no realizer) **refuse cleanly and change nothing** —
+best-effort winget rollback is a later phase (Phase 4), explicitly out of scope here.
+
+`rollback` is a **top-level command**, not an `apply` flag, keeping the install-revert verb
+out of the config-bearing apply flow. It operates on **packages only**: it is distinct from
+`revert` (configuration) and never touches `state/backups/` or the restore revert journal.
+
+This updates `AI_CONTRACT.md` Non-Goal **#4** ("No automatic rollback"): a manual, opt-in,
+`--confirm`-gated **package** rollback now exists alongside the manual `revert` for configs, so
+#4 is reworded to state that all rollback is explicit/opt-in and nothing auto-rolls-back (the
+no-*automatic*-rollback principle is preserved). `AI_CONTRACT.md` is PROTECTED; this edit is
+made at the maintainer's explicit request.
+
+## What Changes
+
+- Implement `provision.Rollbacker` on the Nix realizer (`internal/realizer/nix`):
+  `Rollback(to int) error` runs `nix profile rollback --profile <profile>` (previous version)
+  or `... --to <native>` (a specific Nix version), classifying failures to engine error codes
+  via the existing `classify(...)` path. Raw Nix text is confined to `error.detail` (the moat).
+- Add a top-level **`rollback`** command (`internal/commands/rollback.go`):
+  - Acquires the host realizer via the existing `newRealizerFn()` seam (Windows has none →
+    refuses). Discovers rollback eligibility by **type-assertion** on `provision.Rollbacker`
+    and `provision.CapabilityReporter.Capabilities().NativeRollback` — exactly like
+    `driver.BatchDetector`.
+  - **Target identity = engine generation number.** `rollback --to <N>` maps engine
+    Provisioning Generation N → its recorded `Native` (the Nix version), then rolls back to
+    that native version. Bare `rollback` reverts to the previous version. The user never
+    references a Nix version directly (the moat).
+  - **Requires `--confirm`.** Default refuses (changes nothing); `--dry-run` previews the
+    resolved target without confirmation or mutation. Consistent with `non-destructive-defaults`
+    and symmetric with Phase 4's planned `--confirm`-gated winget rollback.
+  - **Appends a new Provisioning Generation** snapshotting the now-active set after a
+    successful rollback (Native = the active Nix version; `addedRefs` empty; marked as
+    rollback-produced), so the engine's append-only history keeps "newest = currently active"
+    truthful and provides an audit trail. (Empirically, `nix profile rollback` repoints to an
+    *existing* older Nix version rather than minting a new one; the new record is therefore an
+    *engine* generation whose `Native` points back at that older version.)
+- Add an optional `Rollback bool` field to `provision.Generation` to mark rollback-produced
+  records (additive; `SchemaVersion` stays `"1.0"`).
+- Add three additive engine error codes: `ROLLBACK_UNSUPPORTED`, `GENERATION_NOT_FOUND`,
+  `ROLLBACK_FAILED`.
+
+The dual `Driver` + `Realizer` interfaces are **kept beside each other** — unchanged.
+
+## Capabilities
+
+### New Capabilities
+
+- `nix-native-rollback`: a top-level `rollback` command reverts the installed package set to a
+  prior Provisioning Generation, for backends that advertise native rollback. It is identified
+  by engine generation number (mapped to the backend-native anchor), gated by `--confirm` with
+  a `--dry-run` preview, appends a new Provisioning Generation on success, operates on packages
+  only, and confines raw backend diagnostics to the error detail. Non-native-rollback backends
+  refuse without changing state.
+
+### Modified Capabilities
+
+- `separation-of-concerns`: **ADDS** a new requirement ("Rollback operates on packages only")
+  asserting that `rollback` never touches `state/backups/` or the restore revert journal and
+  never invokes restore, and that `rollback` (packages) and `revert` (configs) stay distinct
+  verbs over distinct logs. This is an **ADDED requirement** (a brand-new requirement name), NOT
+  a modification of the existing *Distinct Pipeline Stages* requirement — the not-yet-archived
+  `provisioning-generation` change already MODIFIES that requirement, and a second concurrent
+  MODIFY of the same requirement would risk dropping a scenario at archive time. Also enforced
+  in code by a guard test (`TestRollbackStaysPackageOnly`).
+
+## Impact
+
+- `internal/realizer/nix/rollback.go` (new) — `Rollback(to int) error` on `*Backend` via
+  `nix profile rollback`; classified failures through `classify(...)`.
+- `internal/commands/rollback.go` (new) — `RunRollback` + `RollbackFlags` + `RollbackResult`,
+  modeled on `generations.go` / `apply_realizer.go` (reuses `newRealizerFn`, `provision.List`,
+  `r.Current`, the `realizerEnvelopeError`/`isSystemic` moat pattern).
+- `internal/provision/provision.go` — additive optional `Rollback bool` field on `Generation`.
+- `internal/envelope/errors.go` — `ErrRollbackUnsupported`, `ErrGenerationNotFound`,
+  `ErrRollbackFailed`.
+- `cmd/endstate/main.go` — **PROTECTED (maintainer-approved, additive)**: `case "rollback"` in
+  `dispatch()` + a `usageText` line + `commandUsage("rollback")`. (`--to`/`--confirm`/`--dry-run`
+  parsing already exists in `parseArgs`.)
+- `docs/contracts/cli-json-contract.md` — **PROTECTED (maintainer-approved, additive)**:
+  `## Command: rollback` section + the three new error codes + a note on the optional `rollback`
+  field on generation records.
+- `docs/ai/AI_CONTRACT.md` — **PROTECTED (maintainer-approved)**: reword Non-Goal #4 to reflect
+  that a manual, opt-in `rollback` exists while preserving the no-*automatic*-rollback principle.
+- `openspec/changes/nix-native-rollback/specs/separation-of-concerns/spec.md` — ADDED
+  requirement asserting rollback is package-stage only.
+- No manifest/envelope schema-version bump: the `Generation` record carries its own schema
+  version; the `rollback` command, its fields, and the new error codes are additive per
+  `schema-versioning`.
+- **Zero Windows behavior regression**: `rollback` is a brand-new verb; on Windows (no
+  realizer) it returns a clean `ROLLBACK_UNSUPPORTED`. Proven by host-aware tests +
+  `GOOS=windows` build/vet.

--- a/openspec/changes/nix-native-rollback/specs/nix-native-rollback/spec.md
+++ b/openspec/changes/nix-native-rollback/specs/nix-native-rollback/spec.md
@@ -1,0 +1,82 @@
+## ADDED Requirements
+
+### Requirement: Native package rollback to a prior generation
+
+The engine SHALL provide a top-level `rollback` command that reverts the installed package set to a prior Provisioning Generation, for package backends that advertise native rollback. The target generation SHALL be identified by its engine-owned Provisioning Generation number; the engine SHALL map that number to the backend-native anchor recorded in the generation. Backends that do not advertise native rollback SHALL refuse without changing any state.
+
+#### Scenario: Rollback to a specified generation
+
+- **WHEN** `rollback --to <N> --confirm` runs on a native-rollback backend and Provisioning Generation N exists with a recorded native anchor
+- **THEN** the engine SHALL revert the package set to the state recorded by generation N, using that generation's native anchor
+- **AND** the user SHALL NOT be required to reference any backend-native version number
+
+#### Scenario: Bare rollback reverts to the previous version
+
+- **WHEN** `rollback --confirm` runs on a native-rollback backend with no target generation specified
+- **THEN** the engine SHALL revert the package set to the immediately previous version
+
+#### Scenario: Backend without native rollback refuses
+
+- **WHEN** `rollback` runs on a host whose package backend does not advertise native rollback
+- **THEN** the engine SHALL refuse with a stable error code
+- **AND** it SHALL NOT install, uninstall, or otherwise modify the installed package set
+
+#### Scenario: Unknown target generation is rejected
+
+- **WHEN** `rollback --to <N>` references a Provisioning Generation number that does not exist
+- **THEN** the engine SHALL return a stable error
+- **AND** it SHALL NOT modify the installed package set
+
+#### Scenario: Target generation without a native anchor is rejected
+
+- **WHEN** `rollback --to <N>` references a Provisioning Generation that records no backend-native anchor
+- **THEN** the engine SHALL return a stable error
+- **AND** it SHALL NOT modify the installed package set
+
+### Requirement: Rollback requires explicit confirmation
+
+Because rollback changes the installed package set, it SHALL require an explicit confirmation flag, consistent with non-destructive defaults. A preview mode SHALL be available without confirmation.
+
+#### Scenario: Rollback without confirmation refuses
+
+- **WHEN** `rollback` runs without the confirmation flag and not in preview mode
+- **THEN** the engine SHALL refuse and SHALL NOT modify the installed package set
+- **AND** it SHALL report how to re-run with confirmation
+
+#### Scenario: Preview does not mutate
+
+- **WHEN** `rollback --dry-run` runs
+- **THEN** the engine SHALL report the resolved target without modifying the installed package set
+- **AND** it SHALL NOT require the confirmation flag
+
+#### Scenario: Confirmed rollback executes
+
+- **WHEN** `rollback --to <N> --confirm` runs on a native-rollback backend with a valid target
+- **THEN** the engine SHALL perform the rollback to that target
+
+### Requirement: Rollback appends a Provisioning Generation
+
+After a successful rollback, the engine SHALL append a new numbered Provisioning Generation that snapshots the now-active package set, so the generation history remains append-only and the newest record always reflects the active set.
+
+#### Scenario: Successful rollback records the now-active set
+
+- **WHEN** a rollback completes successfully
+- **THEN** the engine SHALL write a new Provisioning Generation under the resolved state directory
+- **AND** its number SHALL be one greater than the highest existing Provisioning Generation number
+- **AND** it SHALL record the backend-native anchor of the now-active set
+
+#### Scenario: The appended generation is marked as rollback-produced
+
+- **WHEN** a rollback appends a Provisioning Generation
+- **THEN** that generation SHALL be distinguishable as produced by a rollback
+- **AND** its added references SHALL be empty, because no package was newly installed
+
+### Requirement: Rollback confines backend diagnostics
+
+Raw backend output (for example, Nix CLI text) produced during a rollback SHALL be confined to the error detail channel and SHALL NOT appear in the user-facing error message.
+
+#### Scenario: Raw backend text is confined to detail
+
+- **WHEN** a rollback fails with backend diagnostic output
+- **THEN** the raw backend text SHALL appear only in the error detail
+- **AND** the user-facing message SHALL NOT contain the raw backend text

--- a/openspec/changes/nix-native-rollback/specs/separation-of-concerns/spec.md
+++ b/openspec/changes/nix-native-rollback/specs/separation-of-concerns/spec.md
@@ -1,0 +1,19 @@
+## ADDED Requirements
+
+### Requirement: Rollback operates on packages only
+
+The package `rollback` command SHALL operate on the package Provisioning Generation only, never on configuration state, preserving the separation between `rollback` (packages) and `revert` (configuration). The two reversal verbs remain distinct commands over distinct logs.
+
+This is an ADDED requirement (a new, distinct requirement) rather than a modification of *Distinct Pipeline Stages*, so it composes cleanly with any concurrent change that modifies that requirement.
+
+#### Scenario: Rollback does not touch configuration state
+
+- **WHEN** `rollback` runs
+- **THEN** it SHALL NOT read or write the config backup directory (`state/backups/`) or the restore revert journal
+- **AND** it SHALL NOT invoke configuration restore
+
+#### Scenario: Rollback and revert are distinct verbs
+
+- **WHEN** a host has both package Provisioning Generations and a restore revert journal
+- **THEN** `rollback` SHALL act only on the package generation
+- **AND** `revert` SHALL act only on the configuration restore journal

--- a/openspec/changes/nix-native-rollback/tasks.md
+++ b/openspec/changes/nix-native-rollback/tasks.md
@@ -1,0 +1,93 @@
+> TDD: write each test RED first, then implement to green. All CI tests are hermetic (no real
+> `nix`/`winget`). Host-dependent tests are made host-aware (inject `newRealizerFn`; key
+> fixtures by `runtime.GOOS`, per the Phase-1/2 `nixApp`/`foreignRefApp`/`withFakeRealizer`
+> pattern). Verify on Linux: `cd go-engine && go test ./...`; plus `GOOS=windows go build ./...`
+> + `go vet` clean.
+
+## 0. Gate
+
+- [ ] 0.1 `npm run openspec:validate` (strict) passes for this change before implementing
+- [ ] 0.2 **PAUSE for maintainer review of this spec** (Gate A) before any Go is written
+
+## 1. `provision.Generation` — rollback marker (additive)
+
+- [ ] 1.1 Add optional `Rollback bool \`json:"rollback,omitempty"\`` to `Generation`
+- [ ] 1.2 RED test: round-trips; absent when false (omitempty); `SchemaVersion` stays `"1.0"`
+
+## 2. Engine error codes (additive)
+
+- [ ] 2.1 `internal/envelope/errors.go`: `ErrRollbackUnsupported = "ROLLBACK_UNSUPPORTED"`,
+      `ErrGenerationNotFound = "GENERATION_NOT_FOUND"`, `ErrRollbackFailed = "ROLLBACK_FAILED"`
+
+## 3. `provision.Rollbacker` on the Nix realizer
+
+- [ ] 3.1 RED tests (`internal/realizer/nix/rollback_test.go`, injected `Runner`/`fakeRun`):
+      bare rollback emits `profile rollback --profile <p>` (no `--to`); `Rollback(4)` emits
+      `--to 4`; non-zero exit → classified `*realizer.Error`; spawn error → REALIZER_UNAVAILABLE
+- [ ] 3.2 `internal/realizer/nix/rollback.go`: `func (b *Backend) Rollback(to int) error` via
+      `nix profile rollback [--to N]`; classify failures with `classify(...)`; raw text → detail
+- [ ] 3.3 Compile-time assertion that `*nix.Backend` satisfies `provision.Rollbacker`
+
+## 4. `rollback` command
+
+- [ ] 4.1 `internal/commands/rollback.go`: `RollbackFlags{To string; Confirm, DryRun bool; Events string}`,
+      `RollbackResult`, `RunRollback`
+- [ ] 4.2 Acquire realizer via `newRealizerFn()`; `err != nil` → `ROLLBACK_UNSUPPORTED`
+- [ ] 4.3 Gate on `provision.Rollbacker` + `CapabilityReporter.Capabilities().NativeRollback`;
+      else `ROLLBACK_UNSUPPORTED`
+- [ ] 4.4 Target resolution: `--to N` → `provision.List()` find `Number==N`; missing or no
+      `Native` → `GENERATION_NOT_FOUND`; `native = atoi(Native)`. No `--to` → `native = -1`
+- [ ] 4.5 `--dry-run` → preview result, no `Rollback` call, no generation written. No `--confirm`
+      (and not dry-run) → refuse with remediation, no mutation
+- [ ] 4.6 Execute `rb.Rollback(native)`; systemic (`isSystemic`) → top-level envelope error;
+      else `ROLLBACK_FAILED`; raw text only in `error.detail` (the moat)
+- [ ] 4.7 On success: `r.Current()` → append a rollback-marked generation (Items=present set,
+      `AddedRefs=[]`, `Native`=active version, `RunID="rollback-<ts>"`, `Rollback=true`); return
+      `RollbackResult`
+
+## 5. Command tests (`internal/commands/rollback_test.go`, host-aware)
+
+- [ ] 5.1 Extend `fakeRealizer` with `Rollback(to int) error` (+ `rollbackErr`, `lastRollbackArg`)
+      and a configurable `Capabilities()` (`CapabilityReporter`)
+- [ ] 5.2 No realizer (inject `ErrNoRealizer`) → `ROLLBACK_UNSUPPORTED`
+- [ ] 5.3 Realizer with `NativeRollback:false` → `ROLLBACK_UNSUPPORTED`
+- [ ] 5.4 `--to N` present (seed a generation file with `Native`) → `Rollback(native)` called;
+      new generation appended with `Rollback:true`, `AddedRefs` empty
+- [ ] 5.5 `--to N` missing / no native anchor → `GENERATION_NOT_FOUND`; no mutation
+- [ ] 5.6 Bare rollback → `Rollback(-1)`
+- [ ] 5.7 No `--confirm`, not dry-run → refuses, `Rollback` not called, no generation written
+- [ ] 5.8 `--dry-run` → `Rollback` not called, no generation written
+- [ ] 5.9 Systemic error → envelope error, raw text only in `Detail` (not `Message`)
+- [ ] 5.10 Guard test: the rollback command path does not import `internal/restore`
+
+## 6. Dispatch + usage (PROTECTED — maintainer-approved, additive)
+
+- [ ] 6.1 `cmd/endstate/main.go`: `case "rollback"` in `dispatch()` mapping
+      `--to`/`--confirm`/`--dry-run`/`--events`; add `rollback` to `usageText` +
+      `commandUsage("rollback")`
+
+## 7. Contract documentation (PROTECTED — maintainer-approved, additive)
+
+- [ ] 7.1 `docs/contracts/cli-json-contract.md`: `## Command: rollback` (flags + `RollbackResult`
+      shape, "additive in schema 1.x"); add the three error codes to the Standard Error Codes
+      table; note the optional `rollback` field on generation records
+- [ ] 7.2 `docs/ai/AI_CONTRACT.md` (PROTECTED, maintainer-approved): reword Non-Goal #4 to note a
+      manual, opt-in `rollback` exists while preserving the no-*automatic*-rollback principle
+- [ ] 7.3 `specs/separation-of-concerns/spec.md` (this change): ADDED requirement "Rollback
+      operates on packages only" (distinct requirement — no MODIFY conflict)
+
+## 8. Windows no-regression
+
+- [ ] 8.1 Test: on a no-realizer host fixture, `rollback` returns `ROLLBACK_UNSUPPORTED` and
+      writes/changes nothing
+- [ ] 8.2 `GOOS=windows go build ./...` + `go vet ./...` clean; existing tests green
+
+## 9. Verification
+
+- [ ] 9.1 `cd go-engine && go test ./...` green on Linux
+- [ ] 9.2 `GOOS=windows go build ./...` + `go vet ./...` clean
+- [ ] 9.3 `npm run openspec:validate` (strict) passes
+- [ ] 9.4 Real-nix smoke (not CI): `apply` 2-pkg manifest → gen N; add a 3rd → gen N+1;
+      `rollback --to <N> --confirm` → back to the 2-pkg set; `generations` shows the appended
+      rollback-marked generation as newest; `rollback` without `--confirm` refuses; daemon-down →
+      `REALIZER_UNAVAILABLE`


### PR DESCRIPTION
## Summary

Phase 3 of the unified cross-OS provisioning effort. Phase 1 (Nix realizer) and Phase 2 (engine-owned Provisioning Generation + `generations`) are on `main`; Phase 2 declared `provision.Rollbacker` but left it unimplemented.

This implements **native Unix rollback**: a top-level `rollback` command that reverts the installed package set to a prior Provisioning Generation, for backends that advertise `NativeRollback` (the Nix realizer today). Implements `provision.Rollbacker` on the Nix realizer via `nix profile rollback`. Hosts with no realizer (Windows/winget) **refuse cleanly** with `ROLLBACK_UNSUPPORTED` — best-effort winget rollback is Phase 4. **Zero Windows behavior regression.**

`rollback` (packages) stays distinct from `revert` (configs): it never touches `state/backups/` or the revert journal.

## Design (maintainer-approved)

- **Target identity = engine generation number.** `rollback --to <N>` maps engine generation `N` → its recorded `native` Nix version, then `nix profile rollback --to <native>`. Bare `rollback` = previous version. The user never references a Nix version (the moat).
- **`--confirm` required**; default refuses. **`--dry-run`** previews the resolved target without mutating or requiring `--confirm`.
- **Append-only history.** A successful rollback appends a new, rollback-marked Provisioning Generation snapshotting the now-active set (`native` = active version, `addedRefs: []`, `rollback: true`), so `generations` newest-first stays truthful (the engine has no HEAD pointer). Empirically, `nix profile rollback` repoints to an *existing* older version rather than minting a new one, so the appended record is engine-level.
- New error codes: `ROLLBACK_UNSUPPORTED`, `GENERATION_NOT_FOUND`, `ROLLBACK_FAILED`. Raw Nix text confined to `error.detail`.

## OpenSpec

New change `nix-native-rollback` (proposal/design/tasks + two deltas): the new `nix-native-rollback` capability, and an **ADDED** requirement to `separation-of-concerns` ("Rollback operates on packages only") — ADDED (distinct requirement), not a MODIFY of *Distinct Pipeline Stages*, so it composes with the not-yet-archived `provisioning-generation` change without an archive-order conflict.

## Protected edits (maintainer-approved)

- `cmd/endstate/main.go` — `rollback` dispatch + usage (additive).
- `docs/contracts/cli-json-contract.md` — `## Command: rollback` + 3 error codes + the optional `rollback` field note (additive).
- `docs/ai/AI_CONTRACT.md` — reword Non-Goal #4: a manual, opt-in `rollback` now exists; the no-*automatic*-rollback principle is preserved.

## Verification

- `cd go-engine && go test ./...` — green on Linux (24 pkgs).
- `GOOS=windows go build ./...` + `go vet ./...` — clean (Windows CI is the merge gate).
- `npm run openspec:validate` (strict) — 54/54.
- **Real-Nix smoke** (this WSL box, isolated profile): apply `jq`+`ripgrep` → gen 1 (native 1); apply +`hello` → gen 2 (native 2); `rollback --to 1` without `--confirm` → refused; `--dry-run` → preview, profile unchanged; `--to 1 --confirm` → profile reverts v2→v1 (holds jq+ripgrep, not hello), appends gen 3 (`native=1, rollback=true, addedRefs=[]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)