### PR TITLE
feat(engine): Windows version capture + pinning (Phase 6)

### DIFF
--- a/docs/ai/AI_CONTRACT.md
+++ b/docs/ai/AI_CONTRACT.md
@@ -172,7 +172,7 @@ Breaking changes bump the major version (once past 1.0). Signal them with:
 
 1. **Not enterprise configuration management** — this is a personal/small-team tool
 2. **No cross-platform parity yet** — Windows/winget is primary; Linux/macOS is future work
-3. **No package version pinning** — MVP does not compare or pin versions
+3. **No automatic version management** — the engine never compares installed versions, enforces version drift, or pins versions on its own. Version pinning is **explicit and opt-in**: a package is installed at a specific version only when the manifest declares `version` for that app, and only on a backend that supports versioned install (the winget driver; the Nix realizer pins via its ref and ignores the field). The installed version is recorded best-effort in the Provisioning Generation. The engine never downgrades or reinstalls an already-present package to match a declared version (pin-on-install only).
 4. **No automatic rollback** — failed operations do not auto-rollback. All rollback is explicit and opt-in: manual `revert` reverses a restore (configuration), and the manual, `--confirm`-gated `rollback` command reverts the package set to a prior provisioning generation on backends that support it (Nix). Neither runs automatically.
 5. **No GUI business logic** — GUI must not contain provisioning logic; CLI is source of truth
 6. **No GUI-driven installation of manual apps** — manual apps surface instructions only; the GUI never triggers installs for them

--- a/docs/contracts/cli-json-contract.md
+++ b/docs/contracts/cli-json-contract.md
@@ -360,6 +360,21 @@ The recorded Provisioning Generation reflects the converged set: `addedRefs` for
 ```json
 ```
 
+### Version capture and pinning (winget)
+
+On the winget backend, each Provisioning Generation item records the installed `version` of the package, captured from `winget list` (best-effort — empty when winget exposes none). The Nix realizer pins exact versions through its ref, so nix generations leave `version` empty.
+
+A manifest app MAY declare a `version` to **pin** the install:
+
+```jsonc
+{ "id": "vscode", "version": "1.89.0", "refs": { "windows": "Microsoft.VisualStudioCode" } }
+```
+
+- When `version` is declared, the winget backend installs that exact version (`winget install --version`). The recorded generation item carries the pinned `version`.
+- Pinning is **pin-on-install only**: a package already installed at a different version is left untouched (reported `present`); the engine never downgrades, upgrades, or reinstalls to match the declared version.
+- If the declared version is unavailable, that package fails as `INSTALL_FAILED` (the requested version appears in the message); no other version is installed in its place. Other packages in the run are unaffected.
+- Pinning applies only to backends that support versioned install (winget). The Nix realizer ignores `version` (it pins via its ref); this is not an error.
+
 ---
 
 ## Command: `verify`

--- a/go-engine/internal/commands/apply.go
+++ b/go-engine/internal/commands/apply.go
@@ -115,6 +115,7 @@ type ApplyAction struct {
 	Status  string              `json:"status"`
 	Reason  string              `json:"reason,omitempty"`
 	Message string              `json:"message,omitempty"`
+	Version string              `json:"version,omitempty"` // installed/pinned version (best-effort; winget path)
 	Manual  *manifest.ManualApp `json:"manual"`
 }
 
