### PR TITLE
feat(engine): converge to exact set via apply --prune (Phase 5)

### DIFF
--- a/docs/contracts/cli-json-contract.md
+++ b/docs/contracts/cli-json-contract.md
@@ -99,6 +99,7 @@ When `success` is `false`, the `error` field contains:
 | `ROLLBACK_UNSUPPORTED` | The host's package backend does not advertise native rollback (e.g. winget on Windows; any host with no realizer). Additive in schema 1.x. |
 | `GENERATION_NOT_FOUND` | The `rollback --to <n>` target generation does not exist, or records no backend-native rollback anchor. Additive in schema 1.x. |
 | `ROLLBACK_FAILED` | The backend rollback failed (non-systemic). Raw backend text is confined to `error.detail`. Additive in schema 1.x. |
+| `CONVERGENCE_UNSUPPORTED` | `apply --prune` was requested on a backend that cannot safely remove installed-but-undeclared packages (the winget driver, or any host with no realizer). Nothing is removed. Additive in schema 1.x. |
 
 #### Hosted Backup error codes
 
@@ -332,6 +333,29 @@ endstate apply --manifest ./manifest.jsonc --dry-run --json
 ```
 
 **Note:** `eventsFile` is only included when `--events jsonl` is enabled. The engine persists events to `logs/<runId>.events.jsonl` in addition to streaming to stderr.
+
+### Convergence (`--prune`)
+
+`apply --prune` converges the engine-managed set to *exactly* the manifest: after the install phase it removes installed-but-undeclared packages ("drift") in one atomic generation switch. Convergence is realizer-only (Nix on Linux/macOS); the winget driver refuses with `CONVERGENCE_UNSUPPORTED`, changing nothing. Package-stage only: prune never touches configuration restore, `state/backups/`, or the revert journal.
+
+| Flag | Behavior |
+|------|----------|
+| `--prune` | After install, remove installed-but-undeclared packages. Destructive, so it requires `--confirm` (or `--dry-run`). |
+| `--confirm` | Required to execute the prune. Without it (and without `--dry-run`) the command refuses with `INTERNAL_ERROR` and removes nothing — the install-phase results stand. |
+| `--dry-run` | Preview only: the would-be-pruned set is reported in `data.pruned` without removing anything and without requiring `--confirm` (install and prune are both preview-only). |
+
+On a converging run the result carries a `pruned` field — the element names removed this run (omitted when empty):
+
+```json
+"data": {
+  "dryRun": false,
+  "summary": { "total": 1, "success": 0, "skipped": 1, "failed": 0 },
+  "actions": [ /* ... */ ],
+  "pruned": ["ripgrep"]
+}
+```
+
+The recorded Provisioning Generation reflects the converged set: `addedRefs` for packages installed this run and `removedRefs` for packages pruned this run, with `native` set to the final advancing generation. A no-op convergence (nothing added or removed) records no generation.
 
 ```json
 ```

--- a/go-engine/cmd/endstate/main.go
+++ b/go-engine/cmd/endstate/main.go
@@ -67,7 +67,7 @@ Per-command flags:
   --last <n>           Last N runs (report)
   --run-id <id>        Specific run ID (report)
   --to <generation>    Target provisioning generation number (rollback; default: previous)
-  --confirm            Acknowledge a state-changing operation (rollback, backup/account delete)
+  --confirm            Acknowledge a state-changing operation (apply --prune, rollback, backup/account delete)
 
 Subcommands:
   profile list         List discovered profiles
@@ -129,6 +129,7 @@ type parsedArgs struct {
 	versionID      string
 	to             string
 	confirm        bool
+	prune          bool // apply --prune: converge to the exact declared set
 	saveRecoveryTo string
 	overwrite      bool
 
@@ -180,6 +181,8 @@ func parseArgs(args []string) parsedArgs {
 			p.latest = true
 		case "--confirm":
 			p.confirm = true
+		case "--prune":
+			p.prune = true
 		case "--overwrite":
 			p.overwrite = true
 		case "--WithConfig":
@@ -294,7 +297,7 @@ func commandUsage(cmd string) string {
 	case "capabilities":
 		return "Usage: endstate capabilities [--json]\n\nReport CLI capabilities for GUI handshake.\n"
 	case "apply":
-		return "Usage: endstate apply [--manifest <path>] [--dry-run] [--enable-restore] [--json] [--events jsonl]\n\nExecute provisioning plan.\n"
+		return "Usage: endstate apply [--manifest <path>] [--dry-run] [--enable-restore] [--prune] [--confirm] [--json] [--events jsonl]\n\nExecute provisioning plan. With --prune, converge the engine-managed set to exactly the manifest by removing installed-but-undeclared packages (realizer backends only, e.g. Nix on Linux/macOS). --prune requires --confirm to execute; use --prune --dry-run to preview what would be removed.\n"
 	case "verify":
 		return "Usage: endstate verify [--manifest <path>] [--json] [--events jsonl]\n\nVerify machine state against manifest.\n"
 	case "capture":
@@ -411,6 +414,8 @@ func dispatch(p parsedArgs) (interface{}, *envelope.Error) {
 			Events:        p.events,
 			Export:        p.export,
 			RestoreFilter: p.restoreFilter,
+			Prune:         p.prune,
+			Confirm:       p.confirm,
 		})
 
 	case "verify":

--- a/go-engine/internal/commands/apply.go
+++ b/go-engine/internal/commands/apply.go
@@ -61,6 +61,13 @@ type ApplyFlags struct {
 	// RestoreFilter limits restore to entries matching specific module IDs
 	// (comma-separated).
 	RestoreFilter string
+	// Prune enables convergence: after install, remove installed-but-undeclared
+	// packages ("drift") from the engine-managed set. Realizer-only; the winget
+	// driver path refuses with CONVERGENCE_UNSUPPORTED.
+	Prune bool
+	// Confirm authorizes the destructive prune. Without it, --prune refuses
+	// (unless --dry-run, which only previews).
+	Confirm bool
 }
 
 // RestoreModuleRef identifies a config module available for restore, including
@@ -73,12 +80,15 @@ type RestoreModuleRef struct {
 // ApplyResult is the data payload for the apply command JSON envelope.
 // Shape matches docs/contracts/cli-json-contract.md section "Command: apply".
 type ApplyResult struct {
-	DryRun                  bool              `json:"dryRun"`
-	Manifest                ApplyManifestRef  `json:"manifest"`
-	Summary                 ApplySummary      `json:"summary"`
-	Actions                 []ApplyAction     `json:"actions"`
-	ConfigModuleMap         map[string]string `json:"configModuleMap,omitempty"`
+	DryRun                  bool               `json:"dryRun"`
+	Manifest                ApplyManifestRef   `json:"manifest"`
+	Summary                 ApplySummary       `json:"summary"`
+	Actions                 []ApplyAction      `json:"actions"`
+	ConfigModuleMap         map[string]string  `json:"configModuleMap,omitempty"`
 	RestoreModulesAvailable []RestoreModuleRef `json:"restoreModulesAvailable,omitempty"`
+	// Pruned lists the engine-managed element names removed by --prune
+	// convergence (or, on --dry-run, that would be removed). Omitted when empty.
+	Pruned []string `json:"pruned,omitempty"`
 }
 
 // ApplyManifestRef identifies the manifest used for the apply run.
@@ -98,13 +108,13 @@ type ApplySummary struct {
 
 // ApplyAction records the planned or executed action for a single app entry.
 type ApplyAction struct {
-	ID      string           `json:"id"`
-	Ref     *string          `json:"ref"`
-	Driver  string           `json:"driver"`
-	Name    string           `json:"name,omitempty"`
-	Status  string           `json:"status"`
-	Reason  string           `json:"reason,omitempty"`
-	Message string           `json:"message,omitempty"`
+	ID      string              `json:"id"`
+	Ref     *string             `json:"ref"`
+	Driver  string              `json:"driver"`
+	Name    string              `json:"name,omitempty"`
+	Status  string              `json:"status"`
+	Reason  string              `json:"reason,omitempty"`
+	Message string              `json:"message,omitempty"`
 	Manual  *manifest.ManualApp `json:"manual"`
 }
 
@@ -184,6 +194,16 @@ func RunApply(flags ApplyFlags) (interface{}, *envelope.Error) {
 	// driver loop below, byte-identical to prior behavior.
 	if rz, rerr := newRealizerFn(); rerr == nil {
 		return runApplyRealizer(flags, mf, rz, emitter, runID, configModuleMap, restoreModulesAvailable)
+	}
+
+	// Convergence (--prune) is realizer-only. The driver path (winget) operates on
+	// the shared system, where removing undeclared packages is unsafe, so refuse
+	// and change nothing.
+	if flags.Prune {
+		return nil, envelope.NewError(
+			envelope.ErrConvergenceUnsupported,
+			"convergence (--prune) is not supported on this backend").
+			WithRemediation("Run on a host with the Nix realizer (Linux/macOS) to use --prune.")
 	}
 
 	d, derr := newDriverFn()
@@ -367,7 +387,7 @@ func RunApply(flags ApplyFlags) (interface{}, *envelope.Error) {
 		// Record a Provisioning Generation for the install stage (best-effort,
 		// install-only). Written only when >=1 package was installed this run;
 		// Partial when any attempted install failed. Never touches restore state.
-		writeProvisioningGeneration(runID, d.Name(), finalActions, "", failedCount > 0)
+		writeProvisioningGeneration(runID, d.Name(), finalActions, nil, "", failedCount > 0)
 
 		// ----------------------------------------------------------------
 		// Phase 2b: Restore  (when --enable-restore and manifest has entries)
@@ -496,7 +516,7 @@ func RunApply(flags ApplyFlags) (interface{}, *envelope.Error) {
 	if flags.DryRun {
 		// Dry-run: no installs executed. Report plan state.
 		outSummary.Success = 0
-		outSummary.Skipped = presentCount  // already-present apps are effectively "skipped"
+		outSummary.Skipped = presentCount // already-present apps are effectively "skipped"
 		outSummary.Failed = 0
 	} else {
 		outSummary.Success = successCount
@@ -517,4 +537,3 @@ func RunApply(flags ApplyFlags) (interface{}, *envelope.Error) {
 		RestoreModulesAvailable: restoreModulesAvailable,
 	}, nil
 }
-

--- a/go-engine/internal/commands/apply_generation.go
+++ b/go-engine/internal/commands/apply_generation.go
@@ -9,16 +9,16 @@ import (
 	"github.com/Artexis10/endstate/go-engine/internal/provision"
 )
 
-// writeProvisioningGeneration records a Provisioning Generation for a successful
-// apply, but only when the committed package set advanced — i.e. at least one
-// ref was installed this run. Idempotent re-runs (nothing newly installed) write
-// no generation. It is best-effort: a write error never fails the apply,
-// mirroring run-history persistence.
+// writeProvisioningGeneration records a Provisioning Generation for an apply, but
+// only when the committed package set changed — i.e. at least one ref was
+// installed OR removed (pruned) this run. Idempotent re-runs (nothing added or
+// removed) write no generation. It is best-effort: a write error never fails the
+// apply, mirroring run-history persistence.
 //
-// Separation of concerns: this records package facts only (the installed and
-// already-present refs). It never touches the config backup directory
+// Separation of concerns: this records package facts only (the installed,
+// already-present, and pruned refs). It never touches the config backup directory
 // (state/backups/) or the restore revert journal.
-func writeProvisioningGeneration(runID, backend string, actions []ApplyAction, native string, partial bool) {
+func writeProvisioningGeneration(runID, backend string, actions []ApplyAction, removed []string, native string, partial bool) {
 	items := make([]provision.ProvItem, 0, len(actions))
 	added := make([]string, 0)
 	for _, a := range actions {
@@ -31,17 +31,18 @@ func writeProvisioningGeneration(runID, backend string, actions []ApplyAction, n
 			items = append(items, provision.ProvItem{ID: a.ID, Ref: derefRef(a.Ref), Status: "present"})
 		}
 	}
-	if len(added) == 0 {
-		return // nothing newly installed → no new generation
+	if len(added) == 0 && len(removed) == 0 {
+		return // nothing added or removed → no new generation
 	}
 	_ = provision.Write(&provision.Generation{
-		RunID:     runID,
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-		Backend:   backend,
-		Items:     items,
-		AddedRefs: added,
-		Native:    native,
-		Partial:   partial,
+		RunID:       runID,
+		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+		Backend:     backend,
+		Items:       items,
+		AddedRefs:   added,
+		RemovedRefs: removed,
+		Native:      native,
+		Partial:     partial,
 	})
 }
 

--- a/go-engine/internal/commands/apply_generation_test.go
+++ b/go-engine/internal/commands/apply_generation_test.go
@@ -25,7 +25,7 @@ func TestWriteProvisioningGeneration_RecordsInstalledOnly(t *testing.T) {
 		{ID: "jq", Ref: stringPtr("nixpkgs#jq"), Status: "present"},
 		{ID: "bad", Ref: stringPtr("nixpkgs#bad"), Status: "failed"},
 	}
-	writeProvisioningGeneration("apply-x", "nix", actions, "7", false)
+	writeProvisioningGeneration("apply-x", "nix", actions, nil, "7", false)
 
 	gens, err := provision.List()
 	if err != nil {
@@ -50,7 +50,7 @@ func TestWriteProvisioningGeneration_NoInstallsNoGeneration(t *testing.T) {
 	t.Setenv("ENDSTATE_ROOT", t.TempDir())
 
 	actions := []ApplyAction{{ID: "jq", Ref: stringPtr("nixpkgs#jq"), Status: "present"}}
-	writeProvisioningGeneration("apply-x", "nix", actions, "", false)
+	writeProvisioningGeneration("apply-x", "nix", actions, nil, "", false)
 
 	gens, _ := provision.List()
 	if len(gens) != 0 {
@@ -65,7 +65,7 @@ func TestWriteProvisioningGeneration_WingetPartialSubset(t *testing.T) {
 		{ID: "a", Ref: stringPtr("A.A"), Status: "installed"},
 		{ID: "b", Ref: stringPtr("B.B"), Status: "failed"},
 	}
-	writeProvisioningGeneration("apply-x", "winget", actions, "", true)
+	writeProvisioningGeneration("apply-x", "winget", actions, nil, "", true)
 
 	gens, _ := provision.List()
 	if len(gens) != 1 {

--- a/go-engine/internal/commands/apply_prune_test.go
+++ b/go-engine/internal/commands/apply_prune_test.go
@@ -1,0 +1,278 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/manifest"
+	"github.com/Artexis10/endstate/go-engine/internal/provision"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+// ---------------------------------------------------------------------------
+// realizerOnlyStub — implements realizer.Realizer but NOT realizer.Pruner, so
+// the convergence (--prune) path must refuse with CONVERGENCE_UNSUPPORTED.
+// ---------------------------------------------------------------------------
+
+type realizerOnlyStub struct {
+	currentSet    realizer.Set
+	planDiff      realizer.Diff
+	realizeResult realizer.Result
+}
+
+func (s *realizerOnlyStub) Name() string                   { return "stub" }
+func (s *realizerOnlyStub) Current() (realizer.Set, error) { return s.currentSet, nil }
+func (s *realizerOnlyStub) Realize(_ []realizer.Installable) (realizer.Result, error) {
+	return s.realizeResult, nil
+}
+func (s *realizerOnlyStub) Plan(_ []realizer.Installable) (realizer.Diff, error) {
+	return s.planDiff, nil
+}
+
+// driftSet builds a current Set whose elements are jq (declared) plus ripgrep
+// (undeclared drift), so a manifest declaring only jq prunes ripgrep.
+func driftSet(generation int) realizer.Set {
+	return realizer.Set{
+		Generation: generation,
+		Elements: map[string]realizer.Element{
+			"jq":      {Name: "jq", AttrPath: "jq"},
+			"ripgrep": {Name: "ripgrep", AttrPath: "ripgrep"},
+		},
+	}
+}
+
+// jqManifest is a single-app manifest declaring only jq, keyed by the host OS so
+// the realizer path resolves it on any platform.
+func jqManifest() *manifest.Manifest {
+	return &manifest.Manifest{Apps: []manifest.App{nixApp("jq", "nixpkgs#jq")}}
+}
+
+// ---------------------------------------------------------------------------
+// Convergence (--prune) command-level tests — call runApplyRealizer directly so
+// they are host-independent (no real Nix, no driver fork).
+// ---------------------------------------------------------------------------
+
+// Converged apply with --prune --confirm: jq is installed AND undeclared drift
+// (ripgrep) is removed via Remove. result.Pruned is set, and the single recorded
+// generation carries BOTH addedRefs (jq) and removedRefs (ripgrep), with native
+// set to the prune's advancing generation (the final mutating op).
+func TestRunApplyRealizer_PruneConfirm_RemovesDrift(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	fr := &fakeRealizer{
+		// jq is missing (install it); ripgrep is installed-but-undeclared (prune it).
+		planDiff:      realizer.Diff{ToAdd: []realizer.Installable{{ID: "jq", Ref: "nixpkgs#jq"}}},
+		currentSet:    driftSet(5),
+		realizeResult: realizer.Result{Advanced: true, ToGeneration: 5},
+		removeResult:  realizer.Result{Advanced: true, ToGeneration: 6},
+	}
+	flags := ApplyFlags{Manifest: "m.jsonc", Prune: true, Confirm: true}
+
+	raw, eerr := runApplyRealizer(flags, jqManifest(), fr, noopEmitter(), "prune-1", nil, nil)
+	if eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+	if fr.removeCalls != 1 {
+		t.Fatalf("Remove called %d times, want 1", fr.removeCalls)
+	}
+	if len(fr.lastRemoveArgs) != 1 || fr.lastRemoveArgs[0] != "ripgrep" {
+		t.Fatalf("Remove args = %v, want [ripgrep]", fr.lastRemoveArgs)
+	}
+	result := raw.(*ApplyResult)
+	if len(result.Pruned) != 1 || result.Pruned[0] != "ripgrep" {
+		t.Fatalf("result.Pruned = %v, want [ripgrep]", result.Pruned)
+	}
+
+	gens, _ := provision.List()
+	if len(gens) != 1 {
+		t.Fatalf("want 1 generation recording the converged set, got %d", len(gens))
+	}
+	g := gens[0]
+	if len(g.AddedRefs) != 1 || g.AddedRefs[0] != "nixpkgs#jq" {
+		t.Fatalf("generation AddedRefs = %v, want [nixpkgs#jq]", g.AddedRefs)
+	}
+	if len(g.RemovedRefs) != 1 || g.RemovedRefs[0] != "ripgrep" {
+		t.Fatalf("generation RemovedRefs = %v, want [ripgrep]", g.RemovedRefs)
+	}
+	if g.Native != "6" {
+		t.Fatalf("generation Native = %q, want \"6\" (prune's advancing gen)", g.Native)
+	}
+}
+
+// No-op convergence: --prune --confirm with everything already declared and no
+// drift installs nothing and removes nothing, so it records no generation and
+// never calls Remove (an atomic backend writes a generation only when it
+// advances).
+func TestRunApplyRealizer_PruneConfirm_NoDrift_NoGeneration(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	fr := &fakeRealizer{
+		planDiff: realizer.Diff{Present: []realizer.Installable{{ID: "jq", Ref: "nixpkgs#jq"}}},
+		currentSet: realizer.Set{
+			Generation: 4,
+			Elements:   map[string]realizer.Element{"jq": {Name: "jq", AttrPath: "jq"}},
+		},
+	}
+	flags := ApplyFlags{Manifest: "m.jsonc", Prune: true, Confirm: true}
+
+	if _, eerr := runApplyRealizer(flags, jqManifest(), fr, noopEmitter(), "noop", nil, nil); eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+	if fr.removeCalls != 0 {
+		t.Fatalf("Remove called %d times with no drift, want 0", fr.removeCalls)
+	}
+	if gens, _ := provision.List(); len(gens) != 0 {
+		t.Fatalf("no-op convergence must record no generation, got %d", len(gens))
+	}
+}
+
+// --prune --dry-run: the prune set is previewed in result.Pruned WITHOUT calling
+// Remove, requires no --confirm, and records no generation.
+func TestRunApplyRealizer_PruneDryRun_PreviewsWithoutRemoving(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	fr := &fakeRealizer{
+		planDiff:   realizer.Diff{ToAdd: []realizer.Installable{{ID: "jq", Ref: "nixpkgs#jq"}}},
+		currentSet: driftSet(4),
+	}
+	flags := ApplyFlags{Manifest: "m.jsonc", Prune: true, DryRun: true} // no Confirm
+
+	raw, eerr := runApplyRealizer(flags, jqManifest(), fr, noopEmitter(), "prune-dry", nil, nil)
+	if eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+	result := raw.(*ApplyResult)
+	if !result.DryRun {
+		t.Error("result.DryRun = false, want true")
+	}
+	if len(result.Pruned) != 1 || result.Pruned[0] != "ripgrep" {
+		t.Fatalf("result.Pruned = %v, want [ripgrep]", result.Pruned)
+	}
+	if fr.removeCalls != 0 {
+		t.Fatalf("Remove called %d times in dry-run, want 0", fr.removeCalls)
+	}
+	if gens, _ := provision.List(); len(gens) != 0 {
+		t.Fatalf("dry-run must record no generation, got %d", len(gens))
+	}
+}
+
+// --prune without --confirm (not dry-run): refuses with an envelope error and
+// removes nothing; the install phase results stand.
+func TestRunApplyRealizer_PruneWithoutConfirm_Refuses(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	fr := &fakeRealizer{
+		planDiff:   realizer.Diff{Present: []realizer.Installable{{ID: "jq", Ref: "nixpkgs#jq"}}},
+		currentSet: driftSet(4),
+	}
+	flags := ApplyFlags{Manifest: "m.jsonc", Prune: true} // Confirm:false, DryRun:false
+
+	_, eerr := runApplyRealizer(flags, jqManifest(), fr, noopEmitter(), "prune-noconfirm", nil, nil)
+	if eerr == nil {
+		t.Fatal("expected an envelope error refusing --prune without --confirm, got nil")
+	}
+	if eerr.Code != envelope.ErrInternalError {
+		t.Fatalf("refusal code = %q, want INTERNAL_ERROR", eerr.Code)
+	}
+	if fr.removeCalls != 0 {
+		t.Fatalf("Remove called %d times, want 0 (refused)", fr.removeCalls)
+	}
+}
+
+// Default apply (no --prune): Remove is never called even when drift exists.
+func TestRunApplyRealizer_NoPrune_NeverRemoves(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	fr := &fakeRealizer{
+		planDiff:   realizer.Diff{Present: []realizer.Installable{{ID: "jq", Ref: "nixpkgs#jq"}}},
+		currentSet: driftSet(4),
+	}
+	flags := ApplyFlags{Manifest: "m.jsonc"} // no Prune
+
+	if _, eerr := runApplyRealizer(flags, jqManifest(), fr, noopEmitter(), "noprune", nil, nil); eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+	if fr.removeCalls != 0 {
+		t.Fatalf("Remove called %d times without --prune, want 0", fr.removeCalls)
+	}
+}
+
+// A realizer that does NOT implement Pruner must refuse --prune with
+// CONVERGENCE_UNSUPPORTED (the realizer-path counterpart of the driver refusal).
+func TestRunApplyRealizer_NonPruner_Unsupported(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	stub := &realizerOnlyStub{
+		planDiff:   realizer.Diff{Present: []realizer.Installable{{ID: "jq", Ref: "nixpkgs#jq"}}},
+		currentSet: driftSet(4),
+	}
+	flags := ApplyFlags{Manifest: "m.jsonc", Prune: true, Confirm: true}
+
+	_, eerr := runApplyRealizer(flags, jqManifest(), stub, noopEmitter(), "nonpruner", nil, nil)
+	if eerr == nil {
+		t.Fatal("expected CONVERGENCE_UNSUPPORTED for a non-Pruner realizer, got nil")
+	}
+	if eerr.Code != envelope.ErrConvergenceUnsupported {
+		t.Fatalf("error code = %q, want CONVERGENCE_UNSUPPORTED", eerr.Code)
+	}
+}
+
+// Driver (winget) path: --prune refuses with CONVERGENCE_UNSUPPORTED and changes
+// nothing. withMockDriver overrides BOTH newRealizerFn (-> ErrNoRealizer) and
+// newDriverFn so the driver fork is taken even on linux/darwin/windows CI.
+func TestRunApply_DriverPath_PruneUnsupported(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	md := &mockDriver{installed: map[string]bool{}}
+	manifestContent := `{
+		"name": "prune-driver-test",
+		"apps": [
+			{ "id": "a", "refs": { "windows": "Vendor.A" } }
+		]
+	}`
+	manifestPath := filepath.Join(t.TempDir(), "m.jsonc")
+	if err := os.WriteFile(manifestPath, []byte(manifestContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var eerr *envelope.Error
+	withMockDriver(md, func() {
+		_, eerr = RunApply(ApplyFlags{Manifest: manifestPath, Prune: true})
+	})
+	if eerr == nil {
+		t.Fatal("expected CONVERGENCE_UNSUPPORTED on the driver path, got nil")
+	}
+	if eerr.Code != envelope.ErrConvergenceUnsupported {
+		t.Fatalf("error code = %q, want CONVERGENCE_UNSUPPORTED", eerr.Code)
+	}
+	// Nothing installed by the refused run.
+	if gens, _ := provision.List(); len(gens) != 0 {
+		t.Fatalf("refused --prune must record no generation, got %d", len(gens))
+	}
+}
+
+// --- separation of concerns guard --------------------------------------------
+
+// TestPruneStaysPackageOnly: the realizer apply path (which owns convergence /
+// --prune) must not import the config/restore layer — pruning packages is
+// distinct from reverting configs.
+func TestPruneStaysPackageOnly(t *testing.T) {
+	fset := token.NewFileSet()
+	af, err := parser.ParseFile(fset, "apply_realizer.go", nil, parser.ImportsOnly)
+	if err != nil {
+		t.Fatalf("parse apply_realizer.go: %v", err)
+	}
+	for _, imp := range af.Imports {
+		if strings.Contains(imp.Path.Value, "internal/restore") {
+			t.Fatalf("apply_realizer.go imports %s; the prune path must stay package-stage only", imp.Path.Value)
+		}
+	}
+}

--- a/go-engine/internal/commands/apply_realizer.go
+++ b/go-engine/internal/commands/apply_realizer.go
@@ -81,6 +81,38 @@ func presentInSet(set realizer.Set, ref string) bool {
 	return false
 }
 
+// computeDrift returns the element names in the current set that match no desired
+// ref — the installed-but-undeclared packages to prune. It compares on leaf
+// attributes (the inverse of presentInSet) so e.g. "nixpkgs#ripgrep" matches an
+// element named "ripgrep".
+func computeDrift(current realizer.Set, desired []realizer.Installable) []string {
+	want := map[string]bool{}
+	for _, d := range desired {
+		if leaf := leafAttr(d.Ref); leaf != "" {
+			want[leaf] = true
+		}
+	}
+	var drift []string
+	for name, el := range current.Elements {
+		if want[leafAttr(name)] || (el.AttrPath != "" && want[leafAttr(el.AttrPath)]) {
+			continue
+		}
+		drift = append(drift, name)
+	}
+	return drift
+}
+
+// requirePruner returns the realizer's optional Pruner capability, or a
+// CONVERGENCE_UNSUPPORTED envelope error when the backend cannot converge.
+func requirePruner(r realizer.Realizer) (realizer.Pruner, *envelope.Error) {
+	if p, ok := r.(realizer.Pruner); ok {
+		return p, nil
+	}
+	return nil, envelope.NewError(
+		envelope.ErrConvergenceUnsupported,
+		"this backend does not support convergence (--prune)")
+}
+
 // runApplyRealizer is the whole-set apply path for a realizer backend (Nix). It
 // computes one plan over the declared package set, performs ONE atomic
 // generation switch, and fans the single result back into the per-item event
@@ -168,6 +200,16 @@ func runApplyRealizer(flags ApplyFlags, mf *manifest.Manifest, r realizer.Realiz
 	emitter.EmitSummary("plan", totalApps, presentCount, 0, toInstallCount)
 
 	if flags.DryRun {
+		// --prune --dry-run previews the prune set without mutating anything and
+		// without requiring --confirm.
+		var pruned []string
+		if flags.Prune {
+			if _, perr := requirePruner(r); perr != nil {
+				return nil, perr
+			}
+			cur, _ := r.Current()
+			pruned = computeDrift(cur, desired)
+		}
 		return &ApplyResult{
 			DryRun:                  true,
 			Manifest:                ApplyManifestRef{Path: flags.Manifest, Name: mf.Name},
@@ -175,6 +217,7 @@ func runApplyRealizer(flags ApplyFlags, mf *manifest.Manifest, r realizer.Realiz
 			Actions:                 actions,
 			ConfigModuleMap:         configModuleMap,
 			RestoreModulesAvailable: restoreModulesAvailable,
+			Pruned:                  pruned,
 		}, nil
 	}
 
@@ -197,6 +240,11 @@ func runApplyRealizer(flags ApplyFlags, mf *manifest.Manifest, r realizer.Realiz
 		}
 	}
 
+	// Track whether each mutating phase advanced a generation and to which
+	// number, so the single Provisioning Generation below records the converged
+	// set with the final advancing op's native generation.
+	installAdvanced := false
+	installGen := 0
 	if len(diff.ToAdd) > 0 {
 		for _, ins := range diff.ToAdd {
 			emitter.EmitItem(ins.Ref, driverName, "installing", "", fmt.Sprintf("Installing %s", ins.Ref), names[ins.ID])
@@ -227,13 +275,50 @@ func runApplyRealizer(flags ApplyFlags, mf *manifest.Manifest, r realizer.Realiz
 				}
 				successCount++
 			}
-			// Record a Provisioning Generation: the atomic switch committed (full
-			// success advanced the profile generation). Install-only, best-effort.
 			if res.Advanced {
-				writeProvisioningGeneration(runID, driverName, actions, fmt.Sprintf("%d", res.ToGeneration), false)
+				installAdvanced = true
+				installGen = res.ToGeneration
 			}
 		}
 	}
+
+	// --- Phase 2c: Convergence (prune) ---
+	// After install, optionally remove installed-but-undeclared drift from the
+	// engine-managed set. Realizer-only and gated behind --confirm. Element names
+	// removed this run are recorded in the Provisioning Generation below.
+	var removed []string
+	pruneAdvanced := false
+	pruneGen := 0
+	if flags.Prune {
+		pruner, perr := requirePruner(r)
+		if perr != nil {
+			return nil, perr
+		}
+		if !flags.Confirm {
+			// Refuse the destructive prune; the install phase results stand.
+			return nil, envelope.NewError(
+				envelope.ErrInternalError,
+				"convergence (--prune) requires --confirm (it uninstalls undeclared packages)").
+				WithRemediation("Re-run with --prune --confirm, or use --prune --dry-run to preview.")
+		}
+		cur, _ := r.Current()
+		if drift := computeDrift(cur, desired); len(drift) > 0 {
+			pres, _ := pruner.Remove(drift)
+			if pres.Err != nil {
+				if isSystemic(pres.Err.Code) {
+					return nil, realizerEnvelopeError(pres.Err)
+				}
+				return nil, envelope.NewError(envelope.ErrInstallFailed, "Convergence (prune) failed.").
+					WithDetail(map[string]string{"subcode": pres.Err.Subcode, "stage": pres.Err.Stage, "raw": pres.Err.Raw})
+			}
+			removed = drift
+			if pres.Advanced {
+				pruneAdvanced = true
+				pruneGen = pres.ToGeneration
+			}
+		}
+	}
+
 	// Already-present nix packages count as skipped in the apply phase.
 	skippedCount += len(diff.Present)
 
@@ -266,6 +351,19 @@ func runApplyRealizer(flags ApplyFlags, mf *manifest.Manifest, r realizer.Realiz
 	}
 	emitter.EmitSummary("verify", verifyPass+verifyFail, verifyPass, 0, verifyFail)
 
+	// Record one Provisioning Generation reflecting the converged set: refs added
+	// this run and refs removed (pruned) this run. Native = the final advancing
+	// op's generation (prune's if it advanced, else install's). Write only when a
+	// mutating phase advanced a generation; an atomic backend that did not advance
+	// (idempotent re-run / no-op convergence) records nothing.
+	if installAdvanced || pruneAdvanced {
+		finalGen := installGen
+		if pruneAdvanced {
+			finalGen = pruneGen
+		}
+		writeProvisioningGeneration(runID, driverName, actions, removed, fmt.Sprintf("%d", finalGen), failedCount > 0)
+	}
+
 	return &ApplyResult{
 		DryRun:                  false,
 		Manifest:                ApplyManifestRef{Path: flags.Manifest, Name: mf.Name},
@@ -273,5 +371,6 @@ func runApplyRealizer(flags ApplyFlags, mf *manifest.Manifest, r realizer.Realiz
 		Actions:                 actions,
 		ConfigModuleMap:         configModuleMap,
 		RestoreModulesAvailable: restoreModulesAvailable,
+		Pruned:                  removed,
 	}, nil
 }

--- a/go-engine/internal/commands/apply_realizer_test.go
+++ b/go-engine/internal/commands/apply_realizer_test.go
@@ -46,6 +46,20 @@ type fakeRealizer struct {
 	rollbackErr     error                  // scripted Rollback return
 	rollbackCalls   int
 	lastRollbackArg int
+
+	// --- prune / convergence (Phase 5) ---
+	removeResult   realizer.Result // scripted Remove return
+	removeCalls    int
+	lastRemoveArgs []string
+}
+
+// Remove satisfies realizer.Pruner, recording the requested element names and
+// returning the scripted result. Its presence makes *fakeRealizer a Pruner, so
+// the convergence (--prune) path is exercised host-independently.
+func (f *fakeRealizer) Remove(names []string) (realizer.Result, error) {
+	f.removeCalls++
+	f.lastRemoveArgs = names
+	return f.removeResult, nil
 }
 
 // Capabilities satisfies provision.CapabilityReporter so the rollback command can

--- a/go-engine/internal/envelope/errors.go
+++ b/go-engine/internal/envelope/errors.go
@@ -8,23 +8,23 @@ package envelope
 type ErrorCode string
 
 const (
-	ErrManifestNotFound       ErrorCode = "MANIFEST_NOT_FOUND"
-	ErrManifestParseError     ErrorCode = "MANIFEST_PARSE_ERROR"
+	ErrManifestNotFound        ErrorCode = "MANIFEST_NOT_FOUND"
+	ErrManifestParseError      ErrorCode = "MANIFEST_PARSE_ERROR"
 	ErrManifestValidationError ErrorCode = "MANIFEST_VALIDATION_ERROR"
-	ErrManifestWriteFailed    ErrorCode = "MANIFEST_WRITE_FAILED"
-	ErrPlanNotFound           ErrorCode = "PLAN_NOT_FOUND"
-	ErrPlanParseError         ErrorCode = "PLAN_PARSE_ERROR"
-	ErrWingetNotAvailable     ErrorCode = "WINGET_NOT_AVAILABLE"
-	ErrRealizerUnavailable    ErrorCode = "REALIZER_UNAVAILABLE"
-	ErrEngineCLINotFound      ErrorCode = "ENGINE_CLI_NOT_FOUND"
-	ErrCaptureFailed          ErrorCode = "CAPTURE_FAILED"
-	ErrCaptureBlocked         ErrorCode = "CAPTURE_BLOCKED"
-	ErrInstallFailed          ErrorCode = "INSTALL_FAILED"
-	ErrRestoreFailed          ErrorCode = "RESTORE_FAILED"
-	ErrVerifyFailed           ErrorCode = "VERIFY_FAILED"
-	ErrPermissionDenied       ErrorCode = "PERMISSION_DENIED"
-	ErrInternalError          ErrorCode = "INTERNAL_ERROR"
-	ErrSchemaIncompatible     ErrorCode = "SCHEMA_INCOMPATIBLE"
+	ErrManifestWriteFailed     ErrorCode = "MANIFEST_WRITE_FAILED"
+	ErrPlanNotFound            ErrorCode = "PLAN_NOT_FOUND"
+	ErrPlanParseError          ErrorCode = "PLAN_PARSE_ERROR"
+	ErrWingetNotAvailable      ErrorCode = "WINGET_NOT_AVAILABLE"
+	ErrRealizerUnavailable     ErrorCode = "REALIZER_UNAVAILABLE"
+	ErrEngineCLINotFound       ErrorCode = "ENGINE_CLI_NOT_FOUND"
+	ErrCaptureFailed           ErrorCode = "CAPTURE_FAILED"
+	ErrCaptureBlocked          ErrorCode = "CAPTURE_BLOCKED"
+	ErrInstallFailed           ErrorCode = "INSTALL_FAILED"
+	ErrRestoreFailed           ErrorCode = "RESTORE_FAILED"
+	ErrVerifyFailed            ErrorCode = "VERIFY_FAILED"
+	ErrPermissionDenied        ErrorCode = "PERMISSION_DENIED"
+	ErrInternalError           ErrorCode = "INTERNAL_ERROR"
+	ErrSchemaIncompatible      ErrorCode = "SCHEMA_INCOMPATIBLE"
 
 	// Provisioning-generation rollback codes (nix-native-rollback). The package
 	// `rollback` command surfaces these; they are distinct from install/restore
@@ -32,6 +32,11 @@ const (
 	ErrRollbackUnsupported ErrorCode = "ROLLBACK_UNSUPPORTED"
 	ErrGenerationNotFound  ErrorCode = "GENERATION_NOT_FOUND"
 	ErrRollbackFailed      ErrorCode = "ROLLBACK_FAILED"
+
+	// Convergence (apply --prune) error code. Returned when a backend that does
+	// not support whole-set removal (e.g. the winget driver) is asked to prune
+	// installed-but-undeclared packages.
+	ErrConvergenceUnsupported ErrorCode = "CONVERGENCE_UNSUPPORTED"
 
 	// Hosted-backup error codes. Mapped from substrate backend HTTP responses
 	// per docs/contracts/hosted-backup-contract.md and cli-json-contract.md.

--- a/go-engine/internal/realizer/nix/prune.go
+++ b/go-engine/internal/realizer/nix/prune.go
@@ -1,0 +1,59 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package nix
+
+import (
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+// compile-time assertion: the Nix backend implements the optional
+// realizer.Pruner capability, so the apply path can discover convergence
+// eligibility by type-assertion.
+var _ realizer.Pruner = (*Backend)(nil)
+
+// Remove uninstalls the named profile elements in one `nix profile remove`, an
+// atomic generation switch. It is the convergence (prune) half of `apply
+// --prune`: the caller passes the drift set (installed-but-undeclared element
+// names, as they appear in Current().Elements). Remove(nil) is a no-op.
+//
+// It mirrors Realize's contract exactly: it returns (Result, nil) and carries any
+// classified failure in Result.Err (never the second return value), so the apply
+// layer consumes prune and install failures through one code path. Failures are
+// classified through the same anchor table as Realize — spawn/daemon surface
+// REALIZER_UNAVAILABLE, permission PERMISSION_DENIED, anything else INSTALL_FAILED
+// — with raw Nix text confined to Error.Raw (destined for envelope error.detail).
+func (b *Backend) Remove(names []string) (realizer.Result, error) {
+	res := realizer.Result{FromGeneration: -1, ToGeneration: -1}
+	if len(names) == 0 {
+		cur, _ := b.Current()
+		res.After = cur
+		res.FromGeneration, res.ToGeneration = cur.Generation, cur.Generation
+		return res, nil
+	}
+
+	before := b.gen()
+	res.FromGeneration = before
+
+	args := []string{"profile", "remove", "--profile", b.Profile}
+	args = append(args, names...)
+	args = append(args, "--log-format", "internal-json")
+
+	_, stderr, exit, err := b.Run(args...)
+	p := parseInternalJSON(stderr)
+	if err != nil { // spawn failure (binary missing/unrunnable)
+		res.Err = classify(-1, p, false)
+		return res, nil
+	}
+
+	after := b.gen()
+	res.ToGeneration = after
+	res.Advanced = after > before
+	if exit != 0 || !res.Advanced {
+		res.Err = classify(exit, p, res.Advanced)
+	}
+
+	cur, _ := b.Current()
+	res.After = cur
+	return res, nil
+}

