### PR TITLE
feat(engine): best-effort winget rollback (Phase 4)

### DIFF
--- a/docs/contracts/cli-json-contract.md
+++ b/docs/contracts/cli-json-contract.md
@@ -482,9 +482,12 @@ Lists recorded Provisioning Generations, newest first. Read-only. Additive in sc
 
 ## Command: `rollback`
 
-Reverts the installed package set to a prior Provisioning Generation. Available only on backends that advertise **native rollback** (the Nix realizer on Linux/macOS); other backends (winget on Windows) refuse with `ROLLBACK_UNSUPPORTED`. Additive in schema 1.x.
+Reverts the installed package set to a prior Provisioning Generation. Two strategies, both keyed off the recorded generations and identified by **engine generation number** (as listed by `generations`): callers never reference a backend-native version directly. Additive in schema 1.x.
 
-The target is identified by **engine generation number** (as listed by `generations`), which the engine maps to the backend-native anchor (`native`) recorded in that generation — callers never reference a backend-native version directly. Package-stage only: rollback never touches configuration restore, `state/backups/`, or the revert journal (that is `revert`'s concern).
+- **Native** (the Nix realizer on Linux/macOS): an atomic rollback to the backend-native anchor (`native`) recorded in the target generation.
+- **Best-effort** (the winget driver on Windows): there is no native rollback, so the engine uninstalls the union of `addedRefs` of every generation recorded *after* the target. Per-package and non-atomic — it tolerates per-package failure (reporting `partial`), treats an already-absent package as removed, and **does not track package-manager-pulled transitive dependencies/co-installs** (which may remain — surfaced as a `warning`).
+
+A backend that can neither roll back natively nor uninstall refuses with `ROLLBACK_UNSUPPORTED`. Package-stage only: rollback never touches configuration restore, `state/backups/`, or the revert journal (that is `revert`'s concern).
 
 ### Request
 
@@ -516,6 +519,31 @@ The target is identified by **engine generation number** (as listed by `generati
 ```
 
 `targetGeneration` is the engine generation resolved from `--to` (omitted/0 when rolling back to the previous version). `fromNative`/`toNative` are the backend-native versions before and after (on `--dry-run`, `toNative` is the resolved target, or `"previous"`). `newGeneration` is the number of the new rollback-marked Provisioning Generation appended on success (omitted on `--dry-run`). On failure, raw backend text appears only in `error.detail`.
+
+### Response (best-effort / winget)
+
+```json
+{
+  "schemaVersion": "1.0",
+  "cliVersion": "0.1.0",
+  "command": "rollback",
+  "runId": "20241220-143052",
+  "timestampUtc": "2024-12-20T14:30:52Z",
+  "success": true,
+  "data": {
+    "dryRun": false,
+    "backend": "winget",
+    "targetGeneration": 1,
+    "removedRefs": ["Some.AppC", "Some.AppD"],
+    "failedRefs": ["Some.AppB"],
+    "partial": true,
+    "newGeneration": 4,
+    "warning": "Package-manager-pulled transitive dependencies and co-installs are not tracked and may remain installed."
+  }
+}
+```
+
+For the best-effort path, `removedRefs` lists the refs uninstalled (on `--dry-run`, the refs that *would* be uninstalled — an already-absent package counts as removed). `failedRefs` lists refs whose uninstall failed (for example, another installed package still depends on one); `partial` is `true` when any failed. `newGeneration` is the appended rollback-marked generation (it records `removedRefs` and carries an empty `addedRefs`; omitted on `--dry-run` and when nothing was removed). `warning` is the untracked-dependency caveat. When **every** targeted uninstall fails the command returns `ROLLBACK_FAILED`; a missing winget binary returns `WINGET_NOT_AVAILABLE`; an unknown `--to` returns `GENERATION_NOT_FOUND`. No new error codes are introduced.
 
 ## Versioning Rules
 

--- a/go-engine/internal/commands/rollback.go
+++ b/go-engine/internal/commands/rollback.go
@@ -9,10 +9,16 @@ import (
 	"strings"
 	"time"
 
+	"github.com/Artexis10/endstate/go-engine/internal/driver"
 	"github.com/Artexis10/endstate/go-engine/internal/envelope"
 	"github.com/Artexis10/endstate/go-engine/internal/provision"
 	"github.com/Artexis10/endstate/go-engine/internal/realizer"
 )
+
+// untrackedDepsWarning is surfaced by the best-effort (winget) rollback path:
+// package-manager-pulled transitive dependencies and co-installs are not recorded
+// in a Provisioning Generation, so a best-effort rollback may leave them behind.
+const untrackedDepsWarning = "Package-manager-pulled transitive dependencies and co-installs are not tracked and may remain installed."
 
 // RollbackFlags holds the parsed CLI flags for the rollback command.
 type RollbackFlags struct {
@@ -30,31 +36,55 @@ type RollbackFlags struct {
 }
 
 // RollbackResult is the data payload for the rollback command JSON envelope.
+// The native (realizer) path populates FromNative/ToNative; the best-effort
+// (driver/winget) path populates RemovedRefs/FailedRefs/Partial/Warning.
 type RollbackResult struct {
 	DryRun           bool   `json:"dryRun"`
 	Backend          string `json:"backend"`
 	TargetGeneration int    `json:"targetGeneration,omitempty"` // engine generation resolved from --to; 0 = previous
-	FromNative       string `json:"fromNative,omitempty"`       // backend-native version before rollback
-	ToNative         string `json:"toNative,omitempty"`         // native version targeted (dry-run) or active after
-	NewGeneration    int    `json:"newGeneration,omitempty"`    // appended engine generation number (0 on dry-run)
+	// Native (realizer) rollback fields.
+	FromNative    string `json:"fromNative,omitempty"` // backend-native version before rollback
+	ToNative      string `json:"toNative,omitempty"`   // native version targeted (dry-run) or active after
+	NewGeneration int    `json:"newGeneration,omitempty"`
+	// Best-effort (driver/winget) rollback fields.
+	RemovedRefs []string `json:"removedRefs,omitempty"` // refs uninstalled (or, on --dry-run, that would be uninstalled)
+	FailedRefs  []string `json:"failedRefs,omitempty"`  // refs whose uninstall failed
+	Partial     bool     `json:"partial,omitempty"`     // true when any targeted uninstall failed
+	Warning     string   `json:"warning,omitempty"`     // best-effort caveat (untracked dependencies)
 }
 
 // RunRollback reverts the installed package set to a prior Provisioning
-// Generation, for backends that advertise native rollback (the Nix realizer
-// today). It is package-stage only: it never touches config restore,
-// state/backups/, or the revert journal. The target is identified by engine
-// generation number and mapped to the backend-native anchor (the user never
-// references a Nix version directly — the moat).
+// Generation. It is package-stage only: it never touches config restore,
+// state/backups/, or the revert journal.
+//
+// Two strategies, both keyed off the recorded Provisioning Generations:
+//   - Native (realizer, e.g. Nix): atomic `nix profile rollback` to the engine
+//     generation's recorded native anchor (the user never references a Nix
+//     version — the moat).
+//   - Best-effort (driver, e.g. winget): uninstall the union of addedRefs of the
+//     generations recorded after the target (non-atomic, failure-tolerant).
+//
+// Dispatch: a host with a realizer uses the native path exclusively; otherwise a
+// driver that implements driver.Uninstaller uses the best-effort path; otherwise
+// rollback is unsupported on this host.
 func RunRollback(flags RollbackFlags) (interface{}, *envelope.Error) {
-	// Acquire the host realizer. Hosts with no realizer (e.g. Windows, which uses
-	// the per-package winget driver) have no native rollback in this phase.
-	r, rerr := newRealizerFn()
-	if rerr != nil {
-		return nil, envelope.NewError(envelope.ErrRollbackUnsupported,
-			"This platform's package backend does not support rollback.").
-			WithRemediation("Native rollback is available on Linux/macOS via the Nix backend.")
+	if r, rerr := newRealizerFn(); rerr == nil {
+		return runRealizerRollback(flags, r)
 	}
+	if d, derr := newDriverFn(); derr == nil {
+		if un, ok := d.(driver.Uninstaller); ok {
+			return runDriverRollback(flags, d, un)
+		}
+	}
+	return nil, envelope.NewError(envelope.ErrRollbackUnsupported,
+		"This platform's package backend does not support rollback.").
+		WithRemediation("Native rollback needs a Nix backend (Linux/macOS); best-effort rollback needs an uninstall-capable driver (winget).")
+}
 
+// runRealizerRollback performs a native, atomic rollback via a realizer that
+// advertises native rollback (Nix). The target is identified by engine
+// generation number and mapped to the backend-native anchor.
+func runRealizerRollback(flags RollbackFlags, r realizer.Realizer) (interface{}, *envelope.Error) {
 	// Discover rollback eligibility by type-assertion + advertised capability,
 	// exactly like driver.BatchDetector / provision.CapabilityReporter.
 	rb, ok := r.(provision.Rollbacker)
@@ -186,6 +216,141 @@ func appendRollbackGeneration(runID, backend string, set realizer.Set) int {
 		AddedRefs: []string{},
 		Native:    strconv.Itoa(set.Generation),
 		Rollback:  true,
+	}
+	if err := provision.Write(g); err != nil {
+		return 0
+	}
+	return g.Number
+}
+
+// runDriverRollback performs a best-effort rollback on a driver that can
+// uninstall (winget). It reverts by uninstalling the union of the added
+// references of every Provisioning Generation recorded after the target. It is
+// non-atomic and failure-tolerant: per-package failures are reported and the run
+// is marked partial, never aborting mid-way. Package-stage only — it touches the
+// driver and internal/provision, never restore/backups/the revert journal.
+func runDriverRollback(flags RollbackFlags, d driver.Driver, un driver.Uninstaller) (interface{}, *envelope.Error) {
+	backend := d.Name()
+	gens, err := provision.List()
+	if err != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, err.Error())
+	}
+
+	maxNum := 0
+	for _, g := range gens {
+		if g.Number > maxNum {
+			maxNum = g.Number
+		}
+	}
+
+	// Resolve the target generation number.
+	targetGen := maxNum - 1 // bare rollback reverts the most recent generation
+	if to := strings.TrimSpace(flags.To); to != "" {
+		n, perr := strconv.Atoi(to)
+		if perr != nil || n <= 0 {
+			return nil, envelope.NewError(envelope.ErrGenerationNotFound,
+				fmt.Sprintf("Invalid generation number %q.", flags.To)).
+				WithRemediation("Run 'endstate generations' to list available generations.")
+		}
+		if _, gerr := findGeneration(n); gerr != nil {
+			return nil, gerr
+		}
+		targetGen = n
+	}
+
+	// removeRefs = union of addedRefs of every generation numbered > targetGen.
+	seen := map[string]bool{}
+	var removeRefs []string
+	for _, g := range gens {
+		if g.Number <= targetGen {
+			continue
+		}
+		for _, ref := range g.AddedRefs {
+			if ref != "" && !seen[ref] {
+				seen[ref] = true
+				removeRefs = append(removeRefs, ref)
+			}
+		}
+	}
+
+	// Nothing recorded after the target → already at/before it; a no-op success.
+	if len(removeRefs) == 0 {
+		return &RollbackResult{DryRun: flags.DryRun, Backend: backend, TargetGeneration: targetGen}, nil
+	}
+
+	if flags.DryRun {
+		return &RollbackResult{
+			DryRun:           true,
+			Backend:          backend,
+			TargetGeneration: targetGen,
+			RemovedRefs:      removeRefs, // would-remove preview
+			Warning:          untrackedDepsWarning,
+		}, nil
+	}
+
+	if !flags.Confirm {
+		return nil, envelope.NewError(envelope.ErrInternalError,
+			"rollback requires --confirm to acknowledge that it uninstalls packages").
+			WithRemediation("Re-run with --confirm, or use --dry-run to preview what would be removed.")
+	}
+
+	// Uninstall each ref independently; never abort on the first failure.
+	var removed, failed []string
+	for _, ref := range removeRefs {
+		res, uerr := un.Uninstall(ref)
+		if uerr != nil {
+			// Infrastructure failure (e.g. the winget binary is missing) — whole-run.
+			return nil, envelope.NewError(envelope.ErrWingetNotAvailable,
+				"The package backend is unavailable.").
+				WithDetail(map[string]string{"raw": uerr.Error()}).
+				WithRemediation("Ensure winget is installed and on PATH.")
+		}
+		switch res.Status {
+		case driver.StatusUninstalled, driver.StatusAbsent:
+			removed = append(removed, ref)
+		default:
+			failed = append(failed, ref)
+		}
+	}
+
+	// Every targeted uninstall failed → a top-level failure.
+	if len(removed) == 0 {
+		return nil, envelope.NewError(envelope.ErrRollbackFailed,
+			"Rollback failed: no packages could be uninstalled.").
+			WithDetail(map[string]string{"failed": strings.Join(failed, ", ")}).
+			WithRemediation("Another installed package may depend on them; inspect the failed packages.")
+	}
+
+	// Append a rollback-marked generation recording what was removed.
+	newGen := appendRollbackGenerationRemoved(buildRunID("rollback"), backend, removed, len(failed) > 0)
+
+	return &RollbackResult{
+		DryRun:           false,
+		Backend:          backend,
+		TargetGeneration: targetGen,
+		RemovedRefs:      removed,
+		FailedRefs:       failed,
+		Partial:          len(failed) > 0,
+		NewGeneration:    newGen,
+		Warning:          untrackedDepsWarning,
+	}, nil
+}
+
+// appendRollbackGenerationRemoved writes a rollback-marked Provisioning
+// Generation recording the refs a best-effort rollback uninstalled. AddedRefs is
+// empty; RemovedRefs carries what was removed; Partial is set when any targeted
+// uninstall failed. Best-effort: a write error never fails the rollback. Returns
+// the assigned generation number, or 0 on write failure.
+func appendRollbackGenerationRemoved(runID, backend string, removed []string, partial bool) int {
+	g := &provision.Generation{
+		RunID:       runID,
+		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+		Backend:     backend,
+		Items:       []provision.ProvItem{},
+		AddedRefs:   []string{},
+		RemovedRefs: removed,
+		Rollback:    true,
+		Partial:     partial,
 	}
 	if err := provision.Write(g); err != nil {
 		return 0

--- a/go-engine/internal/commands/rollback_test.go
+++ b/go-engine/internal/commands/rollback_test.go
@@ -4,15 +4,89 @@
 package commands
 
 import (
+	"errors"
 	"go/parser"
 	"go/token"
 	"strings"
 	"testing"
 
+	"github.com/Artexis10/endstate/go-engine/internal/driver"
 	"github.com/Artexis10/endstate/go-engine/internal/envelope"
 	"github.com/Artexis10/endstate/go-engine/internal/provision"
 	"github.com/Artexis10/endstate/go-engine/internal/realizer"
 )
+
+// ---------------------------------------------------------------------------
+// Driver (best-effort / winget) rollback test doubles
+// ---------------------------------------------------------------------------
+
+// plainDriver implements driver.Driver but NOT driver.Uninstaller — used to test
+// the unsupported path on a host whose driver cannot uninstall.
+type plainDriver struct{}
+
+func (plainDriver) Name() string                                  { return "winget" }
+func (plainDriver) Detect(string) (bool, string, error)           { return false, "", nil }
+func (plainDriver) Install(string) (*driver.InstallResult, error) { return &driver.InstallResult{}, nil }
+
+// fakeUninstaller implements driver.Driver + driver.Uninstaller with scriptable
+// per-ref outcomes and call capture.
+type fakeUninstaller struct {
+	results map[string]*driver.UninstallResult // ref -> outcome (default: uninstalled)
+	uerr    error                              // infrastructure error (e.g. winget missing)
+	calls   []string                           // refs passed to Uninstall, in order
+}
+
+func (f *fakeUninstaller) Name() string                                  { return "winget" }
+func (f *fakeUninstaller) Detect(string) (bool, string, error)           { return false, "", nil }
+func (f *fakeUninstaller) Install(string) (*driver.InstallResult, error) { return &driver.InstallResult{}, nil }
+func (f *fakeUninstaller) Uninstall(ref string) (*driver.UninstallResult, error) {
+	f.calls = append(f.calls, ref)
+	if f.uerr != nil {
+		return nil, f.uerr
+	}
+	if r, ok := f.results[ref]; ok {
+		return r, nil
+	}
+	return &driver.UninstallResult{Status: driver.StatusUninstalled}, nil
+}
+
+// withDriverOnly forces the no-realizer (driver) dispatch path: newRealizerFn
+// returns ErrNoRealizer and newDriverFn returns d.
+func withDriverOnly(d driver.Driver, fn func()) {
+	origR, origD := newRealizerFn, newDriverFn
+	newRealizerFn = func() (realizer.Realizer, error) { return nil, ErrNoRealizer }
+	newDriverFn = func() (driver.Driver, error) { return d, nil }
+	defer func() { newRealizerFn, newDriverFn = origR, origD }()
+	fn()
+}
+
+// seedWingetGen writes a winget Provisioning Generation with the given addedRefs.
+func seedWingetGen(t *testing.T, added ...string) {
+	t.Helper()
+	if err := provision.Write(&provision.Generation{Backend: "winget", AddedRefs: added}); err != nil {
+		t.Fatalf("seed generation: %v", err)
+	}
+}
+
+// sameSet reports whether got and want contain the same elements, ignoring order.
+func sameSet(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	m := map[string]int{}
+	for _, g := range got {
+		m[g]++
+	}
+	for _, w := range want {
+		m[w]--
+	}
+	for _, v := range m {
+		if v != 0 {
+			return false
+		}
+	}
+	return true
+}
 
 // capableRealizer returns a fakeRealizer that advertises native rollback, with
 // the given current set.
@@ -294,4 +368,252 @@ func TestRollbackStaysPackageOnly(t *testing.T) {
 			t.Fatalf("rollback.go imports %s; rollback must stay package-stage only", imp.Path.Value)
 		}
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Best-effort (driver / winget) rollback tests
+// ---------------------------------------------------------------------------
+
+// TestRollback_Driver_ToGeneration_UninstallsLaterAdditions: --to N uninstalls
+// the union of addedRefs of every generation after N, and appends a
+// rollback-marked generation recording what was removed.
+func TestRollback_Driver_ToGeneration_UninstallsLaterAdditions(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedWingetGen(t, "A")      // gen 1
+	seedWingetGen(t, "B")      // gen 2
+	seedWingetGen(t, "C", "D") // gen 3
+
+	fr := &fakeUninstaller{}
+	var result *RollbackResult
+	withDriverOnly(fr, func() {
+		raw, env := RunRollback(RollbackFlags{To: "1", Confirm: true})
+		if env != nil {
+			t.Fatalf("unexpected envelope error: %+v", env)
+		}
+		result = raw.(*RollbackResult)
+	})
+
+	// gens > 1 = gen2[B] ∪ gen3[C,D] = {B, C, D} (order is newest-gen-first, i.e.
+	// reverse-install order — assert as a set, not a sequence).
+	if !sameSet(fr.calls, []string{"B", "C", "D"}) {
+		t.Errorf("uninstall calls = %v, want the set {B,C,D}", fr.calls)
+	}
+	if len(result.RemovedRefs) != 3 || result.Partial {
+		t.Errorf("RemovedRefs=%v partial=%v, want 3 removed, not partial", result.RemovedRefs, result.Partial)
+	}
+	if result.NewGeneration != 4 {
+		t.Errorf("NewGeneration = %d, want 4", result.NewGeneration)
+	}
+	gens, _ := provision.List()
+	newest := gens[0]
+	if newest.Number != 4 || !newest.Rollback || len(newest.AddedRefs) != 0 || len(newest.RemovedRefs) != 3 {
+		t.Errorf("appended gen wrong: #%d rollback=%v added=%v removed=%v", newest.Number, newest.Rollback, newest.AddedRefs, newest.RemovedRefs)
+	}
+}
+
+// TestRollback_Driver_Bare_RevertsMostRecent: bare rollback removes the most
+// recent generation's additions.
+func TestRollback_Driver_Bare_RevertsMostRecent(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedWingetGen(t, "A") // gen 1
+	seedWingetGen(t, "B") // gen 2
+
+	fr := &fakeUninstaller{}
+	withDriverOnly(fr, func() {
+		_, env := RunRollback(RollbackFlags{Confirm: true})
+		if env != nil {
+			t.Fatalf("unexpected envelope error: %+v", env)
+		}
+	})
+	if got := strings.Join(fr.calls, ","); got != "B" {
+		t.Errorf("bare rollback uninstall calls = %q, want B (most recent gen)", got)
+	}
+}
+
+// TestRollback_Driver_NotUninstaller_Unsupported: a driver that cannot uninstall
+// (and no realizer) → ROLLBACK_UNSUPPORTED.
+func TestRollback_Driver_NotUninstaller_Unsupported(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	withDriverOnly(plainDriver{}, func() {
+		_, env := RunRollback(RollbackFlags{To: "1", Confirm: true})
+		if env == nil || env.Code != envelope.ErrRollbackUnsupported {
+			t.Fatalf("want ROLLBACK_UNSUPPORTED, got %+v", env)
+		}
+	})
+}
+
+// TestRollback_Driver_UnknownGeneration_NotFound: --to N with no such generation.
+func TestRollback_Driver_UnknownGeneration_NotFound(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedWingetGen(t, "A") // gen 1
+	fr := &fakeUninstaller{}
+	withDriverOnly(fr, func() {
+		_, env := RunRollback(RollbackFlags{To: "99", Confirm: true})
+		if env == nil || env.Code != envelope.ErrGenerationNotFound {
+			t.Fatalf("want GENERATION_NOT_FOUND, got %+v", env)
+		}
+	})
+	if len(fr.calls) != 0 {
+		t.Errorf("Uninstall called %v, want none", fr.calls)
+	}
+}
+
+// TestRollback_Driver_PartialFailure: a per-ref failure does not abort; the run
+// is marked partial and the failed ref is reported.
+func TestRollback_Driver_PartialFailure(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedWingetGen(t, "A")      // gen 1
+	seedWingetGen(t, "B", "C") // gen 2
+
+	fr := &fakeUninstaller{results: map[string]*driver.UninstallResult{
+		"B": {Status: driver.StatusFailed, Message: "in use by another package"},
+		"C": {Status: driver.StatusUninstalled},
+	}}
+	var result *RollbackResult
+	withDriverOnly(fr, func() {
+		raw, env := RunRollback(RollbackFlags{To: "1", Confirm: true})
+		if env != nil {
+			t.Fatalf("unexpected envelope error: %+v", env)
+		}
+		result = raw.(*RollbackResult)
+	})
+	if !result.Partial || len(result.FailedRefs) != 1 || result.FailedRefs[0] != "B" {
+		t.Errorf("want partial with FailedRefs=[B], got partial=%v failed=%v", result.Partial, result.FailedRefs)
+	}
+	if len(result.RemovedRefs) != 1 || result.RemovedRefs[0] != "C" {
+		t.Errorf("want RemovedRefs=[C], got %v", result.RemovedRefs)
+	}
+	gens, _ := provision.List()
+	if !gens[0].Partial {
+		t.Errorf("appended generation should be marked partial")
+	}
+}
+
+// TestRollback_Driver_AlreadyAbsent_CountsRemoved: an already-absent package is a
+// successful no-op (counted as removed, not failed).
+func TestRollback_Driver_AlreadyAbsent_CountsRemoved(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedWingetGen(t, "A") // gen 1
+	seedWingetGen(t, "B") // gen 2
+
+	fr := &fakeUninstaller{results: map[string]*driver.UninstallResult{
+		"B": {Status: driver.StatusAbsent},
+	}}
+	var result *RollbackResult
+	withDriverOnly(fr, func() {
+		raw, env := RunRollback(RollbackFlags{To: "1", Confirm: true})
+		if env != nil {
+			t.Fatalf("unexpected envelope error: %+v", env)
+		}
+		result = raw.(*RollbackResult)
+	})
+	if result.Partial || len(result.FailedRefs) != 0 || len(result.RemovedRefs) != 1 {
+		t.Errorf("absent should count as removed: partial=%v failed=%v removed=%v", result.Partial, result.FailedRefs, result.RemovedRefs)
+	}
+}
+
+// TestRollback_Driver_AllFailed_RollbackFailed: when every targeted uninstall
+// fails, the command returns ROLLBACK_FAILED and writes no generation.
+func TestRollback_Driver_AllFailed_RollbackFailed(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedWingetGen(t, "A") // gen 1
+	seedWingetGen(t, "B") // gen 2
+
+	fr := &fakeUninstaller{results: map[string]*driver.UninstallResult{
+		"B": {Status: driver.StatusFailed},
+	}}
+	withDriverOnly(fr, func() {
+		_, env := RunRollback(RollbackFlags{To: "1", Confirm: true})
+		if env == nil || env.Code != envelope.ErrRollbackFailed {
+			t.Fatalf("want ROLLBACK_FAILED, got %+v", env)
+		}
+	})
+	if gens, _ := provision.List(); len(gens) != 2 {
+		t.Errorf("no generation should be appended on total failure; want 2, got %d", len(gens))
+	}
+}
+
+// TestRollback_Driver_RequiresConfirm: without --confirm the command refuses,
+// uninstalls nothing, and writes no generation.
+func TestRollback_Driver_RequiresConfirm(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedWingetGen(t, "A") // gen 1
+	seedWingetGen(t, "B") // gen 2
+
+	fr := &fakeUninstaller{}
+	withDriverOnly(fr, func() {
+		_, env := RunRollback(RollbackFlags{To: "1"})
+		if env == nil || !strings.Contains(env.Message, "--confirm") {
+			t.Fatalf("want refusal mentioning --confirm, got %+v", env)
+		}
+	})
+	if len(fr.calls) != 0 {
+		t.Errorf("Uninstall called %v, want none", fr.calls)
+	}
+	if gens, _ := provision.List(); len(gens) != 2 {
+		t.Errorf("no generation should be appended on refusal; want 2, got %d", len(gens))
+	}
+}
+
+// TestRollback_Driver_DryRun_PreviewsNoMutation: --dry-run lists what would be
+// removed without uninstalling or appending a generation.
+func TestRollback_Driver_DryRun_PreviewsNoMutation(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedWingetGen(t, "A") // gen 1
+	seedWingetGen(t, "B") // gen 2
+
+	fr := &fakeUninstaller{}
+	var result *RollbackResult
+	withDriverOnly(fr, func() {
+		raw, env := RunRollback(RollbackFlags{To: "1", DryRun: true})
+		if env != nil {
+			t.Fatalf("unexpected envelope error: %+v", env)
+		}
+		result = raw.(*RollbackResult)
+	})
+	if !result.DryRun || len(result.RemovedRefs) != 1 || result.RemovedRefs[0] != "B" {
+		t.Errorf("dry-run preview wrong: dryRun=%v removed=%v", result.DryRun, result.RemovedRefs)
+	}
+	if len(fr.calls) != 0 {
+		t.Errorf("dry-run must not uninstall; calls=%v", fr.calls)
+	}
+	if gens, _ := provision.List(); len(gens) != 2 {
+		t.Errorf("dry-run must not append a generation; want 2, got %d", len(gens))
+	}
+}
+
+// TestRollback_Driver_NothingToRollback: target is already the most recent → a
+// no-op success with nothing removed.
+func TestRollback_Driver_NothingToRollback(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedWingetGen(t, "A") // gen 1 (the only/most-recent generation)
+
+	fr := &fakeUninstaller{}
+	var result *RollbackResult
+	withDriverOnly(fr, func() {
+		raw, env := RunRollback(RollbackFlags{To: "1", Confirm: true})
+		if env != nil {
+			t.Fatalf("unexpected envelope error: %+v", env)
+		}
+		result = raw.(*RollbackResult)
+	})
+	if len(fr.calls) != 0 || len(result.RemovedRefs) != 0 {
+		t.Errorf("nothing-to-roll-back should be a no-op: calls=%v removed=%v", fr.calls, result.RemovedRefs)
+	}
+}
+
+// TestRollback_Driver_MissingBinary_WingetUnavailable: an infrastructure error
+// from Uninstall surfaces WINGET_NOT_AVAILABLE.
+func TestRollback_Driver_MissingBinary_WingetUnavailable(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedWingetGen(t, "A") // gen 1
+	seedWingetGen(t, "B") // gen 2
+
+	fr := &fakeUninstaller{uerr: errors.New("winget: executable file not found")}
+	withDriverOnly(fr, func() {
+		_, env := RunRollback(RollbackFlags{To: "1", Confirm: true})
+		if env == nil || env.Code != envelope.ErrWingetNotAvailable {
+			t.Fatalf("want WINGET_NOT_AVAILABLE, got %+v", env)
+		}
+	})
 }

--- a/go-engine/internal/commands/rollback_test.go
+++ b/go-engine/internal/commands/rollback_test.go
@@ -107,12 +107,16 @@ func setOf(gen int, names ...string) realizer.Set {
 
 // --- ROLLBACK_UNSUPPORTED ----------------------------------------------------
 
-// TestRollback_NoRealizer_Unsupported: a host with no realizer (e.g. Windows)
-// refuses with ROLLBACK_UNSUPPORTED and changes nothing.
-func TestRollback_NoRealizer_Unsupported(t *testing.T) {
-	orig := newRealizerFn
+// TestRollback_NoBackend_Unsupported: a host with neither a realizer nor an
+// uninstall-capable driver refuses with ROLLBACK_UNSUPPORTED and changes
+// nothing. Both seams are overridden so the test is host-independent — on
+// Windows the real winget driver now implements driver.Uninstaller, so leaving
+// newDriverFn at its default would take the best-effort path instead.
+func TestRollback_NoBackend_Unsupported(t *testing.T) {
+	origR, origD := newRealizerFn, newDriverFn
 	newRealizerFn = func() (realizer.Realizer, error) { return nil, ErrNoRealizer }
-	defer func() { newRealizerFn = orig }()
+	newDriverFn = func() (driver.Driver, error) { return nil, ErrNoBackend }
+	defer func() { newRealizerFn, newDriverFn = origR, origD }()
 
 	_, env := RunRollback(RollbackFlags{Confirm: true})
 	if env == nil || env.Code != envelope.ErrRollbackUnsupported {

--- a/go-engine/internal/driver/driver.go
+++ b/go-engine/internal/driver/driver.go
@@ -66,6 +66,38 @@ type Driver interface {
 	Install(ref string) (*InstallResult, error)
 }
 
+// Status values for UninstallResult.
+const (
+	// StatusUninstalled means the package was uninstalled this call.
+	StatusUninstalled = "uninstalled"
+	// StatusAbsent means the package was already not installed (a successful
+	// no-op for rollback idempotency).
+	StatusAbsent = "absent"
+	// StatusFailed (defined above) is reused for an uninstall that failed.
+)
+
+// UninstallResult is returned by Uninstaller.Uninstall and carries the outcome
+// of a single package uninstall attempt.
+type UninstallResult struct {
+	// Status is one of StatusUninstalled, StatusAbsent, or StatusFailed.
+	Status string
+	// Message is a human-readable description of what happened.
+	Message string
+}
+
+// Uninstaller is an optional interface that drivers can implement to remove a
+// package. Callers type-assert their Driver to Uninstaller, exactly like
+// BatchDetector; a driver that does not implement it has no uninstall path (and
+// therefore no best-effort rollback). It is deliberately kept off the core
+// Driver interface so install and uninstall stay distinct capabilities.
+type Uninstaller interface {
+	// Uninstall removes the package identified by ref. It returns a non-nil
+	// error only for an infrastructure failure (e.g. the tool binary is
+	// missing); an already-absent package is reported as StatusAbsent, not an
+	// error, and a refused/failed uninstall is reported as StatusFailed.
+	Uninstall(ref string) (*UninstallResult, error)
+}
+
 // DetectResult holds the outcome of a batch detection check for a single ref.
 type DetectResult struct {
 	// Installed is true if the package is currently installed.

--- a/go-engine/internal/driver/winget/uninstall.go
+++ b/go-engine/internal/driver/winget/uninstall.go
@@ -1,0 +1,111 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package winget
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+
+	"github.com/Artexis10/endstate/go-engine/internal/driver"
+)
+
+// compile-time assertion: the winget driver implements driver.Uninstaller, so
+// the rollback command can discover best-effort rollback by type-assertion.
+var _ driver.Uninstaller = (*WingetDriver)(nil)
+
+// noPackageFoundExitCode is winget's APPINSTALLER_CLI_ERROR_NO_APPLICATIONS_FOUND
+// (HRESULT 0x8A15002B), returned by `winget uninstall` when no installed package
+// matches. As with the install codes, Windows may surface the signed or unsigned
+// 32-bit interpretation, and (also like the install codes) an HRESULT cannot
+// survive POSIX 8-bit exit-code truncation — so on non-Windows this path is
+// untested and the output-substring check below is the primary "absent" signal.
+// NOTE: confirm the exact value against a real winget on Windows.
+const noPackageFoundExitCodeSigned = -1978335211
+const noPackageFoundExitCodeUnsigned = 2316632085
+
+// noPackageFoundPattern matches winget output indicating nothing matched the
+// uninstall request. This is the cross-platform-reliable "absent" signal (the
+// exit code cannot survive POSIX truncation, so hermetic tests drive this).
+var noPackageFoundPattern = regexp.MustCompile(`(?i)(no installed package found|no applicable (package|upgrade|installer)|not installed|no package(s)? found)`)
+
+// Uninstall removes the package identified by ref via winget, satisfying
+// driver.Uninstaller. It is the engine's only uninstall path and is used by the
+// best-effort rollback (Phase 4).
+//
+// The command spawned is:
+//
+//	winget uninstall --id <ref> -e --silent --accept-source-agreements
+//
+// Exit/output semantics:
+//   - 0                                  → StatusUninstalled
+//   - "no installed package found" (output) or the not-found HRESULT → StatusAbsent (no-op)
+//   - other non-zero                     → StatusFailed
+//
+// If the winget binary is not found, Uninstall returns (nil, ErrWingetNotAvailable).
+func (w *WingetDriver) Uninstall(ref string) (*driver.UninstallResult, error) {
+	cmd := w.ExecCommand(
+		"winget",
+		"uninstall",
+		"--id", ref,
+		"-e",
+		"--silent",
+		"--accept-source-agreements",
+	)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+
+	// Detect missing binary before inspecting exit code.
+	if runErr != nil {
+		var execErr *exec.Error
+		if errors.As(runErr, &execErr) && execErr.Err == exec.ErrNotFound {
+			return nil, ErrWingetNotAvailable
+		}
+	}
+
+	combined := stdout.String() + stderr.String()
+
+	exitCode := 0
+	if runErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			// Process did not exit normally (e.g. killed); treat as failure.
+			return &driver.UninstallResult{
+				Status:  driver.StatusFailed,
+				Message: fmt.Sprintf("winget did not exit normally: %v", runErr),
+			}, nil
+		}
+	}
+
+	switch {
+	case exitCode == 0:
+		return &driver.UninstallResult{
+			Status:  driver.StatusUninstalled,
+			Message: "Uninstalled successfully",
+		}, nil
+
+	case noPackageFoundPattern.MatchString(combined),
+		exitCode == noPackageFoundExitCodeSigned,
+		exitCode == noPackageFoundExitCodeUnsigned:
+		// Already not installed — a successful no-op for rollback idempotency.
+		return &driver.UninstallResult{
+			Status:  driver.StatusAbsent,
+			Message: "Package was not installed",
+		}, nil
+
+	default:
+		return &driver.UninstallResult{
+			Status:  driver.StatusFailed,
+			Message: fmt.Sprintf("winget exited with code %d", exitCode),
+		}, nil
+	}
+}

--- a/go-engine/internal/driver/winget/uninstall_test.go
+++ b/go-engine/internal/driver/winget/uninstall_test.go
@@ -1,0 +1,85 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package winget
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/driver"
+)
+
+// fakeUninstallCmd is fakeCommand plus argv capture, so tests can assert the
+// spawned winget command line. It re-uses TestHelperProcess (winget_test.go).
+func fakeUninstallCmd(exitCode int, stdout, stderr string, gotArgs *[]string) func(string, ...string) *exec.Cmd {
+	return func(name string, args ...string) *exec.Cmd {
+		if gotArgs != nil {
+			*gotArgs = append([]string(nil), args...)
+		}
+		cs := append([]string{"-test.run=TestHelperProcess", "--"}, args...)
+		cmd := exec.Command(os.Args[0], cs...)
+		cmd.Env = append(os.Environ(),
+			"GO_WANT_HELPER_PROCESS=1",
+			fmt.Sprintf("FAKE_EXIT_CODE=%d", exitCode),
+			fmt.Sprintf("FAKE_STDOUT=%s", stdout),
+			fmt.Sprintf("FAKE_STDERR=%s", stderr),
+		)
+		return cmd
+	}
+}
+
+func TestUninstall_Success(t *testing.T) {
+	var args []string
+	d := &WingetDriver{ExecCommand: fakeUninstallCmd(0, "Successfully uninstalled", "", &args)}
+	res, err := d.Uninstall("Git.Git")
+	if err != nil {
+		t.Fatalf("Uninstall returned unexpected error: %v", err)
+	}
+	if res.Status != driver.StatusUninstalled {
+		t.Errorf("Status = %q, want %q", res.Status, driver.StatusUninstalled)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, "uninstall --id Git.Git -e --silent --accept-source-agreements") {
+		t.Errorf("unexpected winget argv: %q", joined)
+	}
+}
+
+func TestUninstall_AbsentViaOutput(t *testing.T) {
+	// winget prints this when nothing matches; the exit code is an HRESULT that
+	// cannot survive POSIX truncation, so the output substring is the signal.
+	d := &WingetDriver{ExecCommand: fakeUninstallCmd(1, "", "No installed package found matching input criteria.", nil)}
+	res, err := d.Uninstall("Some.Removed.App")
+	if err != nil {
+		t.Fatalf("Uninstall returned unexpected error: %v", err)
+	}
+	if res.Status != driver.StatusAbsent {
+		t.Errorf("Status = %q, want %q (already-absent is a no-op)", res.Status, driver.StatusAbsent)
+	}
+}
+
+func TestUninstall_Failed(t *testing.T) {
+	d := &WingetDriver{ExecCommand: fakeUninstallCmd(1, "", "0x80070005 : Access is denied; package is in use", nil)}
+	res, err := d.Uninstall("In.Use.App")
+	if err != nil {
+		t.Fatalf("Uninstall returned unexpected error: %v", err)
+	}
+	if res.Status != driver.StatusFailed {
+		t.Errorf("Status = %q, want %q", res.Status, driver.StatusFailed)
+	}
+}
+
+func TestUninstall_MissingBinary(t *testing.T) {
+	// ExecCommand returns a command for a binary that does not exist → Run yields
+	// exec.ErrNotFound → Uninstall surfaces ErrWingetNotAvailable.
+	d := &WingetDriver{ExecCommand: func(name string, args ...string) *exec.Cmd {
+		return exec.Command("endstate-no-such-winget-binary-xyz")
+	}}
+	_, err := d.Uninstall("Any.App")
+	if err != ErrWingetNotAvailable {
+		t.Fatalf("expected ErrWingetNotAvailable, got %v", err)
+	}
+}

--- a/go-engine/internal/provision/provision.go
+++ b/go-engine/internal/provision/provision.go
@@ -40,7 +40,8 @@ type Generation struct {
 	AddedRefs     []string   `json:"addedRefs"`
 	Native        string     `json:"native,omitempty"` // backend-native anchor (nix generation number); "" if none
 	Partial       bool       `json:"partial"`          // true when a non-atomic backend committed a partial set
-	Rollback      bool       `json:"rollback,omitempty"` // true when this generation was produced by a rollback (AddedRefs is empty)
+	Rollback      bool       `json:"rollback,omitempty"`    // true when this generation was produced by a rollback (AddedRefs is empty)
+	RemovedRefs   []string   `json:"removedRefs,omitempty"` // refs uninstalled by a best-effort (winget) rollback; empty for native/apply generations
 }
 
 // Capabilities describes what a package backend can do. It is discovered at

--- a/openspec/changes/winget-best-effort-rollback/design.md
+++ b/openspec/changes/winget-best-effort-rollback/design.md
@@ -1,0 +1,112 @@
+## Context
+
+Phase 3 (`nix-native-rollback`) added `rollback` for **native-rollback** backends (Nix). The
+command acquires a realizer via `newRealizerFn()`, gates on
+`Rollbacker` + `CapabilityReporter.NativeRollback`, maps an engine generation number → the
+backend-native anchor, and on success appends a rollback-marked Provisioning Generation. Hosts
+with no realizer (Windows) refuse with `ROLLBACK_UNSUPPORTED`.
+
+The winget driver (`driver.Driver`) exposes only `Detect` + `Install` — **no uninstall** — and
+reports `Capabilities{}` all-false. Winget cannot atomically switch generations, so it has no
+native rollback. But the engine already records, per `apply`, a Provisioning Generation with
+`AddedRefs` = the refs installed that run. That recorded history is enough to reconstruct a
+best-effort reversal.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `rollback` on winget = uninstall the union of `addedRefs` of all generations after the target.
+- First uninstall path in the engine (`driver.Uninstaller`), discovered by type-assertion.
+- Per-package, non-atomic, failure-tolerant; `--confirm`-gated; `--dry-run` preview.
+- Append a rollback-marked generation recording `removedRefs`.
+- Zero Windows regression (provable by hermetic tests + `GOOS=windows` build/vet).
+
+**Non-Goals:**
+- **No dependency-graph tracking / orphan prevention.** Best-effort with a warning (maintainer
+  decision: architecture-plan open decision #3). winget-pulled transitive deps/co-installs are
+  not recorded and may remain.
+- **No convergence-to-exact-set** (uninstall packages never recorded as added) — that is Phase 5.
+- **No config involvement** — package-stage only (already asserted by the
+  `separation-of-concerns` "Rollback operates on packages only" requirement from Phase 3).
+
+## Decisions
+
+### Target = engine generation number; removeRefs = union of addedRefs after target
+
+`rollback --to <N>` resolves `removeRefs` = ∪ `addedRefs` of every generation with `Number > N`.
+Bare `rollback` targets the most recent generation (`N` = highest number − 1). This reverses the
+recorded install transaction. The "union of addedRefs after N" math is robust to interspersed
+rollback generations (they carry empty `addedRefs`, contributing nothing). If `removeRefs` is
+empty, the rollback is a successful no-op ("nothing to roll back").
+
+### `driver.Uninstaller` optional interface
+
+```go
+type UninstallResult struct { Status, Message string } // Status: uninstalled | absent | failed
+type Uninstaller interface { Uninstall(ref string) (*UninstallResult, error) }
+```
+Discovered by type-assertion (like `driver.BatchDetector`). winget implements it via
+`winget uninstall --id <ref> -e --silent --accept-source-agreements`:
+- exit 0 → `uninstalled`
+- "no installed package found" code/output → `absent` (successful no-op, for idempotency)
+- other non-zero → `failed`
+- binary missing → `(nil, ErrWingetNotAvailable)`
+
+**Caveat:** the exact "no installed package found" winget exit code must be confirmed against a
+real winget (this dev box is Linux/Nix, no winget) — mirrors how the install already-installed
+code was locked. Hermetic tests use the existing `WingetDriver.ExecCommand` injection seam;
+a best-effort output-substring fallback complements the exit-code check.
+
+### Command flow (`runDriverRollback`, dispatched from `RunRollback`)
+
+`RunRollback` dispatches: realizer present → Phase 3 native path; else driver present and is an
+`Uninstaller` → this path; else `ROLLBACK_UNSUPPORTED`.
+
+1. Resolve target N (`--to`, validated against `provision.List()`; missing → `GENERATION_NOT_FOUND`).
+   Bare = most recent generation.
+2. Compute `removeRefs`. Empty → success no-op.
+3. `--dry-run` → report `removeRefs` as the preview, no uninstall. No `--confirm` (and not
+   dry-run) → refuse (message names `--confirm`), no mutation.
+4. For each ref: `Uninstall(ref)`; collect `{removed, absent, failed}`. Never abort early.
+5. Emit the untracked-dependency warning.
+6. If ≥1 ref removed: append a rollback-marked generation (`Backend="winget"`, `Rollback=true`,
+   `AddedRefs=[]`, `RemovedRefs=<removed>`, `Partial`=any failure, `RunID="rollback-<ts>"`).
+7. Result envelope: `success=true` with summary {removed, absent, failed, partial}; raw winget
+   messages in per-ref entries. **Top-level error only** for: no uninstall-capable backend
+   (`ROLLBACK_UNSUPPORTED`), bad target (`GENERATION_NOT_FOUND`), winget binary missing
+   (`WINGET_NOT_AVAILABLE`), or **every** targeted uninstall failed (`ROLLBACK_FAILED`).
+   (Mirrors `apply`, which returns a success envelope with a non-zero `failed` count.)
+
+### Error codes — reuse, no new codes
+
+`ROLLBACK_UNSUPPORTED` / `GENERATION_NOT_FOUND` / `ROLLBACK_FAILED` (from Phase 3) +
+`WINGET_NOT_AVAILABLE` (existing). No `UNINSTALL_FAILED`: per-ref failures live in the result
+data, not as an envelope code.
+
+### Generation record change
+
+Add optional `RemovedRefs []string \`json:"removedRefs,omitempty"\`` to `provision.Generation`
+(additive; `SchemaVersion` stays `"1.0"`). A rollback generation has empty `AddedRefs` and
+populated `RemovedRefs`.
+
+## Separation of concerns
+
+Already covered: the `separation-of-concerns` "Rollback operates on packages only" requirement
+(added in `nix-native-rollback`) applies to the whole `rollback` command, including this path.
+`runDriverRollback` touches only the package driver + `internal/provision`; it never imports
+`internal/restore` or touches `state/backups/` (extend the existing rollback import-guard test).
+
+## Risks / limitations (documented, not blockers)
+
+- **Orphans:** winget-pulled transitive deps/co-installs are untracked → may remain after
+  rollback. Surfaced as a warning; not prevented (accepted best-effort).
+- **Dependency-protected uninstall:** winget may refuse to remove a package another package
+  depends on → reported as a per-ref `failed`, run marked partial.
+- **No real-winget CI here:** uninstall exit-code anchors verified hermetically + on the
+  maintainer's Windows; `GOOS=windows` build/vet is the cross-compile gate.
+
+## Migration
+
+Purely additive. No manifest/envelope schema bump. No `cmd/endstate/main.go` change (the
+`rollback` dispatch is already generic). Existing state, generations, and non-Windows behavior
+unchanged.

--- a/openspec/changes/winget-best-effort-rollback/proposal.md
+++ b/openspec/changes/winget-best-effort-rollback/proposal.md
@@ -1,0 +1,89 @@
+## Why
+
+Phase 3 (`nix-native-rollback`, PR #60, merged) added the top-level `rollback` command for
+backends that advertise **native** rollback — the Nix realizer, via `nix profile rollback`.
+Hosts whose backend is the winget driver (Windows) currently refuse with
+`ROLLBACK_UNSUPPORTED`, because winget has no native rollback and the engine had no uninstall
+path at all.
+
+This change is **Phase 4 — Windows migrates in**: a **best-effort** winget rollback. Since
+winget cannot atomically switch generations, the engine reverts by **reconstructing the
+package delta from the recorded Provisioning Generations** and uninstalling what was added
+after the target — the union of the `addedRefs` of every generation numbered greater than the
+target. This is the first uninstall path in the engine. It is best-effort by nature: winget
+pulls transitive dependencies and co-installs that the engine never recorded, so a rollback
+may leave orphans or fail on a package another package still depends on. Per the maintainer
+(architecture plan open decision #3), this is **accepted as documented best-effort with a
+warning**, not prevented.
+
+It is `--confirm`-gated (default refuses — honors `non-destructive-defaults`, symmetric with
+the Phase 3 gate), with a `--dry-run` preview. It operates on **packages only** (the
+`separation-of-concerns` "Rollback operates on packages only" requirement added in Phase 3
+already covers it).
+
+## What Changes
+
+- Add an optional **`driver.Uninstaller`** interface (`Uninstall(ref) (*UninstallResult, error)`)
+  + `UninstallResult` to the `driver` package, discovered by type-assertion exactly like
+  `driver.BatchDetector`. Implement it on the winget driver via `winget uninstall` (the first
+  uninstall path in the engine), classifying exit codes to outcomes
+  (`uninstalled` / `absent` / `failed`); an already-absent package is a successful no-op.
+- Extend the **`rollback`** command (`internal/commands/rollback.go`): when no realizer is
+  present but the driver implements `Uninstaller`, take a **best-effort transaction-rollback**
+  path:
+  - Resolve the target by **engine generation number** (`--to <N>`; bare = the most recent
+    generation). Compute `removeRefs` = union of `addedRefs` of all generations with
+    `number > N`.
+  - Uninstall each ref independently (non-atomic): collect per-ref outcomes, never abort on the
+    first failure; an already-absent ref counts as removed. Mark the run **partial** when any
+    uninstall failed. Surface a **warning** that winget-pulled transitive deps/co-installs are
+    untracked and may be orphaned.
+  - Require `--confirm` (default refuses); `--dry-run` lists what would be removed without
+    uninstalling.
+  - On success (≥1 ref removed), **append** a new rollback-marked Provisioning Generation
+    recording `removedRefs` (`addedRefs` empty; `partial` set from per-ref failures).
+- Add an optional **`RemovedRefs []string`** field to `provision.Generation` (additive;
+  `SchemaVersion` stays `"1.0"`).
+- **No new error codes:** reuse `ROLLBACK_UNSUPPORTED` (backend can neither roll back natively
+  nor uninstall), `GENERATION_NOT_FOUND` (bad `--to`), `WINGET_NOT_AVAILABLE` (winget binary
+  missing), and `ROLLBACK_FAILED` (every targeted uninstall failed). Per-ref failures inside a
+  partial run are reported in the result data, not as a top-level error code (mirrors `apply`).
+- **No `cmd/endstate/main.go` change** — the `rollback` dispatch is already generic.
+
+## Capabilities
+
+### New Capabilities
+
+- `winget-best-effort-rollback`: `rollback` works on non-native backends that can uninstall
+  (winget), reverting by uninstalling the union of `addedRefs` recorded after the target
+  generation. Per-package and non-atomic: it tolerates per-package failure (reporting partial),
+  treats already-absent as a no-op, surfaces an orphan caveat, requires `--confirm` (with a
+  `--dry-run` preview), and appends a rollback-marked generation recording what it removed.
+
+### Modified Capabilities
+
+- None. The package-stage-only guarantee is already asserted by the `separation-of-concerns`
+  "Rollback operates on packages only" requirement (added in `nix-native-rollback`), which
+  covers the whole `rollback` command. The `--confirm` gate realizes the existing
+  `non-destructive-defaults` "destructive operations require explicit flags" invariant without
+  modifying that spec.
+
+## Impact
+
+- `internal/driver/driver.go` — add `Uninstaller` optional interface + `UninstallResult` +
+  status constants (`uninstalled` / `absent` / `failed`).
+- `internal/driver/winget/uninstall.go` (new) — `Uninstall(ref)` via
+  `winget uninstall --id <ref> -e --silent --accept-source-agreements`; exit-code/output
+  classification. **Real-winget verification of the "no installed package found" exit code is
+  on the maintainer's Windows side** (this WSL box has no winget); hermetic tests use the
+  `ExecCommand` injection seam already on `WingetDriver`.
+- `internal/commands/rollback.go` — refactor `RunRollback` to dispatch realizer (Phase 3) vs
+  driver (Phase 4) paths; add `runDriverRollback` (compute `removeRefs`, per-ref uninstall,
+  partial handling, warning, append generation).
+- `internal/provision/provision.go` — additive optional `RemovedRefs []string` field.
+- `docs/contracts/cli-json-contract.md` — **PROTECTED (maintainer-approved, additive)**: extend
+  `## Command: rollback` with the winget best-effort data shape (removed/absent/failed counts,
+  `partial`, `removedRefs`, orphan-warning note).
+- **Zero Windows behavior regression**: `rollback` previously returned `ROLLBACK_UNSUPPORTED`
+  on Windows; it now performs a best-effort rollback. No other command changes. Proven by
+  host-aware hermetic tests + `GOOS=windows` build/vet; real-winget smoke is the maintainer's.

--- a/openspec/changes/winget-best-effort-rollback/specs/winget-best-effort-rollback/spec.md
+++ b/openspec/changes/winget-best-effort-rollback/specs/winget-best-effort-rollback/spec.md
@@ -1,0 +1,85 @@
+## ADDED Requirements
+
+### Requirement: Best-effort rollback for non-native backends
+
+The engine SHALL extend the `rollback` command to package backends that have no native rollback but can uninstall packages. For such a backend, rollback SHALL revert by uninstalling the packages recorded as added after the target Provisioning Generation — the union of the added references of every generation numbered greater than the target. Eligibility SHALL be discovered by the backend exposing an uninstall capability; a backend that can neither roll back natively nor uninstall SHALL refuse without changing any state.
+
+#### Scenario: Rollback to a generation uninstalls later additions
+
+- **WHEN** `rollback --to <N> --confirm` runs on a non-native backend that can uninstall
+- **THEN** the engine SHALL uninstall the union of the added references recorded by every Provisioning Generation numbered greater than N
+- **AND** it SHALL NOT uninstall packages recorded at or before generation N
+
+#### Scenario: Bare rollback reverts the most recent generation
+
+- **WHEN** `rollback --confirm` runs with no target on a non-native, uninstall-capable backend
+- **THEN** the engine SHALL uninstall the added references recorded by the most recent Provisioning Generation
+
+#### Scenario: Backend that cannot uninstall refuses
+
+- **WHEN** `rollback` runs on a backend with neither native rollback nor an uninstall capability
+- **THEN** the engine SHALL refuse with a stable error code
+- **AND** it SHALL NOT modify the installed package set
+
+#### Scenario: Unknown target generation is rejected
+
+- **WHEN** `rollback --to <N>` references a Provisioning Generation number that does not exist
+- **THEN** the engine SHALL return a stable error
+- **AND** it SHALL NOT modify the installed package set
+
+#### Scenario: Nothing to roll back is a no-op
+
+- **WHEN** the target generation is already the most recent (no later additions are recorded)
+- **THEN** the engine SHALL report that there is nothing to roll back
+- **AND** it SHALL NOT uninstall anything
+
+### Requirement: Best-effort uninstall tolerates per-package failure
+
+Because per-package uninstall is non-atomic, rollback SHALL attempt every targeted package independently and report per-package outcomes rather than aborting on the first failure. A package that is already absent SHALL count as a successful removal.
+
+#### Scenario: Per-package failure does not abort the rollback
+
+- **WHEN** one targeted package fails to uninstall (for example, another installed package still depends on it)
+- **THEN** the engine SHALL continue attempting the remaining targeted packages
+- **AND** it SHALL report the failed package(s) in the result
+- **AND** the result SHALL be marked partial
+
+#### Scenario: Already-absent package is a successful no-op
+
+- **WHEN** a targeted package is already not installed
+- **THEN** the engine SHALL treat it as successfully removed
+- **AND** it SHALL NOT report an error for that package
+
+#### Scenario: Untracked dependencies are surfaced as a caveat
+
+- **WHEN** a best-effort rollback uninstalls packages
+- **THEN** the engine SHALL surface a caveat that package-manager-pulled transitive dependencies and co-installs are not tracked and may remain installed
+
+### Requirement: Best-effort rollback requires explicit confirmation
+
+Because it uninstalls packages, best-effort rollback SHALL require an explicit confirmation flag, with a preview available without it. This realizes the non-destructive-defaults invariant for the uninstall path.
+
+#### Scenario: Rollback without confirmation refuses
+
+- **WHEN** `rollback` runs against an uninstall-capable backend without the confirmation flag and not in preview mode
+- **THEN** the engine SHALL refuse and SHALL NOT uninstall anything
+- **AND** it SHALL report how to re-run with confirmation
+
+#### Scenario: Preview lists what would be removed without mutating
+
+- **WHEN** `rollback --dry-run` runs against an uninstall-capable backend
+- **THEN** the engine SHALL report the packages it would uninstall without uninstalling them
+- **AND** it SHALL NOT require the confirmation flag
+
+### Requirement: Best-effort rollback appends a Provisioning Generation
+
+After a best-effort rollback that removed at least one package, the engine SHALL append a new numbered Provisioning Generation marked as rollback-produced, recording the removed references, so the history remains append-only and auditable.
+
+#### Scenario: Rollback records what it removed
+
+- **WHEN** a best-effort rollback successfully removes one or more packages
+- **THEN** the engine SHALL append a new Provisioning Generation under the resolved state directory
+- **AND** it SHALL mark the generation as rollback-produced
+- **AND** it SHALL record the removed references
+- **AND** its added references SHALL be empty
+- **AND** it SHALL be marked partial when any targeted uninstall failed

--- a/openspec/changes/winget-best-effort-rollback/tasks.md
+++ b/openspec/changes/winget-best-effort-rollback/tasks.md
@@ -1,0 +1,81 @@
+> TDD: write each test RED first, then implement to green. All CI tests are hermetic (no real
+> `winget`) — use the `WingetDriver.ExecCommand` injection seam and inject `newDriverFn`/
+> `newRealizerFn` in command tests (host-aware, per the Phase-3 pattern). This WSL box has no
+> winget: real-winget uninstall smoke is the maintainer's Windows side. Verify here:
+> `cd go-engine && go test ./...` (Linux) + `GOOS=windows go build ./...` + `go vet`.
+
+## 0. Gate
+
+- [ ] 0.1 `npm run openspec:validate` (strict) passes for this change
+- [ ] 0.2 **PAUSE for maintainer review of this spec** before any Go is written
+
+## 1. `provision.Generation` — RemovedRefs (additive)
+
+- [ ] 1.1 Add optional `RemovedRefs []string \`json:"removedRefs,omitempty"\`` to `Generation`
+- [ ] 1.2 RED test: round-trips; omitted when empty; `SchemaVersion` stays `"1.0"`
+
+## 2. `driver.Uninstaller` + winget implementation
+
+- [ ] 2.1 `internal/driver/driver.go`: `UninstallResult{Status,Message}` + status constants
+      (`uninstalled`/`absent`/`failed`) + `Uninstaller` optional interface
+- [ ] 2.2 RED tests (`internal/driver/winget/uninstall_test.go`, `ExecCommand` shim): exit 0 →
+      `uninstalled`; "no installed package found" → `absent`; other non-zero → `failed`; missing
+      binary → `ErrWingetNotAvailable`. Assert the spawned argv (`winget uninstall --id <ref> -e
+      --silent --accept-source-agreements`)
+- [ ] 2.3 `internal/driver/winget/uninstall.go`: implement `Uninstall(ref)`; classify via exit
+      code + output-substring fallback. **Flag the not-found exit code for maintainer Windows
+      verification** (mirrors install already-installed code)
+- [ ] 2.4 Compile-time assertion `*winget.WingetDriver` satisfies `driver.Uninstaller`
+
+## 3. `rollback` command — driver (best-effort) path
+
+- [ ] 3.1 Refactor `RunRollback` to dispatch: realizer present → existing native path
+      (`runRealizerRollback`); else driver present + `Uninstaller` → `runDriverRollback`; else
+      `ROLLBACK_UNSUPPORTED`
+- [ ] 3.2 `runDriverRollback`: resolve target N (`--to`; bare = most recent); compute
+      `removeRefs` = union of `addedRefs` of generations with `Number > N`; empty → success no-op
+- [ ] 3.3 `--dry-run` → preview `removeRefs`, no uninstall, no generation. No `--confirm`
+      (and not dry-run) → refuse (message names `--confirm`), no mutation
+- [ ] 3.4 Per-ref `Uninstall`: collect `{removed, absent→removed, failed}`; never abort early;
+      emit the untracked-dependency warning
+- [ ] 3.5 On ≥1 removed: append generation (`Backend="winget"`, `Rollback=true`, `AddedRefs=[]`,
+      `RemovedRefs`, `Partial`=any failure)
+- [ ] 3.6 Result envelope: success + summary {removed, absent, failed, partial}; top-level error
+      only for `WINGET_NOT_AVAILABLE` (binary missing) or `ROLLBACK_FAILED` (every uninstall failed)
+
+## 4. Command tests (`internal/commands/rollback_test.go`, host-aware)
+
+- [ ] 4.1 Add a `fakeUninstaller` driver stub (scriptable per-ref outcomes + arg capture);
+      inject via `newDriverFn` (and `newRealizerFn` → `ErrNoRealizer` to force the driver path)
+- [ ] 4.2 `--to N` → uninstalls union of `addedRefs` of generations > N; appends a
+      rollback-marked generation with `RemovedRefs` + empty `AddedRefs`
+- [ ] 4.3 Bare rollback → targets the most recent generation
+- [ ] 4.4 Driver not an `Uninstaller` (and no realizer) → `ROLLBACK_UNSUPPORTED`
+- [ ] 4.5 Unknown `--to` → `GENERATION_NOT_FOUND`; no uninstall
+- [ ] 4.6 Per-ref failure → run continues, result partial, generation `Partial=true`
+- [ ] 4.7 Already-absent ref → counted removed, no error
+- [ ] 4.8 Every uninstall fails → `ROLLBACK_FAILED`
+- [ ] 4.9 No `--confirm` → refuses, nothing uninstalled, no generation
+- [ ] 4.10 `--dry-run` → previews `removeRefs`, no uninstall, no generation
+- [ ] 4.11 Nothing to roll back (target is most recent) → success no-op, no generation
+- [ ] 4.12 Extend the rollback import-guard test to the driver path (no `internal/restore`)
+
+## 5. Windows no-regression
+
+- [ ] 5.1 Existing winget tests stay green; new uninstall tests are hermetic
+- [ ] 5.2 `GOOS=windows go build ./...` + `go vet ./...` clean
+
+## 6. Contract documentation (PROTECTED — maintainer-approved, additive)
+
+- [ ] 6.1 `docs/contracts/cli-json-contract.md`: extend `## Command: rollback` with the winget
+      best-effort data shape (removed/absent/failed counts, `partial`, `removedRefs`,
+      orphan-warning note). No new error codes; no `main.go` change
+
+## 7. Verification
+
+- [ ] 7.1 `cd go-engine && go test ./...` green on Linux
+- [ ] 7.2 `GOOS=windows go build ./...` + `go vet ./...` clean
+- [ ] 7.3 `npm run openspec:validate` (strict) passes
+- [ ] 7.4 **Maintainer-side real-winget smoke (Windows):** apply 2 apps → gen 1; apply a 3rd →
+      gen 2; `rollback --to 1 --confirm` → uninstalls the 3rd; `generations` shows the appended
+      rollback-marked gen; `rollback` without `--confirm` refuses; already-absent ref is a no-op


### PR DESCRIPTION
## Summary

Phase 4 of the cross-OS provisioning effort — **Windows migrates in**. Phase 3 (#60) gave Nix *native* rollback; winget has none, so this adds a **best-effort** rollback: the engine reverts by reconstructing the package delta from the recorded Provisioning Generations and uninstalling what was added after the target — the union of `addedRefs` of every generation numbered greater than the target. First uninstall path in the engine.

## What changed

- **`driver.Uninstaller`** optional interface (+ `UninstallResult`), discovered by type-assertion like `BatchDetector`. Implemented on the winget driver via `winget uninstall` (`uninstall.go`); classified to `uninstalled`/`absent`/`failed`, already-absent = no-op success.
- **`rollback` dispatch:** realizer present → native path (Phase 3); else a driver that implements `Uninstaller` → best-effort `runDriverRollback`; else `ROLLBACK_UNSUPPORTED`.
- **Best-effort path:** per-package, non-atomic, **failure-tolerant** (reports `partial`, never aborts); surfaces an untracked-dependency/orphan **warning** (maintainer decision: documented best-effort, not prevented); requires `--confirm` with `--dry-run` preview; appends a rollback-marked generation recording `removedRefs` (new optional `Generation.RemovedRefs`).
- **No new error codes** (reuse `ROLLBACK_UNSUPPORTED`/`GENERATION_NOT_FOUND`/`ROLLBACK_FAILED`/`WINGET_NOT_AVAILABLE`); **no `main.go` change** (dispatch already generic).

## OpenSpec

New change `winget-best-effort-rollback` (new capability, 4 requirements / 12 scenarios). Package-stage-only is covered by the archived `separation-of-concerns` "Rollback operates on packages only" requirement + the `rollback.go` import-guard test.

## Verification

- Linux `go test ./...` — **24/0**.
- `GOOS=windows go build ./...` + `go vet ./...` — clean.
- `npm run openspec:validate` strict — **55/55**.
- **Real-winget uninstall smoke is the maintainer's Windows side** — this dev box has no winget. "Absent" detection is output-substring-primary (testable cross-platform); the not-found HRESULT is flagged for Windows verification (like the install codes). Hermetic tests use the `ExecCommand` seam.

## Merge ordering

Independent of #61 (archival): the changes are disjoint, and a three-way merge keeps the archived dirs deleted regardless of order (Phase 4 never touches them). No stacking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)