@@ -281,9 +282,11 @@ func RunApply(flags ApplyFlags) (interface{}, *envelope.Error) {
 		// Winget app: detect via driver (use batch results if available).
 		var installed bool
 		var displayName string
+		var version string // best-effort installed version captured from the batch
 		if br, ok := batchResults[ref]; ok {
 			installed = br.Installed
 			displayName = br.DisplayName
+			version = br.Version
 		} else {
 			installed, displayName, _ = d.Detect(ref)
 		}
@@ -296,6 +299,7 @@ func RunApply(flags ApplyFlags) (interface{}, *envelope.Error) {
 		action.Ref = stringPtr(ref)
 		action.Driver = d.Name()
 		action.Name = itemName
+		action.Version = version // captured installed version for present packages
 
 		if installed {
 			action.Status = "present"
@@ -355,7 +359,16 @@ func RunApply(flags ApplyFlags) (interface{}, *envelope.Error) {
 
 			emitter.EmitItem(entry.ref, d.Name(), "installing", "", fmt.Sprintf("Installing %s", entry.ref), entry.displayName)
 
-			result, installErr := d.Install(entry.ref)
+			// Honor a declared version (pin-on-install) when the driver supports
+			// versioned installation; otherwise install the latest, as before.
+			pinned := entry.app.Version != ""
+			var result *driver.InstallResult
+			var installErr error
+			if vi, ok := d.(driver.VersionedInstaller); ok && pinned {
+				result, installErr = vi.InstallVersion(entry.ref, entry.app.Version)
+			} else {
+				result, installErr = d.Install(entry.ref)
+			}
 			if installErr != nil {
 				// Infrastructure failure (e.g. winget not available).
 				finalActions[i].Status = driver.StatusFailed
@@ -370,6 +383,11 @@ func RunApply(flags ApplyFlags) (interface{}, *envelope.Error) {
 
 			switch result.Status {
 			case driver.StatusInstalled:
+				if pinned {
+					// The pinned version is now the committed version; record it
+					// (winget exposes no version on install for the unpinned path).
+					finalActions[i].Version = entry.app.Version
+				}
 				emitter.EmitItem(entry.ref, d.Name(), "installed", "", result.Message, entry.displayName)
 				successCount++
 			case driver.StatusPresent:

--- a/go-engine/internal/commands/apply_generation.go
+++ b/go-engine/internal/commands/apply_generation.go
@@ -25,10 +25,10 @@ func writeProvisioningGeneration(runID, backend string, actions []ApplyAction, r
 		switch a.Status {
 		case "installed":
 			ref := derefRef(a.Ref)
-			items = append(items, provision.ProvItem{ID: a.ID, Ref: ref, Status: "installed"})
+			items = append(items, provision.ProvItem{ID: a.ID, Ref: ref, Status: "installed", Version: a.Version})
 			added = append(added, ref)
 		case "present":
-			items = append(items, provision.ProvItem{ID: a.ID, Ref: derefRef(a.Ref), Status: "present"})
+			items = append(items, provision.ProvItem{ID: a.ID, Ref: derefRef(a.Ref), Status: "present", Version: a.Version})
 		}
 	}
 	if len(added) == 0 && len(removed) == 0 {

--- a/go-engine/internal/commands/apply_version_test.go
+++ b/go-engine/internal/commands/apply_version_test.go
@@ -1,0 +1,183 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/driver"
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/manifest"
+	"github.com/Artexis10/endstate/go-engine/internal/provision"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+// writeManifest writes content to a temp manifest file and returns its path.
+func writeManifest(t *testing.T, content string) string {
+	t.Helper()
+	p := filepath.Join(t.TempDir(), "m.jsonc")
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+// provItem finds a generation item by app ID.
+func provItem(t *testing.T, items []provision.ProvItem, id string) provision.ProvItem {
+	t.Helper()
+	for _, it := range items {
+		if it.ID == id {
+			return it
+		}
+	}
+	t.Fatalf("no generation item for id %q in %+v", id, items)
+	return provision.ProvItem{}
+}
+
+// Capture: a present package's installed version is recorded in the generation.
+// (A second app is installed so a generation is actually written — a present-only
+// run records none.)
+func TestRunApply_DriverPath_CapturesVersion(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	md := &mockDriver{
+		installed: map[string]bool{"Vendor.A": true},      // present
+		versions:  map[string]string{"Vendor.A": "3.4.5"}, // captured version
+	}
+	mPath := writeManifest(t, `{
+		"name": "capture-test",
+		"apps": [
+			{ "id": "a", "refs": { "windows": "Vendor.A" } },
+			{ "id": "b", "refs": { "windows": "Vendor.B" } }
+		]
+	}`)
+
+	var eerr *envelope.Error
+	withMockDriver(md, func() { _, eerr = RunApply(ApplyFlags{Manifest: mPath}) })
+	if eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+
+	gens, _ := provision.List()
+	if len(gens) != 1 {
+		t.Fatalf("want 1 generation, got %d", len(gens))
+	}
+	if v := provItem(t, gens[0].Items, "a").Version; v != "3.4.5" {
+		t.Fatalf("present item version = %q, want 3.4.5 (captured)", v)
+	}
+}
+
+// Pinning: a declared App.Version installs that exact version via InstallVersion
+// and the generation records it.
+func TestRunApply_DriverPath_PinsDeclaredVersion(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	md := &mockDriver{installed: map[string]bool{}}
+	mPath := writeManifest(t, `{
+		"name": "pin-test",
+		"apps": [
+			{ "id": "a", "version": "1.2.0", "refs": { "windows": "Vendor.A" } }
+		]
+	}`)
+
+	var eerr *envelope.Error
+	withMockDriver(md, func() { _, eerr = RunApply(ApplyFlags{Manifest: mPath}) })
+	if eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+
+	if md.installVersionCalls != 1 || md.lastInstallVersion != "1.2.0" {
+		t.Fatalf("InstallVersion calls=%d lastVersion=%q, want 1 / 1.2.0", md.installVersionCalls, md.lastInstallVersion)
+	}
+	if md.installCalls != 0 {
+		t.Fatalf("plain Install called %d times, want 0 (pinned)", md.installCalls)
+	}
+	gens, _ := provision.List()
+	if len(gens) != 1 {
+		t.Fatalf("want 1 generation, got %d", len(gens))
+	}
+	if v := provItem(t, gens[0].Items, "a").Version; v != "1.2.0" {
+		t.Fatalf("installed item version = %q, want 1.2.0 (pinned)", v)
+	}
+}
+
+// No declared version installs the latest via plain Install (no pinning).
+func TestRunApply_DriverPath_NoVersion_InstallsLatest(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	md := &mockDriver{installed: map[string]bool{}}
+	mPath := writeManifest(t, `{
+		"name": "latest-test",
+		"apps": [ { "id": "a", "refs": { "windows": "Vendor.A" } } ]
+	}`)
+
+	var eerr *envelope.Error
+	withMockDriver(md, func() { _, eerr = RunApply(ApplyFlags{Manifest: mPath}) })
+	if eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+	if md.installCalls != 1 || md.installVersionCalls != 0 {
+		t.Fatalf("Install=%d InstallVersion=%d, want 1 / 0 (no pin)", md.installCalls, md.installVersionCalls)
+	}
+}
+
+// An unavailable pinned version fails the item as install_failed; nothing else
+// is installed in its place.
+func TestRunApply_DriverPath_UnavailablePin_Fails(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	md := &mockDriver{
+		installed: map[string]bool{},
+		installVersionResult: &driver.InstallResult{
+			Status:  driver.StatusFailed,
+			Reason:  driver.ReasonInstallFailed,
+			Message: "winget exited with code 1 (requested version 9.9.9)",
+		},
+	}
+	mPath := writeManifest(t, `{
+		"name": "pin-unavailable",
+		"apps": [ { "id": "a", "version": "9.9.9", "refs": { "windows": "Vendor.A" } } ]
+	}`)
+
+	var raw interface{}
+	var eerr *envelope.Error
+	withMockDriver(md, func() { raw, eerr = RunApply(ApplyFlags{Manifest: mPath}) })
+	if eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+	if md.installVersionCalls != 1 || md.lastInstallVersion != "9.9.9" {
+		t.Fatalf("InstallVersion calls=%d version=%q, want 1 / 9.9.9", md.installVersionCalls, md.lastInstallVersion)
+	}
+	result := raw.(*ApplyResult)
+	if result.Summary.Failed != 1 {
+		t.Fatalf("Summary.Failed = %d, want 1", result.Summary.Failed)
+	}
+	// A failed install records no added refs, so no generation is written.
+	if gens, _ := provision.List(); len(gens) != 0 {
+		t.Fatalf("failed pin must record no generation, got %d", len(gens))
+	}
+}
+
+// The Nix realizer path ignores App.Version (Nix pins via its ref) and does not
+// error.
+func TestRunApplyRealizer_IgnoresAppVersion(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	app := nixApp("ripgrep", "nixpkgs#ripgrep")
+	app.Version = "1.2.0" // declared, must be ignored by the realizer path
+	mf := &manifest.Manifest{Apps: []manifest.App{app}}
+	fr := &fakeRealizer{
+		planDiff:      realizer.Diff{ToAdd: []realizer.Installable{{ID: "ripgrep", Ref: "nixpkgs#ripgrep"}}},
+		realizeResult: realizer.Result{Advanced: true, ToGeneration: 2},
+	}
+
+	if _, eerr := runApplyRealizer(ApplyFlags{Manifest: "m.jsonc"}, mf, fr, noopEmitter(), "rz-ver", nil, nil); eerr != nil {
+		t.Fatalf("realizer must ignore App.Version, got error: %v", eerr)
+	}
+	if fr.realizeCalls != 1 {
+		t.Fatalf("Realize calls = %d, want 1 (installed via ref)", fr.realizeCalls)
+	}
+}

--- a/go-engine/internal/commands/commands_test.go
+++ b/go-engine/internal/commands/commands_test.go
@@ -30,6 +30,14 @@ type mockDriver struct {
 	installed map[string]bool
 	// installErr, if non-nil, is returned by Install for every call.
 	installErr error
+	// versions maps ref -> installed version reported by DetectBatch (capture).
+	versions map[string]string
+
+	// --- version pinning (Phase 6) observation/scripting ---
+	installCalls         int                   // plain Install (latest) call count
+	installVersionCalls  int                   // InstallVersion (pinned) call count
+	lastInstallVersion   string                // version arg of the last InstallVersion call
+	installVersionResult *driver.InstallResult // scripted InstallVersion return (nil = default success)
 }
 
 func (m *mockDriver) Name() string { return "mock" }
@@ -45,7 +53,7 @@ func (m *mockDriver) DetectBatch(refs []string) (map[string]driver.DetectResult,
 	results := make(map[string]driver.DetectResult, len(refs))
 	for _, ref := range refs {
 		if m.installed[ref] {
-			results[ref] = driver.DetectResult{Installed: true, DisplayName: ref + " Display Name"}
+			results[ref] = driver.DetectResult{Installed: true, DisplayName: ref + " Display Name", Version: m.versions[ref]}
 		} else {
 			results[ref] = driver.DetectResult{Installed: false}
 		}
@@ -53,7 +61,27 @@ func (m *mockDriver) DetectBatch(refs []string) (map[string]driver.DetectResult,
 	return results, nil
 }
 
+// InstallVersion makes mockDriver a driver.VersionedInstaller. It records the
+// pinned version and returns the scripted result, or a default success that
+// reports the pinned version (mirroring the winget driver).
+func (m *mockDriver) InstallVersion(ref, version string) (*driver.InstallResult, error) {
+	m.installVersionCalls++
+	m.lastInstallVersion = version
+	if m.installErr != nil {
+		return nil, m.installErr
+	}
+	if m.installVersionResult != nil {
+		return m.installVersionResult, nil
+	}
+	if m.installed == nil {
+		m.installed = make(map[string]bool)
+	}
+	m.installed[ref] = true
+	return &driver.InstallResult{Status: driver.StatusInstalled, Message: "Installed version " + version}, nil
+}
+
 func (m *mockDriver) Install(ref string) (*driver.InstallResult, error) {
+	m.installCalls++
 	if m.installErr != nil {
 		return nil, m.installErr
 	}
@@ -133,7 +161,7 @@ func withMockDriver(md *mockDriver, f func()) {
 func TestRunVerify_AllPresent_ReturnsCorrectShape(t *testing.T) {
 	md := &mockDriver{installed: map[string]bool{
 		"Microsoft.VisualStudioCode": true,
-		"Git.Git":                   true,
+		"Git.Git":                    true,
 	}}
 
 	var result interface{}
@@ -230,7 +258,7 @@ func TestRunVerify_ManifestNotFound_ReturnsEnvelopeError(t *testing.T) {
 func TestRunVerify_EventOrdering(t *testing.T) {
 	md := &mockDriver{installed: map[string]bool{
 		"Microsoft.VisualStudioCode": true,
-		"Git.Git":                   true,
+		"Git.Git":                    true,
 	}}
 
 	emitter, buf := captureEmitter("test-verify-order")
@@ -302,7 +330,7 @@ func TestRunApply_DryRun_ReturnsDryRunTrue(t *testing.T) {
 func TestRunApply_AllPresent_SkipsInstall(t *testing.T) {
 	md := &mockDriver{installed: map[string]bool{
 		"Microsoft.VisualStudioCode": true,
-		"Git.Git":                   true,
+		"Git.Git":                    true,
 	}}
 
 	var result *ApplyResult
@@ -1082,7 +1110,7 @@ func TestRunApply_ManualApp_SummaryCount(t *testing.T) {
 func TestRunApply_RestoreModulesAvailable_DisplayNames(t *testing.T) {
 	md := &mockDriver{installed: map[string]bool{
 		"Microsoft.VisualStudioCode": true,
-		"Git.Git":                   true,
+		"Git.Git":                    true,
 	}}
 
 	catalog := map[string]*modules.Module{
@@ -1284,7 +1312,7 @@ func TestRunApply_ItemEvents_IncludeDisplayName(t *testing.T) {
 	md := &mockDriver{
 		installed: map[string]bool{
 			"Microsoft.VisualStudioCode": true,
-			"Git.Git":                   false,
+			"Git.Git":                    false,
 		},
 	}
 
@@ -1325,7 +1353,7 @@ func TestRunVerify_ItemEvents_IncludeDisplayName(t *testing.T) {
 	md := &mockDriver{
 		installed: map[string]bool{
 			"Microsoft.VisualStudioCode": true,
-			"Git.Git":                   false,
+			"Git.Git":                    false,
 		},
 	}
 

--- a/go-engine/internal/driver/driver.go
+++ b/go-engine/internal/driver/driver.go
@@ -98,12 +98,30 @@ type Uninstaller interface {
 	Uninstall(ref string) (*UninstallResult, error)
 }
 
+// VersionedInstaller is an optional interface that drivers can implement to
+// install a specific version of a package (version pinning). Callers
+// type-assert their Driver to VersionedInstaller, exactly like BatchDetector /
+// Uninstaller; a driver that does not implement it has no pinning path and the
+// caller falls back to Install (latest). It is kept off the core Driver
+// interface so pinning stays an opt-in capability that not every backend needs.
+type VersionedInstaller interface {
+	// InstallVersion installs the exact given version of the package identified
+	// by ref. It follows Install's contract: a non-nil error signals an
+	// infrastructure problem (e.g. the tool binary is missing); an expected
+	// failure — including the requested version being unavailable — is encoded
+	// in InstallResult as StatusFailed/ReasonInstallFailed.
+	InstallVersion(ref, version string) (*InstallResult, error)
+}
+
 // DetectResult holds the outcome of a batch detection check for a single ref.
 type DetectResult struct {
 	// Installed is true if the package is currently installed.
 	Installed bool
 	// DisplayName is the human-readable name from the package manager output.
 	DisplayName string
+	// Version is the installed version reported by the package manager, or ""
+	// when the manager exposes none (best-effort capture).
+	Version string
 }
 
 // BatchDetector is an optional interface that drivers can implement to detect

--- a/go-engine/internal/driver/winget/detect.go
+++ b/go-engine/internal/driver/winget/detect.go
@@ -148,28 +148,34 @@ func allDashes(s string) bool {
 	return len(s) > 0
 }
 
+// takeSnapshotFn is the snapshot source used by DetectBatch. It is a package
+// var so tests can inject a fixture set of installed apps (with versions)
+// without spawning a real winget process.
+var takeSnapshotFn = snapshot.TakeSnapshot
+
 // DetectBatch checks multiple package refs in a single winget list call.
 // It runs `winget list --source winget` once via snapshot.TakeSnapshot(),
 // then matches each ref against the results. This is dramatically faster
 // than calling Detect() per ref (1 process spawn vs N).
 func (w *WingetDriver) DetectBatch(refs []string) (map[string]driver.DetectResult, error) {
-	apps, err := snapshot.TakeSnapshot()
+	apps, err := takeSnapshotFn()
 	if err != nil {
 		return nil, err
 	}
 
-	// Build case-insensitive lookup: winget ID → display name.
-	installed := make(map[string]string, len(apps))
+	// Build case-insensitive lookup: winget ID → snapshot entry (name + version).
+	installed := make(map[string]snapshot.SnapshotApp, len(apps))
 	for _, app := range apps {
-		installed[strings.ToLower(app.ID)] = app.Name
+		installed[strings.ToLower(app.ID)] = app
 	}
 
 	results := make(map[string]driver.DetectResult, len(refs))
 	for _, ref := range refs {
-		name, found := installed[strings.ToLower(ref)]
+		app, found := installed[strings.ToLower(ref)]
 		results[ref] = driver.DetectResult{
 			Installed:   found,
-			DisplayName: name,
+			DisplayName: app.Name,
+			Version:     app.Version, // best-effort capture from `winget list`
 		}
 	}
 	return results, nil

--- a/go-engine/internal/driver/winget/install_version.go
+++ b/go-engine/internal/driver/winget/install_version.go
@@ -1,0 +1,21 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package winget
+
+import "github.com/Artexis10/endstate/go-engine/internal/driver"
+
+// compile-time assertion: the winget driver implements the optional
+// VersionedInstaller capability, so the apply path can discover version-pinning
+// eligibility by type-assertion.
+var _ driver.VersionedInstaller = (*WingetDriver)(nil)
+
+// InstallVersion installs the exact given version of ref via
+// `winget install --version <version>`. It is the version-pinning counterpart of
+// Install and shares its implementation and exit-code classification: an
+// unavailable version makes winget exit non-zero (and not the already-installed
+// HRESULT), so it surfaces as StatusFailed/ReasonInstallFailed — the pin is
+// never silently satisfied by a different version.
+func (w *WingetDriver) InstallVersion(ref, version string) (*driver.InstallResult, error) {
+	return w.install(ref, version)
+}

--- a/go-engine/internal/driver/winget/install_version_test.go
+++ b/go-engine/internal/driver/winget/install_version_test.go
@@ -1,0 +1,130 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package winget
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/driver"
+	"github.com/Artexis10/endstate/go-engine/internal/snapshot"
+)
+
+// capturingCommand records the argv handed to winget (into *captured) and then
+// re-invokes the helper process with the given exit code, so a test can assert
+// the flags passed AND drive the simulated winget exit. Reuses TestHelperProcess
+// defined in winget_test.go.
+func capturingCommand(exitCode int, captured *[]string) func(string, ...string) *exec.Cmd {
+	return func(name string, args ...string) *exec.Cmd {
+		if captured != nil {
+			*captured = append([]string{name}, args...)
+		}
+		cs := append([]string{"-test.run=TestHelperProcess", "--"}, args...)
+		cmd := exec.Command(os.Args[0], cs...)
+		cmd.Env = append(os.Environ(),
+			"GO_WANT_HELPER_PROCESS=1",
+			fmt.Sprintf("FAKE_EXIT_CODE=%d", exitCode),
+		)
+		return cmd
+	}
+}
+
+func hasFlagValue(args []string, flag, value string) bool {
+	for i, a := range args {
+		if a == flag && i+1 < len(args) && args[i+1] == value {
+			return true
+		}
+	}
+	return false
+}
+
+// InstallVersion passes `--version <v>` and, on success, reports the pinned
+// version in the message.
+func TestInstallVersion_PassesVersionFlag(t *testing.T) {
+	var got []string
+	d := &WingetDriver{ExecCommand: capturingCommand(0, &got)}
+
+	res, err := d.InstallVersion("Vendor.App", "1.2.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !hasFlagValue(got, "--id", "Vendor.App") {
+		t.Fatalf("expected --id Vendor.App in args: %v", got)
+	}
+	if !hasFlagValue(got, "--version", "1.2.0") {
+		t.Fatalf("expected --version 1.2.0 in args: %v", got)
+	}
+	if res.Status != driver.StatusInstalled {
+		t.Fatalf("Status = %q, want installed", res.Status)
+	}
+	if !strings.Contains(res.Message, "1.2.0") {
+		t.Fatalf("message should surface the pinned version: %q", res.Message)
+	}
+}
+
+// An unavailable pinned version (generic non-zero exit, not the already-installed
+// HRESULT) is a per-item install failure — never a silent different-version
+// install.
+func TestInstallVersion_UnavailableIsInstallFailed(t *testing.T) {
+	d := &WingetDriver{ExecCommand: capturingCommand(1, nil)}
+
+	res, err := d.InstallVersion("Vendor.App", "9.9.9")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != driver.StatusFailed || res.Reason != driver.ReasonInstallFailed {
+		t.Fatalf("want failed/install_failed, got %q/%q", res.Status, res.Reason)
+	}
+	if !strings.Contains(res.Message, "9.9.9") {
+		t.Fatalf("failure message should surface the requested version: %q", res.Message)
+	}
+}
+
+// The unpinned Install path must NOT pass --version (regression guard for the
+// shared-impl refactor) and keeps its historical success message.
+func TestInstall_Unpinned_NoVersionFlag(t *testing.T) {
+	var got []string
+	d := &WingetDriver{ExecCommand: capturingCommand(0, &got)}
+
+	res, err := d.Install("Vendor.App")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, a := range got {
+		if a == "--version" {
+			t.Fatalf("unpinned Install must not pass --version: %v", got)
+		}
+	}
+	if res.Message != "Installed successfully" {
+		t.Fatalf("unpinned success message changed: %q", res.Message)
+	}
+}
+
+// DetectBatch propagates the snapshot's parsed Version column into
+// DetectResult.Version (capture), keyed case-insensitively by winget Id.
+func TestDetectBatch_CapturesVersion(t *testing.T) {
+	orig := takeSnapshotFn
+	takeSnapshotFn = func() ([]snapshot.SnapshotApp, error) {
+		return []snapshot.SnapshotApp{
+			{Name: "Ripgrep", ID: "BurntSushi.ripgrep.MSVC", Version: "14.1.0"},
+		}, nil
+	}
+	defer func() { takeSnapshotFn = orig }()
+
+	d := New()
+	results, err := d.DetectBatch([]string{"BurntSushi.ripgrep.MSVC", "Not.Installed"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	rg := results["BurntSushi.ripgrep.MSVC"]
+	if !rg.Installed || rg.Version != "14.1.0" {
+		t.Fatalf("ripgrep result = %+v, want installed with version 14.1.0", rg)
+	}
+	if absent := results["Not.Installed"]; absent.Installed || absent.Version != "" {
+		t.Fatalf("absent ref should carry no version: %+v", absent)
+	}
+}

--- a/go-engine/internal/driver/winget/winget.go
+++ b/go-engine/internal/driver/winget/winget.go
@@ -64,15 +64,26 @@ func (w *WingetDriver) Name() string { return "winget" }
 //
 // If the winget binary is not found, Install returns (nil, ErrWingetNotAvailable).
 func (w *WingetDriver) Install(ref string) (*driver.InstallResult, error) {
-	cmd := w.ExecCommand(
-		"winget",
+	return w.install(ref, "")
+}
+
+// install is the shared winget-install implementation. When version is non-empty
+// it pins the install via `--version <version>` (the VersionedInstaller path);
+// otherwise it installs the latest, byte-identical to the historical Install
+// behavior.
+func (w *WingetDriver) install(ref, version string) (*driver.InstallResult, error) {
+	args := []string{
 		"install",
 		"--id", ref,
 		"--accept-source-agreements",
 		"--accept-package-agreements",
 		"-e",
 		"--silent",
-	)
+	}
+	if version != "" {
+		args = append(args, "--version", version)
+	}
+	cmd := w.ExecCommand("winget", args...)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -110,7 +121,7 @@ func (w *WingetDriver) Install(ref string) (*driver.InstallResult, error) {
 	case exitCode == 0:
 		return &driver.InstallResult{
 			Status:  driver.StatusInstalled,
-			Message: "Installed successfully",
+			Message: installedMessage(version),
 		}, nil
 
 	case exitCode == alreadyInstalledExitCodeSigned || exitCode == alreadyInstalledExitCodeUnsigned:
@@ -131,7 +142,24 @@ func (w *WingetDriver) Install(ref string) (*driver.InstallResult, error) {
 		return &driver.InstallResult{
 			Status:  driver.StatusFailed,
 			Reason:  reason,
-			Message: fmt.Sprintf("winget exited with code %d", exitCode),
+			Message: failedMessage(exitCode, version),
 		}, nil
 	}
+}
+
+// installedMessage and failedMessage keep the unpinned messages byte-identical
+// to the historical Install output, and append the requested version on the
+// pinned path so a failed pin surfaces which version was unavailable.
+func installedMessage(version string) string {
+	if version != "" {
+		return "Installed version " + version
+	}
+	return "Installed successfully"
+}
+
+func failedMessage(exitCode int, version string) string {
+	if version != "" {
+		return fmt.Sprintf("winget exited with code %d (requested version %s)", exitCode, version)
+	}
+	return fmt.Sprintf("winget exited with code %d", exitCode)
 }

--- a/openspec/changes/windows-version-capture-pinning/design.md
+++ b/openspec/changes/windows-version-capture-pinning/design.md
@@ -1,0 +1,109 @@
+## Context
+
+Phases 1–5 shipped. Today on Windows:
+- `driver.Driver` is `Name`/`Detect(ref)→(installed,displayName,err)`/`Install(ref)`; optional
+  `BatchDetector`/`Uninstaller`. None exposes a version.
+- `internal/snapshot.TakeSnapshot()` already parses `winget list` into `SnapshotApp{Name, ID,
+  Version, Source}` — the **Version is already captured**, but `DetectBatch` copies only `Name` into
+  `DetectResult{Installed, DisplayName}` and drops the version.
+- `provision.ProvItem` has `Version string` (best-effort, always `""` on winget today). The spec
+  already requires generations to record "version when the backend exposes it".
+- `manifest.App` has `Version string` (`json:"version,omitempty"`) — **declared in the schema,
+  never read**. `AI_CONTRACT.md` Non-Goal #3 states "No package version pinning — MVP does not
+  compare or pin versions".
+- The Nix realizer pins exact versions via its ref (`nixpkgs/<rev>#pkg`); it has no per-app version
+  concept.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Record the installed version of each winget package in the Provisioning Generation (capture).
+- Honor a declared `App.Version` by installing that exact version on the winget path (pin).
+- Zero default/Unix regression; reuse existing parsing and classification.
+
+**Non-Goals:**
+- **No convergent pinning** — `App.Version` pins only when *installing*; an already-installed
+  different version is left as `present` (no compare, no downgrade). Convergence is future work.
+- **No fallback** — an unavailable pinned version is a per-item `INSTALL_FAILED`, never a silent
+  install of a different version.
+- **No nix version capture / nix `App.Version`** — Nix reproducibility is the ref pin; the realizer
+  ignores `App.Version`. (Documented asymmetry.)
+- **No version drift detection in `verify`** — capture makes drift *visible* in the generation; a
+  verifier is a later phase.
+
+## Decisions (maintainer, this session)
+
+- **(a) Scope = capture + pinning** in one phase.
+- **(b) Pin-on-install only** (not convergent) — smallest change that delivers reproducible *fresh*
+  rebuilds; keeps the "compare versions" half of the old non-goal out.
+- **(c) Hard fail** when the pin is unavailable — reproducibility means the exact version or an
+  error; also winget's native behavior, so the existing classifier already maps it to
+  `INSTALL_FAILED`.
+- **(d) Pin interface = optional `VersionedInstaller`** (type-asserted), matching
+  `BatchDetector`/`Uninstaller`/`Pruner`/`Rollbacker`. `Install(ref)` and `mockDriver` stay
+  untouched.
+
+## Design
+
+### Capture
+
+`DetectResult` gains `Version string`. `DetectBatch` sets it from the snapshot's already-parsed
+`SnapshotApp.Version`. In the driver `apply` plan loop, the per-app `ApplyAction` gains
+`Version string`, set from `batchResults[ref].Version` for **present** packages. After a successful
+install:
+- **pinned install** → `action.Version = app.Version` (the version we asked winget to install, now
+  committed);
+- **unpinned fresh install** → `action.Version = ""` (winget exposes no version on `install`;
+  best-effort, consistent with the existing `ProvItem.version` contract).
+
+`writeProvisioningGeneration` copies `ApplyAction.Version` into `ProvItem.Version`. nix-path actions
+never set `Version`, so nix generations keep `version: ""` (capture is winget-scoped this phase).
+
+### Pinning
+
+New optional interface in `internal/driver`:
+
+```go
+type VersionedInstaller interface {
+    InstallVersion(ref, version string) (*InstallResult, error)
+}
+```
+
+The winget driver implements it identically to `Install` plus `--version <version>`; the same
+exit-code switch classifies the result, so an unavailable version (winget non-zero, not the
+already-installed HRESULT) → `StatusFailed`/`ReasonInstallFailed`.
+
+Driver `apply` install loop:
+
+```go
+var result *driver.InstallResult
+if entry.app.Version != "" {
+    if vi, ok := d.(driver.VersionedInstaller); ok {
+        result, installErr = vi.InstallVersion(entry.ref, entry.app.Version)
+    } else {
+        result, installErr = d.Install(entry.ref) // no versioned path on this driver
+    }
+} else {
+    result, installErr = d.Install(entry.ref)
+}
+```
+
+The Nix realizer path (`apply_realizer.go`) is unchanged — it never reads `App.Version`.
+
+### Edge cases
+
+- `App.Version` set, driver is **not** a `VersionedInstaller`: no such driver exists today (winget
+  implements it); the fallback installs latest. (A warning is optional; not specified, to avoid
+  scope.)
+- `App.Version` set on the **nix** path: ignored by design (nix pins via ref).
+- Capture parsing failure (missing/garbled Version column): `Version = ""`, never fails the run —
+  identical best-effort posture to display-name parsing.
+
+## Risks / Verification
+
+- **No real winget on the Linux dev box.** Hermetic tests inject `ExecCommand`/snapshot fixtures
+  and the `mockDriver`; `GOOS=windows go build`/`vet` gate cross-compilation. The real-winget
+  pin+capture smoke (install `Vendor.App --version X` → generation records that version; unavailable
+  version → INSTALL_FAILED) is the maintainer's Windows step.
+- **CI gotcha (Phase 4 lesson):** any `RunApply` test overriding `newDriverFn` must also override
+  `newRealizerFn` (and vice-versa), or windows-latest exercises the wrong backend.

--- a/openspec/changes/windows-version-capture-pinning/proposal.md
+++ b/openspec/changes/windows-version-capture-pinning/proposal.md
@@ -1,0 +1,76 @@
+## Why
+
+Phases 1–5 give the engine a unified, declarative package model across Windows / macOS / Linux:
+Nix/winget install (P1/P2), a numbered Provisioning Generation (P2), native Unix rollback (P3),
+best-effort winget rollback (P4), and convergence-to-exact-set (P5). One asymmetry remains —
+**reproducibility**. On Nix the version is locked for free by the pinned `nixpkgs` rev, so a
+rebuild is byte-identical. On Windows it is not: the winget driver records **no version**
+(`ProvItem.version` is always empty), and the manifest already carries an **`App.Version` field**
+that is **never used**. So a Windows Provisioning Generation cannot even tell you which version was
+installed, let alone reproduce it.
+
+This change is **Phase 6 — Windows version capture + pinning**: the winget path now (1) **captures**
+the installed version into the Provisioning Generation, and (2) **pins** to a declared
+`App.Version` by installing that exact version. Both close the documented Windows reproducibility
+gap while keeping the engine's default behavior unchanged.
+
+## What Changes
+
+- **Capture (always on).** Add a `Version` field to `driver.DetectResult`. The winget snapshot
+  already parses the `Version` column of `winget list` (`internal/snapshot`); propagate it through
+  `DetectBatch` so the driver `apply` path records the installed version in `ProvItem.version`. No
+  new winget call. nix version capture is **out of scope** (Nix reproducibility comes from the ref
+  pin, not a per-package version).
+- **Pinning (opt-in, declarative via `App.Version`).** Add an optional
+  **`driver.VersionedInstaller`** interface (`InstallVersion(ref, version string) (*InstallResult,
+  error)`), discovered by type-assertion like `BatchDetector`/`Uninstaller`. The winget driver
+  implements it via `winget install --version <v> …`. The driver `apply` path calls it when the
+  manifest declares `App.Version` **and** the driver implements it; otherwise it installs latest as
+  today.
+- **Pin-on-install only.** `App.Version` sets the version used **when installing a missing
+  package**. An already-installed package of any version stays `present`/skipped — no version
+  comparison, no downgrade. (Drift stays visible via capture, for a future convergent phase.)
+- **Hard fail on unavailable pin.** If the pinned version is not available, `winget --version`
+  exits non-zero and the item resolves as `INSTALL_FAILED` (the version is surfaced in the
+  message). No silent fallback to a different version.
+- **Backend-scoped.** Pinning is winget-only. The **Nix realizer ignores `App.Version`** — Nix
+  pins via its ref (`nixpkgs/<rev>#pkg`), so a per-app version is redundant there.
+- **Contract:** rewrite `AI_CONTRACT.md` Non-Goal #3 ("No package version pinning") to allow
+  **opt-in, declared** pinning (mirrors the Non-Goal #4 rewording in Phase 3); the
+  no-*automatic*-version-management spirit is preserved. Document `App.Version` pinning and the
+  now-populated `version` field in `cli-json-contract.md`.
+
+## Capabilities
+
+### New Capabilities
+
+- `windows-version-capture-pinning`: the winget backend records the installed version of each
+  package in the Provisioning Generation, and honors a declared `App.Version` by installing that
+  exact version (pin-on-install). An unavailable pinned version is a per-item install failure.
+  Pinning is winget-scoped; the Nix realizer pins via its ref and ignores `App.Version`.
+
+### Modified Capabilities
+
+- None. `provisioning-generation` already requires generations to record "version when the backend
+  exposes it" — this change makes the winget backend *expose* it, fulfilling the existing
+  best-effort requirement rather than altering the spec.
+
+## Impact
+
+- `internal/driver/driver.go` — add `DetectResult.Version`; add the optional `VersionedInstaller`
+  interface.
+- `internal/driver/winget/detect.go` — `DetectBatch` propagates the snapshot's already-parsed
+  version into `DetectResult.Version`.
+- `internal/driver/winget/install_version.go` (new) — `InstallVersion(ref, version)` via `winget
+  install --version`; reuses the existing exit-code classification (unavailable → install failed).
+- `internal/commands/apply.go` (driver path) — add `ApplyAction.Version`; populate it from the
+  batch capture (present) and the honored pin (installed); install via `VersionedInstaller` when
+  `App.Version` is set.
+- `internal/commands/apply_generation.go` — copy `ApplyAction.Version` into `ProvItem.version`.
+- `docs/ai/AI_CONTRACT.md` — **PROTECTED (maintainer-approved)**: reword Non-Goal #3 to permit
+  opt-in declared version pinning.
+- `docs/contracts/cli-json-contract.md` — **PROTECTED (maintainer-approved, additive)**: document
+  `App.Version` pinning and the populated `version` field on winget generations.
+- **Zero default / Unix regression.** Without `App.Version` the install path is byte-identical;
+  the Nix realizer is untouched. Proven by host-aware tests + `GOOS=windows` build/vet. The
+  real-winget pin/capture smoke is maintainer-side on Windows (no winget on the Linux dev box).

--- a/openspec/changes/windows-version-capture-pinning/specs/windows-version-capture-pinning/spec.md
+++ b/openspec/changes/windows-version-capture-pinning/specs/windows-version-capture-pinning/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: The winget backend records installed package versions
+
+When recording a Provisioning Generation on the winget backend, the engine SHALL include the
+installed version of each package whose version the package manager exposes, so the history reflects
+what was actually committed. A version the package manager does not expose SHALL be recorded as
+empty rather than failing the run.
+
+#### Scenario: Generation records the installed version of present packages
+
+- **WHEN** `apply` runs on the winget backend and a declared package is already installed
+- **THEN** the Provisioning Generation entry for that package SHALL record the installed version
+  reported by the package manager
+
+#### Scenario: Missing version does not fail capture
+
+- **WHEN** the package manager exposes no version for a package
+- **THEN** the engine SHALL record an empty version for that package
+- **AND** the run SHALL NOT fail because a version was unavailable
+
+### Requirement: A declared version pins the installed version
+
+When the manifest declares a version for a package, the engine SHALL install that exact version on a
+backend that supports versioned installation, rather than the latest available version.
+
+#### Scenario: Declared version installs that exact version
+
+- **WHEN** `apply` installs a missing package whose manifest entry declares a version, on a backend
+  that supports versioned installation
+- **THEN** the engine SHALL install the declared version
+- **AND** the Provisioning Generation SHALL record that version as the installed version
+
+#### Scenario: Pinning applies only when installing
+
+- **WHEN** a package is already installed at a version different from the declared version
+- **THEN** the engine SHALL leave the installed package unchanged (it remains present)
+- **AND** the engine SHALL NOT downgrade, upgrade, or reinstall it solely to match the declared
+  version
+
+#### Scenario: No declared version installs the latest
+
+- **WHEN** a package's manifest entry declares no version
+- **THEN** the engine SHALL install the latest available version, exactly as before
+
+### Requirement: An unavailable pinned version fails the package
+
+The engine SHALL fail a package whose declared version the package manager cannot install, and SHALL
+NOT install a different version in its place.
+
+#### Scenario: Unavailable pinned version is an install failure
+
+- **WHEN** `apply` attempts to install a declared version that the package manager does not offer
+- **THEN** the engine SHALL report that package as an install failure
+- **AND** it SHALL NOT silently install a different version
+- **AND** other packages in the run SHALL be unaffected
+
+### Requirement: Version pinning is scoped to the backend that supports it
+
+Version pinning via the manifest's declared version SHALL apply only to backends that install a
+specific version (the winget driver). A whole-set realizer that pins exact versions through its own
+reference (the Nix realizer) SHALL ignore the declared per-package version, and this SHALL NOT be an
+error.
+
+#### Scenario: Realizer backend ignores the declared per-package version
+
+- **WHEN** `apply` runs through the Nix realizer and a package declares a version
+- **THEN** the engine SHALL resolve the package through the realizer's reference as usual
+- **AND** the declared per-package version SHALL NOT cause an error

--- a/openspec/changes/windows-version-capture-pinning/tasks.md
+++ b/openspec/changes/windows-version-capture-pinning/tasks.md
@@ -1,0 +1,59 @@
+> TDD: write each test RED first, then implement to green. Hermetic + host-aware (inject
+> `ExecCommand`/snapshot fixtures and `newDriverFn`/`newRealizerFn`; key apply fixtures by
+> `runtime.GOOS`). Verify: `cd go-engine && go test ./...` (Linux) + `GOOS=windows go build ./...`
+> + `go vet`. Real-winget pin/capture smoke is maintainer-side on Windows (no winget on this box).
+
+## 1. Capture: driver result carries version
+
+- [x] 1.1 `internal/driver/driver.go`: add `Version string` to `DetectResult`
+- [x] 1.2 RED test (`internal/driver/winget/detect_test.go`): `DetectBatch` populates
+      `DetectResult.Version` from the snapshot's parsed Version column
+- [x] 1.3 `internal/driver/winget/detect.go`: `DetectBatch` copies `SnapshotApp.Version` into
+      `DetectResult.Version` (no new winget call)
+
+## 2. Capture: apply records the version in the generation
+
+- [x] 2.1 `internal/commands/apply.go`: add `Version string` to `ApplyAction`; set it from
+      `batchResults[ref].Version` for present packages
+- [x] 2.2 `internal/commands/apply_generation.go`: copy `ApplyAction.Version` into
+      `ProvItem.Version`
+- [x] 2.3 RED test: driver-path `apply` writes a generation whose installed/present item carries the
+      captured version; nix-path generation keeps `version: ""`
+
+## 3. Pinning: VersionedInstaller
+
+- [x] 3.1 `internal/driver/driver.go`: add optional `VersionedInstaller` interface
+      (`InstallVersion(ref, version string) (*InstallResult, error)`)
+- [x] 3.2 RED tests (`internal/driver/winget/install_version_test.go`, injected `ExecCommand`):
+      `InstallVersion` passes `--version <v>`; exit 0 → installed; unavailable (non-zero,
+      non-already-installed) → `StatusFailed`/`ReasonInstallFailed`
+- [x] 3.3 `internal/driver/winget/install_version.go`: implement `InstallVersion` via `winget
+      install --version`; reuse the existing exit-code classification; compile-time assert
+      `*WingetDriver` satisfies `driver.VersionedInstaller`
+
+## 4. Pinning: apply honors App.Version
+
+- [x] 4.1 `internal/commands/apply.go` (driver path): when `app.Version != ""` and the driver is a
+      `VersionedInstaller`, install via `InstallVersion`; else `Install`. On a pinned success set
+      `action.Version = app.Version`
+- [x] 4.2 RED tests (call the driver-path apply with a mock that records args; override BOTH
+      `newDriverFn` AND `newRealizerFn`): pinned manifest → `InstallVersion(ref, "x")` called,
+      generation records version "x"; no-version manifest → `Install` called, no `--version`;
+      unavailable pin → item `failed`/`install_failed`
+- [x] 4.3 RED test: nix realizer path ignores `App.Version` (no error; installs via ref)
+
+## 5. Contract (PROTECTED — maintainer-approved)
+
+- [x] 5.1 `docs/ai/AI_CONTRACT.md`: reword Non-Goal #3 to allow opt-in, declared version pinning
+      (preserve the no-automatic-version-management spirit)
+- [x] 5.2 `docs/contracts/cli-json-contract.md`: document `App.Version` pinning + the populated
+      `version` field on winget generations
+
+## 6. Verification
+
+- [x] 6.1 `cd go-engine && go test ./...` green on Linux
+- [x] 6.2 `GOOS=windows go build ./...` + `go vet ./...` clean
+- [x] 6.3 `npm run openspec:validate` (strict) passes
+- [ ] 6.4 (Maintainer, Windows) real-winget smoke: pinned `App.Version` installs that exact version
+      and the generation records it; an unavailable version → `INSTALL_FAILED`; an unpinned app
+      installs latest and records its version


### PR DESCRIPTION
## Summary

Phase 6 closes the cross-OS **reproducibility** gap. On Nix the version is locked for free by the pinned `nixpkgs` rev; on Windows it was not — the winget driver recorded no version and the manifest's `App.Version` was unused. After this:

- **Capture (always on):** every winget Provisioning Generation item records the installed `version` (from the `winget list` column the snapshot already parses — no new winget call).
- **Pinning (opt-in via `App.Version`):** a declared version installs that exact version via `winget install --version`.

## Design decisions (this session)

- **Pin-on-install only** — an already-installed different version is left `present` (no compare, no downgrade). Drift stays *visible* via capture for a future convergent phase.
- **Hard fail** — an unavailable pinned version is a per-item `INSTALL_FAILED` (version in the message); never a silent different-version install.
- **Optional `VersionedInstaller` interface** — type-asserted like `BatchDetector`/`Uninstaller`/`Pruner`; `Install(ref)` and the core `Driver` stay untouched.
- **Backend-scoped** — the Nix realizer ignores `App.Version` (it pins via its ref); nix version capture is out of scope this phase.

## Changes

- `internal/driver`: `DetectResult.Version`; optional `VersionedInstaller`.
- `internal/driver/winget`: `DetectBatch` propagates the snapshot version; new `InstallVersion` sharing `Install`'s exit-code classification.
- `internal/commands/apply.go`: capture version into the generation; pin via `VersionedInstaller` when declared.
- `docs/ai/AI_CONTRACT.md` (maintainer-approved): reword Non-Goal #3 to permit opt-in declared pinning (no-automatic-version-management spirit preserved).
- `docs/contracts/cli-json-contract.md`: document `App.Version` pinning + the `version` field.
- OpenSpec change `windows-version-capture-pinning` (new capability).

## Verification

- `go test ./...` (Linux) — green; `GOOS=windows go build` + `go vet` — clean; `npm run openspec:validate` — 57/57.
- Hermetic + host-aware tests: winget `ExecCommand`/snapshot shims; command-path tests override **both** backend seams (Phase 4 CI lesson).
- ⚠️ **Real-winget pin/capture smoke is maintainer-side on Windows** — the Linux dev box has no winget (tasks.md §6.4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)