--- a/go-engine/internal/realizer/nix/prune_test.go
+++ b/go-engine/internal/realizer/nix/prune_test.go
@@ -1,0 +1,117 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package nix
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// removeRunner scripts a `profile remove` result and captures its args. `list`
+// returns an empty set so Remove's post-op Current() read stays hermetic.
+func removeRunner(stderr []byte, exit int, runErr error, captured *[]string) Runner {
+	return func(args ...string) ([]byte, []byte, int, error) {
+		sub := ""
+		for i, a := range args {
+			if a == "profile" && i+1 < len(args) {
+				sub = args[i+1]
+				break
+			}
+		}
+		switch sub {
+		case "remove":
+			if captured != nil {
+				*captured = append([]string{}, args...)
+			}
+			return nil, stderr, exit, runErr
+		case "list":
+			return []byte(`{"version":3,"elements":{}}`), nil, 0, nil
+		}
+		return nil, nil, 0, nil
+	}
+}
+
+func TestRemove_EmitsProfileRemoveAndAdvances(t *testing.T) {
+	var got []string
+	gen := 0
+	b := &Backend{
+		Profile: "/tmp/endstate-nix-test-nonexistent",
+		Run:     removeRunner(nil, 0, nil, &got),
+		genFn:   func() int { v := gen; gen++; return v }, // 0 (before) -> 1 (after) = advanced
+	}
+	res, err := b.Remove([]string{"ripgrep", "jq"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Err != nil {
+		t.Fatalf("unexpected res.Err: %+v", res.Err)
+	}
+	if !res.Advanced {
+		t.Errorf("expected Advanced=true")
+	}
+	// args: profile remove --profile <p> ripgrep jq --log-format internal-json
+	if len(got) < 6 || got[0] != "profile" || got[1] != "remove" || got[2] != "--profile" {
+		t.Fatalf("unexpected args: %v", got)
+	}
+	if got[4] != "ripgrep" || got[5] != "jq" {
+		t.Fatalf("expected element names after the profile path, got: %v", got)
+	}
+}
+
+func TestRemove_NoOpWhenEmpty(t *testing.T) {
+	var got []string
+	b := &Backend{Profile: "/tmp/endstate-nix-test-nonexistent", Run: removeRunner(nil, 0, nil, &got)}
+	if _, err := b.Remove(nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != nil {
+		t.Fatalf("expected no `profile remove` call, got args: %v", got)
+	}
+}
+
+func TestRemove_PermissionFailureIsSystemic(t *testing.T) {
+	stderr := mkStderr([]struct {
+		level int
+		text  string
+	}{{0, "error: opening lock file: permission denied"}}, nil)
+	b := &Backend{
+		Profile: "/tmp/endstate-nix-test-nonexistent",
+		Run:     removeRunner(stderr, 1, nil, nil),
+		genFn:   func() int { return 0 }, // no advance
+	}
+	res, _ := b.Remove([]string{"ripgrep"})
+	if res.Err == nil || res.Err.Code != envelope.ErrPermissionDenied {
+		t.Fatalf("want PERMISSION_DENIED, got %+v", res.Err)
+	}
+}
+
+func TestRemove_SpawnFailureIsRealizerUnavailable(t *testing.T) {
+	b := &Backend{
+		Profile: "/tmp/endstate-nix-test-nonexistent",
+		Run:     removeRunner(nil, -1, errors.New("exec: nix not found"), nil),
+		genFn:   func() int { return 0 },
+	}
+	res, _ := b.Remove([]string{"ripgrep"})
+	if res.Err == nil || res.Err.Code != envelope.ErrRealizerUnavailable {
+		t.Fatalf("want REALIZER_UNAVAILABLE on spawn, got %+v", res.Err)
+	}
+}
+
+func TestRemove_GenericFailureIsInstallFailed(t *testing.T) {
+	stderr := mkStderr([]struct {
+		level int
+		text  string
+	}{{0, "error: something unexpected happened"}}, nil)
+	b := &Backend{
+		Profile: "/tmp/endstate-nix-test-nonexistent",
+		Run:     removeRunner(stderr, 1, nil, nil),
+		genFn:   func() int { return 0 },
+	}
+	res, _ := b.Remove([]string{"ripgrep"})
+	if res.Err == nil || res.Err.Code != envelope.ErrInstallFailed {
+		t.Fatalf("want INSTALL_FAILED, got %+v", res.Err)
+	}
+}

--- a/go-engine/internal/realizer/realizer.go
+++ b/go-engine/internal/realizer/realizer.go
@@ -86,3 +86,16 @@ type Realizer interface {
 	// failure the prior generation is left intact.
 	Realize(toAdd []Installable) (Result, error)
 }
+
+// Pruner is an OPTIONAL realizer capability: whole-set convergence by removing
+// installed-but-undeclared elements ("drift") from the engine-managed set. It is
+// discovered by type-assertion on a Realizer (like the rollback capability), so
+// backends that cannot safely remove (e.g. shared-system package managers) simply
+// do not implement it and the engine refuses `apply --prune` with
+// CONVERGENCE_UNSUPPORTED. The Nix backend implements it via `nix profile remove`,
+// which advances a profile generation atomically.
+type Pruner interface {
+	// Remove uninstalls the named elements in one atomic operation. names are
+	// element names as they appear in Current().Elements. Remove(nil) is a no-op.
+	Remove(names []string) (Result, error)
+}

--- a/openspec/changes/converge-to-exact-set/design.md
+++ b/openspec/changes/converge-to-exact-set/design.md
@@ -1,0 +1,93 @@
+## Context
+
+Phases 1–4 shipped: Nix/winget install, Provisioning Generation + `generations`, native Unix
+rollback (P3), best-effort winget rollback (P4). `apply` adds only; it never removes undeclared
+packages. The realizer interface is `Name`/`Current`/`Plan(desired)→Diff{ToAdd,Present}`/
+`Realize(toAdd)` — there is **no removal** path, and `Diff` has no `ToRemove`. The Nix backend
+installs into an **isolated, Endstate-managed profile** (`$XDG_STATE_HOME/endstate/nix-profile`),
+so the profile's contents are entirely engine-owned.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Opt-in `apply --prune` that converges the package set to exactly the manifest by removing drift.
+- Unix-first via `nix profile remove` (atomic). `--confirm`-gated; `--dry-run` preview.
+- Reuse `Generation.RemovedRefs` (Phase 4) to record what was pruned.
+- Zero default/Windows regression.
+
+**Non-Goals:**
+- **No winget convergence** — refuse (`CONVERGENCE_UNSUPPORTED`). winget operates on the shared
+  system with untracked dependencies; convergence there is riskier future work.
+- **No config involvement** — package-stage only.
+- **No removal of non-engine packages** — only the Endstate-managed profile is touched.
+
+## Decisions (maintainer, this session)
+
+- **(a) Surface = flag on `apply` (`--prune`).** Convergence is manifest-relative and `apply`
+  already loads the manifest and computes the diff; `--prune` enables the removal half so `apply`
+  becomes truly declarative ("make reality match exactly").
+- **(b) Non-realizer backends hard-refuse** (`CONVERGENCE_UNSUPPORTED`) — explicit, mirrors P4's
+  `ROLLBACK_UNSUPPORTED`.
+- **(c) `--confirm` required** (default refuses); `--dry-run` previews. Honors
+  `non-destructive-defaults`.
+
+## Design
+
+### Drift computation
+
+`desired` = the manifest's host installables (as `apply_realizer` already builds). After install,
+read `Current()`. **Drift** = every `Current().Elements` entry whose name/attrPath leaf matches no
+`desired` ref leaf (reuse `leafAttr`/`presentInSet` matching, inverted). Those element names are
+the prune set. Manual apps and non-host refs are not in the Nix profile, so they are unaffected.
+
+### Removal — `realizer.Pruner` optional interface
+
+```go
+// realizer
+type Pruner interface { Remove(names []string) (Result, error) }
+```
+Discovered by type-assertion (like `Rollbacker`/`Uninstaller`). Nix implements via
+`nix profile remove <name>...` (atomic; advances a profile generation; classified through the
+existing `classify` anchor path). If the realizer is not a `Pruner` → `CONVERGENCE_UNSUPPORTED`.
+Winget path (driver) → `CONVERGENCE_UNSUPPORTED` before doing anything.
+
+### Flow (apply_realizer, prune phase after install)
+
+1. Install phase runs as today (ToAdd).
+2. If `flags.Prune`:
+   - If `--dry-run`: include the computed prune set in the result; remove nothing.
+   - Else if `!--confirm`: refuse with a clear message (install results stand; nothing removed).
+   - Else: compute drift from a fresh `Current()`, `Remove(drift)`. On failure: systemic
+     (`isSystemic`) → top-level envelope error; else `INSTALL_FAILED` with raw text in detail.
+3. Generation: write when `len(added) > 0 || len(removed) > 0`; `AddedRefs`=installed-this-run,
+   `RemovedRefs`=pruned-this-run, `Native`=final nix generation. (Install + remove may advance
+   the Nix profile twice; the engine still records one generation per apply.)
+
+### Error codes
+
+Add `CONVERGENCE_UNSUPPORTED` (non-realizer / non-Pruner backend asked to prune). Removal-step
+failures reuse the realizer classification (`REALIZER_UNAVAILABLE`/`PERMISSION_DENIED` systemic;
+else `INSTALL_FAILED`). No other new codes.
+
+### Ordering note
+
+Install-then-prune (not prune-then-install): never remove before the desired set is in place.
+Both orders reach the same end state; install-first is safer on partial failure.
+
+## Separation of concerns
+
+Package-stage only. The prune phase touches the realizer + `internal/provision` only — never
+restore, `state/backups/`, or the revert journal. Covered by the existing install-stage
+separation invariants; no `separation-of-concerns` delta needed.
+
+## Risks / limitations
+
+- Two Nix generation advances per `apply --prune` (add, then remove) but one engine Provisioning
+  Generation — `Native` records the final nix gen. Documented.
+- A package shared between the old and new manifest is declared in both → not drift → kept. Good.
+- winget convergence deferred (shared-system orphan/dependency risk) — refused, not silently
+  skipped.
+
+## Migration
+
+Additive. No manifest/envelope schema bump (reuses `RemovedRefs`). Default `apply` unchanged.

--- a/openspec/changes/converge-to-exact-set/proposal.md
+++ b/openspec/changes/converge-to-exact-set/proposal.md
@@ -1,0 +1,78 @@
+## Why
+
+Phases 1–4 give the engine a unified package model: Nix/winget install (P1/P2), a numbered
+Provisioning Generation (P2), native Unix rollback (P3), and best-effort winget rollback (P4).
+But `apply` only ever **adds** — it installs declared packages and leaves undeclared ones
+untouched (`non-destructive-defaults`: "Apply does not remove unlisted packages"). So the
+declarative ideal is half-complete: **drift** accumulates — packages the engine installed for a
+past manifest but that are no longer declared linger forever.
+
+This change is **Phase 5 — convergence-to-exact-set**: an **opt-in**, `--confirm`-gated
+`apply --prune` that converges the package set to *exactly* the declared manifest by
+uninstalling drift. **Unix-first** (the Nix realizer, via `nix profile remove`): because Nix
+installs into an **Endstate-managed, isolated profile**, "drift" is unambiguous and safe to
+remove — every element in that profile was put there by Endstate, so pruning only removes what
+the engine itself installed and the manifest no longer declares. Non-realizer backends (winget
+on Windows) **hard-refuse** with `CONVERGENCE_UNSUPPORTED` — winget operates on the shared
+system with untracked dependencies, so convergence there is riskier future work.
+
+Default `apply` behavior is **unchanged**: without `--prune` nothing is ever removed. This keeps
+`non-destructive-defaults` intact and makes removal a deliberate, confirmed opt-in.
+
+## What Changes
+
+- Add a **`--prune`** flag to `apply`. On the realizer (Nix) path, after the install phase it
+  computes **drift** = installed profile elements that match no declared host installable, and
+  removes them via a new realizer removal path. Requires `--confirm`; `--dry-run` previews the
+  prune set without removing anything.
+- Add an optional **`realizer.Pruner`** interface (`Remove(names []string) (Result, error)`),
+  discovered by type-assertion like the other optional capabilities. The Nix backend implements
+  it via `nix profile remove <name>` (atomic — advances a profile generation). A realizer that
+  does not implement it, or the **winget driver path**, refuses `--prune` with
+  `CONVERGENCE_UNSUPPORTED`.
+- The converged `apply` writes one Provisioning Generation reflecting the final set: `addedRefs`
+  (installed this run) **and** `removedRefs` (pruned this run) — **reusing the
+  `Generation.RemovedRefs` field added in Phase 4**. A generation is written when anything was
+  added **or** removed.
+- Add the additive error code **`CONVERGENCE_UNSUPPORTED`** (removal-step failures reuse the
+  realizer classification: systemic `REALIZER_UNAVAILABLE`/`PERMISSION_DENIED`, else
+  `INSTALL_FAILED`).
+- Safety: convergence touches **only the Endstate-managed Nix profile** — never system-wide
+  packages, never config (`state/backups/`, the revert journal, restore are untouched).
+
+## Capabilities
+
+### New Capabilities
+
+- `converge-to-exact-set`: `apply --prune --confirm` converges the package set to exactly the
+  declared manifest by uninstalling drift (installed-but-undeclared) from the engine-managed
+  package set. Realizer-only (Nix today); non-realizer backends refuse. `--dry-run` previews;
+  the converged apply records both added and removed refs in one Provisioning Generation.
+
+### Modified Capabilities
+
+- `non-destructive-defaults`: **ADDS** a requirement ("Convergence is opt-in and confirmed")
+  affirming that default `apply` removes nothing and that pruning requires both `--prune` and
+  `--confirm`. This is an **ADDED requirement** (a new, distinct requirement name), NOT a
+  modification of the existing *No Silent Deletions* / *Destructive Operations Require Explicit
+  Flags* requirements — so it composes cleanly with any concurrent change and does not weaken
+  the default-safe guarantee.
+
+## Impact
+
+- `internal/realizer/realizer.go` — add the `Pruner` optional interface.
+- `internal/realizer/nix/prune.go` (new) — `Remove(names)` via `nix profile remove`; classified
+  via the existing anchor path. Real-nix removal smoke verifiable on this box.
+- `internal/commands/apply_realizer.go` — a prune phase after install (gated on `--prune` +
+  `--confirm`; `--dry-run` previews); drift = `Current` ∖ desired; record `removedRefs`.
+- `internal/commands/apply.go` (driver path) — `--prune` → `CONVERGENCE_UNSUPPORTED`.
+- `internal/commands/apply_generation.go` — write a generation when added **or** removed; carry
+  `RemovedRefs`.
+- `internal/envelope/errors.go` — `ErrConvergenceUnsupported = "CONVERGENCE_UNSUPPORTED"`.
+- `cmd/endstate/main.go` — **PROTECTED (maintainer-approved, additive)**: parse `--prune`, pass
+  it through `ApplyFlags`; usage line.
+- `docs/contracts/cli-json-contract.md` — **PROTECTED (maintainer-approved, additive)**: document
+  `apply --prune` (prune actions in the result + `CONVERGENCE_UNSUPPORTED`).
+- **Zero Windows / default regression**: default `apply` is byte-identical; `apply --prune` on
+  Windows refuses cleanly. Proven by host-aware tests + `GOOS=windows` build/vet; real-nix prune
+  smoke on this box.

--- a/openspec/changes/converge-to-exact-set/specs/converge-to-exact-set/spec.md
+++ b/openspec/changes/converge-to-exact-set/specs/converge-to-exact-set/spec.md
@@ -1,0 +1,66 @@
+## ADDED Requirements
+
+### Requirement: Convergence prunes undeclared packages
+
+The engine SHALL provide an opt-in convergence mode (`apply --prune`) that, after installing the declared packages, removes packages that are installed in the engine-managed package set but are not declared by the manifest — converging the package set to exactly the declared set. Convergence operates only on the engine-managed package set; it SHALL NOT remove system-wide packages the engine did not install.
+
+#### Scenario: Prune removes installed-but-undeclared packages
+
+- **WHEN** `apply --prune --confirm` runs on a backend that supports convergence and the engine-managed package set contains packages not present in the manifest
+- **THEN** the engine SHALL uninstall those undeclared packages
+- **AND** packages that are declared in the manifest SHALL remain installed
+
+#### Scenario: Prune touches only the engine-managed set
+
+- **WHEN** convergence runs
+- **THEN** it SHALL only remove packages from the engine-managed package set
+- **AND** it SHALL NOT remove packages the engine did not install
+
+#### Scenario: Default apply never prunes
+
+- **WHEN** `apply` runs without `--prune`
+- **THEN** the engine SHALL NOT remove any package
+- **AND** undeclared installed packages SHALL be left untouched
+
+### Requirement: Convergence requires explicit confirmation
+
+Because it uninstalls packages, convergence SHALL require an explicit confirmation flag, with a preview available without it.
+
+#### Scenario: Prune without confirmation refuses
+
+- **WHEN** `apply --prune` runs without the confirmation flag and not in preview mode
+- **THEN** the engine SHALL refuse to prune and SHALL NOT remove any package
+- **AND** it SHALL report how to re-run with confirmation
+- **AND** the install phase behavior SHALL be unaffected by the refusal
+
+#### Scenario: Preview lists what would be pruned without mutating
+
+- **WHEN** `apply --prune --dry-run` runs
+- **THEN** the engine SHALL report the packages it would prune without removing them
+- **AND** it SHALL NOT require the confirmation flag
+
+### Requirement: Convergence is supported only on capable backends
+
+Convergence SHALL be available only on backends that support whole-set removal (the Nix realizer today). A backend that does not support convergence SHALL refuse a prune request with a stable error and change nothing.
+
+#### Scenario: Non-supporting backend refuses to prune
+
+- **WHEN** `apply --prune` runs on a backend that does not support convergence (for example, the winget driver)
+- **THEN** the engine SHALL return a stable error
+- **AND** it SHALL NOT install, uninstall, or otherwise modify the package set
+
+### Requirement: Convergence records the converged generation
+
+After a convergence that changes the package set, the engine SHALL write a Provisioning Generation that records both the packages added and the packages removed this run, so the history reflects the converged set.
+
+#### Scenario: Converged apply records added and removed refs
+
+- **WHEN** `apply --prune --confirm` installs at least one package and/or removes at least one package
+- **THEN** the engine SHALL write a Provisioning Generation
+- **AND** it SHALL record the packages installed this run as added references
+- **AND** it SHALL record the packages pruned this run as removed references
+
+#### Scenario: No-op convergence writes no generation
+
+- **WHEN** `apply --prune --confirm` neither installs nor removes any package (the set already matches the manifest)
+- **THEN** no new Provisioning Generation SHALL be written

--- a/openspec/changes/converge-to-exact-set/specs/non-destructive-defaults/spec.md
+++ b/openspec/changes/converge-to-exact-set/specs/non-destructive-defaults/spec.md
@@ -1,0 +1,23 @@
+## ADDED Requirements
+
+### Requirement: Convergence is opt-in and confirmed
+
+Removal of undeclared (drift) packages via convergence SHALL require an explicit opt-in flag (`--prune`) AND explicit confirmation (`--confirm`). This is a new, distinct requirement that does not relax the default-safe guarantees: without `--prune`, `apply` removes nothing.
+
+#### Scenario: Default apply removes nothing
+
+- **WHEN** `apply` runs without `--prune`
+- **THEN** no package SHALL be uninstalled
+- **AND** undeclared installed packages SHALL be left untouched
+
+#### Scenario: Convergence is not inferred from the manifest
+
+- **WHEN** `apply` is run without `--prune` against a manifest that declares fewer packages than are installed
+- **THEN** the engine SHALL NOT infer removal intent from the manifest
+- **AND** no package SHALL be uninstalled
+
+#### Scenario: Prune requires both opt-in and confirmation
+
+- **WHEN** `apply --prune` runs without `--confirm` and not in preview mode
+- **THEN** the engine SHALL NOT uninstall any package
+- **AND** removal SHALL proceed only when both `--prune` and `--confirm` are present

--- a/openspec/changes/converge-to-exact-set/tasks.md
+++ b/openspec/changes/converge-to-exact-set/tasks.md
@@ -5,67 +5,67 @@
 
 ## 0. Gate
 
-- [ ] 0.1 `npm run openspec:validate` (strict) passes for this change
-- [ ] 0.2 **PAUSE for maintainer review of this spec** before any Go is written
+- [x] 0.1 `npm run openspec:validate` (strict) passes for this change
+- [x] 0.2 **PAUSE for maintainer review of this spec** before any Go is written
 
 ## 1. `realizer.Pruner` + Nix `Remove`
 
-- [ ] 1.1 `internal/realizer/realizer.go`: add optional `Pruner` interface
+- [x] 1.1 `internal/realizer/realizer.go`: add optional `Pruner` interface
       (`Remove(names []string) (Result, error)`)
-- [ ] 1.2 RED tests (`internal/realizer/nix/prune_test.go`, injected `Runner`): `Remove([a,b])`
+- [x] 1.2 RED tests (`internal/realizer/nix/prune_test.go`, injected `Runner`): `Remove([a,b])`
       emits `profile remove --profile <p> a b`; advance → success; non-zero/spawn → classified
       `*realizer.Error` (REALIZER_UNAVAILABLE on spawn/daemon)
-- [ ] 1.3 `internal/realizer/nix/prune.go`: `Remove(names)` via `nix profile remove`; classify
+- [x] 1.3 `internal/realizer/nix/prune.go`: `Remove(names)` via `nix profile remove`; classify
       via the existing anchor path; compile-time assert `*nix.Backend` satisfies `realizer.Pruner`
 
 ## 2. Error code
 
-- [ ] 2.1 `internal/envelope/errors.go`: `ErrConvergenceUnsupported = "CONVERGENCE_UNSUPPORTED"`
+- [x] 2.1 `internal/envelope/errors.go`: `ErrConvergenceUnsupported = "CONVERGENCE_UNSUPPORTED"`
 
 ## 3. apply `--prune` — realizer path
 
-- [ ] 3.1 `ApplyFlags.Prune bool`; thread through `RunApply` → `runApplyRealizer`
-- [ ] 3.2 Drift = `Current().Elements` whose leaf matches no desired ref leaf (invert
+- [x] 3.1 `ApplyFlags.Prune bool`; thread through `RunApply` → `runApplyRealizer`
+- [x] 3.2 Drift = `Current().Elements` whose leaf matches no desired ref leaf (invert
       `presentInSet`)
-- [ ] 3.3 `--dry-run` → include prune set in result, remove nothing; `--prune && !--confirm &&
+- [x] 3.3 `--dry-run` → include prune set in result, remove nothing; `--prune && !--confirm &&
       !--dry-run` → refuse (install results stand, nothing removed)
-- [ ] 3.4 `--prune && --confirm` → `Remove(drift)`; systemic → top-level envelope error; else
+- [x] 3.4 `--prune && --confirm` → `Remove(drift)`; systemic → top-level envelope error; else
       `INSTALL_FAILED` (raw text in detail)
-- [ ] 3.5 If realizer is not a `Pruner` → `CONVERGENCE_UNSUPPORTED`
+- [x] 3.5 If realizer is not a `Pruner` → `CONVERGENCE_UNSUPPORTED`
 
 ## 4. apply `--prune` — driver (winget) path refuses
 
-- [ ] 4.1 `internal/commands/apply.go`: `--prune` on the driver path → `CONVERGENCE_UNSUPPORTED`,
+- [x] 4.1 `internal/commands/apply.go`: `--prune` on the driver path → `CONVERGENCE_UNSUPPORTED`,
       change nothing
 
 ## 5. Generation records added + removed
 
-- [ ] 5.1 `apply_generation.go`: write a generation when `added>0 || removed>0`; populate
+- [x] 5.1 `apply_generation.go`: write a generation when `added>0 || removed>0`; populate
       `RemovedRefs` (reuse Phase-4 field); `Native`=final nix gen
-- [ ] 5.2 RED test: converged apply (install 1, prune 1) → one generation with both `addedRefs`
+- [x] 5.2 RED test: converged apply (install 1, prune 1) → one generation with both `addedRefs`
       and `removedRefs`; no-op convergence → no generation
 
 ## 6. Command tests (host-aware)
 
-- [ ] 6.1 `fakeRealizer` gains `Remove` (+ scripted result, captured args); a non-Pruner realizer
+- [x] 6.1 `fakeRealizer` gains `Remove` (+ scripted result, captured args); a non-Pruner realizer
       stub for the unsupported case
-- [ ] 6.2 `apply --prune --confirm` removes drift; `--dry-run` previews, removes nothing;
+- [x] 6.2 `apply --prune --confirm` removes drift; `--dry-run` previews, removes nothing;
       `--prune` without `--confirm` refuses, install unaffected
-- [ ] 6.3 Non-realizer (driver) `--prune` → `CONVERGENCE_UNSUPPORTED`
-- [ ] 6.4 Default `apply` (no `--prune`) removes nothing — `Remove` never called
-- [ ] 6.5 Guard: prune path does not import `internal/restore`
+- [x] 6.3 Non-realizer (driver) `--prune` → `CONVERGENCE_UNSUPPORTED`
+- [x] 6.4 Default `apply` (no `--prune`) removes nothing — `Remove` never called
+- [x] 6.5 Guard: prune path does not import `internal/restore`
 
 ## 7. Dispatch + usage + contract (PROTECTED — maintainer-approved, additive)
 
-- [ ] 7.1 `cmd/endstate/main.go`: parse `--prune` → `ApplyFlags.Prune`; usage line
-- [ ] 7.2 `docs/contracts/cli-json-contract.md`: document `apply --prune` (prune actions in the
+- [x] 7.1 `cmd/endstate/main.go`: parse `--prune` → `ApplyFlags.Prune`; usage line
+- [x] 7.2 `docs/contracts/cli-json-contract.md`: document `apply --prune` (prune actions in the
       result + `CONVERGENCE_UNSUPPORTED`)
 
 ## 8. Verification
 
-- [ ] 8.1 `cd go-engine && go test ./...` green on Linux
-- [ ] 8.2 `GOOS=windows go build ./...` + `go vet ./...` clean
-- [ ] 8.3 `npm run openspec:validate` (strict) passes
-- [ ] 8.4 Real-nix prune smoke: apply [jq,ripgrep] → gen; apply [jq] `--prune --confirm` →
+- [x] 8.1 `cd go-engine && go test ./...` green on Linux
+- [x] 8.2 `GOOS=windows go build ./...` + `go vet ./...` clean
+- [x] 8.3 `npm run openspec:validate` (strict) passes
+- [x] 8.4 Real-nix prune smoke: apply [jq,ripgrep] → gen; apply [jq] `--prune --confirm` →
       ripgrep removed, `nix profile list` shows only jq, generation records `removedRefs`;
       `--prune` without `--confirm` refuses; default apply removes nothing

--- a/openspec/changes/converge-to-exact-set/tasks.md
+++ b/openspec/changes/converge-to-exact-set/tasks.md
@@ -1,0 +1,71 @@
+> TDD: write each test RED first, then implement to green. Hermetic + host-aware (inject
+> `newRealizerFn`/`newDriverFn`; key fixtures by `runtime.GOOS`). Verify: `cd go-engine && go
+> test ./...` (Linux) + `GOOS=windows go build ./...` + `go vet`. Real-nix prune smoke is
+> runnable on this WSL box.
+
+## 0. Gate
+
+- [ ] 0.1 `npm run openspec:validate` (strict) passes for this change
+- [ ] 0.2 **PAUSE for maintainer review of this spec** before any Go is written
+
+## 1. `realizer.Pruner` + Nix `Remove`
+
+- [ ] 1.1 `internal/realizer/realizer.go`: add optional `Pruner` interface
+      (`Remove(names []string) (Result, error)`)
+- [ ] 1.2 RED tests (`internal/realizer/nix/prune_test.go`, injected `Runner`): `Remove([a,b])`
+      emits `profile remove --profile <p> a b`; advance → success; non-zero/spawn → classified
+      `*realizer.Error` (REALIZER_UNAVAILABLE on spawn/daemon)
+- [ ] 1.3 `internal/realizer/nix/prune.go`: `Remove(names)` via `nix profile remove`; classify
+      via the existing anchor path; compile-time assert `*nix.Backend` satisfies `realizer.Pruner`
+
+## 2. Error code
+
+- [ ] 2.1 `internal/envelope/errors.go`: `ErrConvergenceUnsupported = "CONVERGENCE_UNSUPPORTED"`
+
+## 3. apply `--prune` — realizer path
+
+- [ ] 3.1 `ApplyFlags.Prune bool`; thread through `RunApply` → `runApplyRealizer`
+- [ ] 3.2 Drift = `Current().Elements` whose leaf matches no desired ref leaf (invert
+      `presentInSet`)
+- [ ] 3.3 `--dry-run` → include prune set in result, remove nothing; `--prune && !--confirm &&
+      !--dry-run` → refuse (install results stand, nothing removed)
+- [ ] 3.4 `--prune && --confirm` → `Remove(drift)`; systemic → top-level envelope error; else
+      `INSTALL_FAILED` (raw text in detail)
+- [ ] 3.5 If realizer is not a `Pruner` → `CONVERGENCE_UNSUPPORTED`
+
+## 4. apply `--prune` — driver (winget) path refuses
+
+- [ ] 4.1 `internal/commands/apply.go`: `--prune` on the driver path → `CONVERGENCE_UNSUPPORTED`,
+      change nothing
+
+## 5. Generation records added + removed
+
+- [ ] 5.1 `apply_generation.go`: write a generation when `added>0 || removed>0`; populate
+      `RemovedRefs` (reuse Phase-4 field); `Native`=final nix gen
+- [ ] 5.2 RED test: converged apply (install 1, prune 1) → one generation with both `addedRefs`
+      and `removedRefs`; no-op convergence → no generation
+
+## 6. Command tests (host-aware)
+
+- [ ] 6.1 `fakeRealizer` gains `Remove` (+ scripted result, captured args); a non-Pruner realizer
+      stub for the unsupported case
+- [ ] 6.2 `apply --prune --confirm` removes drift; `--dry-run` previews, removes nothing;
+      `--prune` without `--confirm` refuses, install unaffected
+- [ ] 6.3 Non-realizer (driver) `--prune` → `CONVERGENCE_UNSUPPORTED`
+- [ ] 6.4 Default `apply` (no `--prune`) removes nothing — `Remove` never called
+- [ ] 6.5 Guard: prune path does not import `internal/restore`
+
+## 7. Dispatch + usage + contract (PROTECTED — maintainer-approved, additive)
+
+- [ ] 7.1 `cmd/endstate/main.go`: parse `--prune` → `ApplyFlags.Prune`; usage line
+- [ ] 7.2 `docs/contracts/cli-json-contract.md`: document `apply --prune` (prune actions in the
+      result + `CONVERGENCE_UNSUPPORTED`)
+
+## 8. Verification
+
+- [ ] 8.1 `cd go-engine && go test ./...` green on Linux
+- [ ] 8.2 `GOOS=windows go build ./...` + `go vet ./...` clean
+- [ ] 8.3 `npm run openspec:validate` (strict) passes
+- [ ] 8.4 Real-nix prune smoke: apply [jq,ripgrep] → gen; apply [jq] `--prune --confirm` →
+      ripgrep removed, `nix profile list` shows only jq, generation records `removedRefs`;
+      `--prune` without `--confirm` refuses; default apply removes nothing


### PR DESCRIPTION
## Summary

Phase 5 of the cross-OS provisioning effort: opt-in **whole-set convergence**. `apply --prune` removes installed-but-undeclared packages ("drift") after the install phase, so the engine-managed set matches the manifest **exactly**.

- **Realizer-only** (Nix on Linux/macOS), discovered by type-asserting the new optional `realizer.Pruner` capability (same pattern as native rollback).
- **Gated behind `--confirm`** — destructive removal never happens implicitly. The winget driver and any non-Pruner backend refuse with `CONVERGENCE_UNSUPPORTED`, changing nothing.
- **`--prune --dry-run`** previews the would-be-pruned set (`data.pruned`) without mutating anything and without requiring `--confirm`.
- One **Provisioning Generation** records the converged set: `addedRefs` (installed this run) **and** `removedRefs` (pruned this run), with `native` = the final advancing generation.

## Changes

- `internal/realizer`: optional `Pruner` interface; Nix `Remove` via `nix profile remove` (atomic generation switch), classified through the existing anchor table (spawn/daemon → `REALIZER_UNAVAILABLE`, permission → `PERMISSION_DENIED`, else `INSTALL_FAILED`; raw Nix text confined to `error.detail`).
- `internal/commands/apply`: drift computation (inverse of `presentInSet` on leaf attrs), `--prune`/`--confirm`/`--dry-run` handling, advancement-tracked generation write.
- `internal/envelope`: `CONVERGENCE_UNSUPPORTED` error code.
- `cmd/endstate/main.go`: parse `--prune`; apply usage + `--confirm` help lines.
- `docs/contracts/cli-json-contract.md`: `apply --prune` convergence section + error-code row.

## Tests

- Nix `Remove` classification (success/no-op/permission/spawn/generic).
- Host-aware command-level prune behavior: converged apply (install **+** prune → one generation with both added & removed refs), no-op convergence → no generation, dry-run preview, refuse-without-confirm, default-apply-never-removes.
- Driver-path `--prune` → `CONVERGENCE_UNSUPPORTED` (overrides **both** realizer and driver seams so windows-latest CI exercises the driver fork).
- Import guard: the prune path stays package-stage only (no `internal/restore`).

## Verification

- `go test ./...` (Linux) — green
- `GOOS=windows go build ./...` + `go vet ./...` — clean
- `npm run openspec:validate` (strict) — 56/56
- **Real-nix prune smoke** on an isolated profile: install `[jq, ripgrep]` → gen 1; `--prune` without `--confirm` refuses (profile unchanged); default apply leaves drift; `--prune --confirm` removes ripgrep → profile converges to jq-only, gen 2 records `removedRefs=[ripgrep]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
