### PR TITLE
feat(backup): add 'backup push --if-changed' (content-hash dedup) (#62)

### DIFF
--- a/go-engine/cmd/endstate/main.go
+++ b/go-engine/cmd/endstate/main.go
@@ -132,6 +132,7 @@ type parsedArgs struct {
 	prune          bool // apply --prune: converge to the exact declared set
 	saveRecoveryTo string
 	overwrite      bool
+	ifChanged      bool
 
 	// Positional args after command (used by profile / backup / account subcommands)
 	positionalArgs []string
@@ -185,6 +186,8 @@ func parseArgs(args []string) parsedArgs {
 			p.prune = true
 		case "--overwrite":
 			p.overwrite = true
+		case "--if-changed":
+			p.ifChanged = true
 		case "--WithConfig":
 			// GUI sends --WithConfig for capture; the Go engine includes
 			// config modules by default, so this is a no-op. Accept it
@@ -535,6 +538,7 @@ func dispatch(p parsedArgs) (interface{}, *envelope.Error) {
 			VersionID:      p.versionID,
 			Profile:        p.profile,
 			Name:           p.name,
+			IfChanged:      p.ifChanged,
 			To:             p.to,
 			Confirm:        p.confirm,
 			SaveRecoveryTo: p.saveRecoveryTo,

--- a/go-engine/internal/backup/download/download.go
+++ b/go-engine/internal/backup/download/download.go
@@ -191,6 +191,61 @@ func PullVersion(ctx context.Context, deps Dependencies, backupID, versionID, to
 	}, nil
 }
 
+// LatestManifest fetches and decrypts the manifest of the newest version of a
+// backup, for read-only inspection. It downloads only the manifest blob (not the
+// chunks) and emits no events. Used by `backup push --if-changed` to read the
+// latest version's ContentSHA256 for content-hash dedup. Returns (nil, nil) when
+// the backup has no versions yet.
+func LatestManifest(ctx context.Context, deps Dependencies, backupID string) (*manifest.Manifest, *envelope.Error) {
+	dek, lerr := deps.Session.LoadDEK()
+	if lerr != nil {
+		return nil, envelope.NewError(envelope.ErrAuthRequired,
+			"backup: no DEK in keychain — sign in first").
+			WithRemediation("Run `endstate backup login` to populate the session.")
+	}
+	defer wipe(dek)
+
+	versions, vErr := deps.Storage.ListVersions(ctx, backupID)
+	if vErr != nil {
+		return nil, vErr
+	}
+	if len(versions) == 0 {
+		return nil, nil
+	}
+	latest, sErr := manifest.SelectLatest(toManifestVersions(versions))
+	if sErr != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, "backup: select latest version: "+sErr.Error())
+	}
+
+	httpClient := deps.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	urls, uErr := deps.Storage.DownloadURLs(ctx, backupID, latest.VersionID, []int{storage.ManifestChunkIndex})
+	if uErr != nil {
+		return nil, uErr
+	}
+	murl := storage.FindManifestURL(urls)
+	if murl == nil {
+		return nil, envelope.NewError(envelope.ErrBackendIncompatible,
+			"backup: substrate did not return a manifest URL").
+			WithRemediation("Update the engine; this typically means a substrate response shape changed.")
+	}
+	encManifest, gerr := getOnce(ctx, httpClient, murl.PresignedURL)
+	if gerr != nil {
+		return nil, envelope.NewError(envelope.ErrBackendUnreachable, "backup: download manifest: "+gerr.Error())
+	}
+	mfJSON, dmErr := crypto.DecryptManifest(encManifest, dek)
+	if dmErr != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, "backup: decrypt manifest: "+dmErr.Error())
+	}
+	mf, pErr := manifest.Unmarshal(mfJSON)
+	if pErr != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, "backup: parse manifest: "+pErr.Error())
+	}
+	return mf, nil
+}
+
 // toManifestVersions adapts storage.VersionInfo (from substrate) to the
 // manifest.Version shape SelectLatest expects. They have identical fields
 // today; the bridge keeps the manifest package free of storage's wire types.

--- a/go-engine/internal/backup/manifest/manifest.go
+++ b/go-engine/internal/backup/manifest/manifest.go
@@ -29,15 +29,24 @@ type ChunkMeta struct {
 // `WrappedDEK` is base64-encoded; `KDF` lets the recipient verify the
 // envelope was produced under acceptable parameters before decrypting.
 type Manifest struct {
-	EnvelopeVersion int               `json:"envelopeVersion"`
-	VersionID       string            `json:"versionId"`
-	CreatedAt       string            `json:"createdAt"`
-	OriginalSize    int64             `json:"originalSize"`
-	ChunkSize       int64             `json:"chunkSize"`
-	ChunkCount      int               `json:"chunkCount"`
-	Chunks          []ChunkMeta       `json:"chunks"`
-	KDF             crypto.KDFParams  `json:"kdf"`
-	WrappedDEK      string            `json:"wrappedDEK"`
+	EnvelopeVersion int              `json:"envelopeVersion"`
+	VersionID       string           `json:"versionId"`
+	CreatedAt       string           `json:"createdAt"`
+	OriginalSize    int64            `json:"originalSize"`
+	ChunkSize       int64            `json:"chunkSize"`
+	ChunkCount      int              `json:"chunkCount"`
+	Chunks          []ChunkMeta      `json:"chunks"`
+	KDF             crypto.KDFParams `json:"kdf"`
+	WrappedDEK      string           `json:"wrappedDEK"`
+	// ContentSHA256 is the hex SHA-256 of the plaintext tar (with modification
+	// times zeroed — see upload.tarProfile), a deterministic fingerprint of the
+	// backed-up content. `backup push --if-changed` compares it against the
+	// latest version's value to skip re-uploading unchanged profiles. Encrypted
+	// blobs cannot be compared (random AES-GCM nonces differ every push), so this
+	// plaintext hash lives inside the encrypted manifest where only the engine
+	// (holding the DEK) can read it. Empty on manifests written before this field
+	// existed; such versions are always treated as changed.
+	ContentSHA256 string `json:"contentSha256,omitempty"`
 }
 
 // Marshal serialises the manifest to compact JSON ready for encryption.

--- a/go-engine/internal/backup/upload/upload.go
+++ b/go-engine/internal/backup/upload/upload.go
@@ -42,6 +42,7 @@ import (
 	"github.com/Artexis10/endstate/go-engine/internal/backup"
 	"github.com/Artexis10/endstate/go-engine/internal/backup/auth"
 	"github.com/Artexis10/endstate/go-engine/internal/backup/crypto"
+	"github.com/Artexis10/endstate/go-engine/internal/backup/download"
 	"github.com/Artexis10/endstate/go-engine/internal/backup/manifest"
 	"github.com/Artexis10/endstate/go-engine/internal/backup/storage"
 	"github.com/Artexis10/endstate/go-engine/internal/envelope"
@@ -52,6 +53,9 @@ import (
 type PushResult struct {
 	BackupID  string
 	VersionID string
+	// Skipped is true when --if-changed found the content unchanged and no new
+	// version was created; VersionID then refers to the existing latest version.
+	Skipped bool
 }
 
 // Dependencies are the moving pieces a push operation needs. Construct
@@ -65,6 +69,10 @@ type Dependencies struct {
 	Concurrency int          // bounded parallelism for chunk PUTs; <1 → backup.Concurrency()
 	UploadRetry int          // retries on 5xx per chunk; <0 → 1
 	Now         func() time.Time
+	// IfChanged enables content-hash dedup: skip the upload (mint no new version)
+	// when the candidate's plaintext content matches the latest version's
+	// ContentSHA256. Best-effort — a failed/absent peek falls through to upload.
+	IfChanged bool
 }
 
 // PushVersion executes the upload pipeline. Inputs:
@@ -97,6 +105,26 @@ func PushVersion(ctx context.Context, deps Dependencies, backupID, profilePath, 
 	if terr != nil {
 		return nil, envelope.NewError(envelope.ErrInternalError, "backup push: tar profile: "+terr.Error()).
 			WithRemediation("Verify --profile points at a readable file or directory.")
+	}
+
+	// Deterministic plaintext content fingerprint (tarProfile zeroes mod-times).
+	// Stored in the manifest and compared by --if-changed.
+	contentSum := sha256.Sum256(tarBytes)
+	contentSHA := hex.EncodeToString(contentSum[:])
+
+	// Content-hash dedup (--if-changed): if the latest version's plaintext content
+	// matches this candidate, skip the upload entirely — no new version is minted.
+	// Best-effort: a failed or absent peek falls through to a normal upload, so a
+	// transient hiccup never blocks a backup ("when in doubt, back up"). Versions
+	// written before ContentSHA256 existed have an empty value and never match.
+	if deps.IfChanged {
+		if latest, _ := download.LatestManifest(ctx, download.Dependencies{
+			Storage:    deps.Storage,
+			Session:    deps.Session,
+			HTTPClient: deps.HTTPClient,
+		}, resolvedBackupID); latest != nil && latest.ContentSHA256 == contentSHA {
+			return &PushResult{BackupID: resolvedBackupID, VersionID: latest.VersionID, Skipped: true}, nil
+		}
 	}
 
 	chunks := chunkBytes(tarBytes, crypto.ChunkPlainSize)
@@ -144,6 +172,7 @@ func PushVersion(ctx context.Context, deps Dependencies, backupID, profilePath, 
 		Chunks:          manifestChunks,
 		KDF:             crypto.DefaultKDFParams(),
 		WrappedDEK:      wrappedDEKB64,
+		ContentSHA256:   contentSHA,
 	}
 	mfJSON, mfErr := manifest.Marshal(mf)
 	if mfErr != nil {
@@ -487,7 +516,9 @@ func putOnce(ctx context.Context, hc *http.Client, it uploadItem) error {
 
 type putError struct{ status int }
 
-func (e *putError) Error() string { return fmt.Sprintf("upload: presigned PUT returned HTTP %d", e.status) }
+func (e *putError) Error() string {
+	return fmt.Sprintf("upload: presigned PUT returned HTTP %d", e.status)
+}
 
 func isRetryable(err error) bool {
 	var pe *putError

--- a/go-engine/internal/commands/backup.go
+++ b/go-engine/internal/commands/backup.go
@@ -51,6 +51,10 @@ type BackupFlags struct {
 	// Name is the --name flag (push), the human-readable label for the backup.
 	Name string
 
+	// IfChanged is the --if-changed flag (push): skip the upload (mint no new
+	// version) when the candidate content matches the latest version's hash.
+	IfChanged bool
+
 	// To is the --to flag (pull), the directory the decrypted profile is
 	// written into.
 	To string

--- a/go-engine/internal/commands/backup_push.go
+++ b/go-engine/internal/commands/backup_push.go
@@ -17,6 +17,9 @@ import (
 type PushResult struct {
 	BackupID  string `json:"backupId"`
 	VersionID string `json:"versionId"`
+	// Skipped is true when --if-changed found the content unchanged: no new
+	// version was created and versionId is the existing latest version.
+	Skipped bool `json:"skipped,omitempty"`
 }
 
 func runBackupPush(flags BackupFlags) (interface{}, *envelope.Error) {
@@ -30,12 +33,13 @@ func runBackupPush(flags BackupFlags) (interface{}, *envelope.Error) {
 	em := events.NewEmitter(envelope.BuildRunID("backup-push", time.Now().UTC()), flags.Events == "jsonl")
 
 	res, envErr := upload.PushVersion(context.Background(), upload.Dependencies{
-		Storage: st.Storage,
-		Session: st.Session,
-		Events:  em,
+		Storage:   st.Storage,
+		Session:   st.Session,
+		Events:    em,
+		IfChanged: flags.IfChanged,
 	}, flags.BackupID, flags.Profile, flags.Name)
 	if envErr != nil {
 		return nil, envErr
 	}
-	return &PushResult{BackupID: res.BackupID, VersionID: res.VersionID}, nil
+	return &PushResult{BackupID: res.BackupID, VersionID: res.VersionID, Skipped: res.Skipped}, nil
 }

--- a/go-engine/internal/commands/backup_push_ifchanged_test.go
+++ b/go-engine/internal/commands/backup_push_ifchanged_test.go
@@ -1,0 +1,132 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/backup"
+	"github.com/Artexis10/endstate/go-engine/internal/commands"
+)
+
+// ifcWriteProfile (re)writes a single-file profile directory.
+func ifcWriteProfile(t *testing.T, dir, content string) {
+	t.Helper()
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "manifest.jsonc"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// countingCreateVersion mirrors the default create-version handler but counts
+// POSTs, so a skip (which returns before creating a version) is observable.
+func countingCreateVersion(pp *pushPullBackend, counter *int32) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(counter, 1)
+		var body struct {
+			ChunkMetadata []struct {
+				Index uint32 `json:"index"`
+			} `json:"chunkMetadata"`
+		}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		urls := []map[string]interface{}{
+			{"chunkIndex": -1, "presignedUrl": pp.r2.URL + "/r2/manifest", "expiresAt": "2026-05-02T01:00:00Z"},
+		}
+		for _, c := range body.ChunkMetadata {
+			urls = append(urls, map[string]interface{}{
+				"chunkIndex":   c.Index,
+				"presignedUrl": fmt.Sprintf("%s/r2/%d", pp.r2.URL, c.Index),
+				"expiresAt":    "2026-05-02T01:00:00Z",
+			})
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"versionId": "v-pushed", "uploadUrls": urls})
+	}
+}
+
+// Unchanged content + --if-changed → no new version is created (skipped).
+func TestBackupPush_IfChanged_SkipsUnchanged(t *testing.T) {
+	pp := newPushPullBackend(t)
+	var creates int32
+	pp.createVersionFn = countingCreateVersion(pp, &creates)
+	st, _ := stackForPushPull(pp)
+	defer commands.ReplaceBackupStackFactoryForTest(func() *backup.Stack { return st })()
+
+	profile := filepath.Join(t.TempDir(), "profile")
+	ifcWriteProfile(t, profile, `{"name":"unchanged"}`)
+
+	// First push uploads and stores the manifest (carrying ContentSHA256).
+	if _, err := commands.RunBackup(commands.BackupFlags{Subcommand: "push", Profile: profile, BackupID: "b-1"}); err != nil {
+		t.Fatalf("first push: %+v", err)
+	}
+	// Second push of byte-identical content with --if-changed must skip.
+	data, err := commands.RunBackup(commands.BackupFlags{Subcommand: "push", Profile: profile, BackupID: "b-1", IfChanged: true})
+	if err != nil {
+		t.Fatalf("if-changed push: %+v", err)
+	}
+	res := data.(*commands.PushResult)
+	if !res.Skipped {
+		t.Errorf("Skipped = false, want true (content unchanged)")
+	}
+	if got := atomic.LoadInt32(&creates); got != 1 {
+		t.Errorf("createVersion called %d times, want 1 (no upload on skip)", got)
+	}
+}
+
+// Changed content + --if-changed → a new version is uploaded as normal.
+func TestBackupPush_IfChanged_UploadsChanged(t *testing.T) {
+	pp := newPushPullBackend(t)
+	st, _ := stackForPushPull(pp)
+	defer commands.ReplaceBackupStackFactoryForTest(func() *backup.Stack { return st })()
+
+	profile := filepath.Join(t.TempDir(), "profile")
+	ifcWriteProfile(t, profile, `{"name":"v1"}`)
+	if _, err := commands.RunBackup(commands.BackupFlags{Subcommand: "push", Profile: profile, BackupID: "b-1"}); err != nil {
+		t.Fatalf("first push: %+v", err)
+	}
+	// Mutate the content, then push with --if-changed: must upload.
+	ifcWriteProfile(t, profile, `{"name":"v2-different-content"}`)
+	data, err := commands.RunBackup(commands.BackupFlags{Subcommand: "push", Profile: profile, BackupID: "b-1", IfChanged: true})
+	if err != nil {
+		t.Fatalf("if-changed push: %+v", err)
+	}
+	res := data.(*commands.PushResult)
+	if res.Skipped {
+		t.Errorf("Skipped = true, want false (content changed)")
+	}
+	if res.VersionID != "v-pushed" {
+		t.Errorf("VersionID = %q, want v-pushed", res.VersionID)
+	}
+}
+
+// --if-changed on a backup with no prior versions → uploads (nothing to dedup).
+func TestBackupPush_IfChanged_FirstPushUploads(t *testing.T) {
+	pp := newPushPullBackend(t)
+	pp.versionsFn = func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"versions": []interface{}{}})
+	}
+	st, _ := stackForPushPull(pp)
+	defer commands.ReplaceBackupStackFactoryForTest(func() *backup.Stack { return st })()
+
+	profile := filepath.Join(t.TempDir(), "profile")
+	ifcWriteProfile(t, profile, `{"name":"first"}`)
+	data, err := commands.RunBackup(commands.BackupFlags{Subcommand: "push", Profile: profile, BackupID: "b-1", IfChanged: true})
+	if err != nil {
+		t.Fatalf("if-changed first push: %+v", err)
+	}
+	res := data.(*commands.PushResult)
+	if res.Skipped {
+		t.Errorf("Skipped = true, want false (no prior version)")
+	}
+	if res.VersionID != "v-pushed" {
+		t.Errorf("VersionID = %q, want v-pushed", res.VersionID)
+	}
+}

--- a/go-engine/internal/commands/capabilities.go
+++ b/go-engine/internal/commands/capabilities.go
@@ -17,13 +17,13 @@ import (
 // It matches the shape defined in docs/contracts/cli-json-contract.md and
 // docs/contracts/gui-integration-contract.md.
 type CapabilitiesData struct {
-	SupportedSchemaVersions SchemaVersionRange        `json:"supportedSchemaVersions"`
-	Commands                map[string]CommandInfo    `json:"commands"`
-	Features                FeaturesInfo              `json:"features"`
-	Platform                PlatformInfo              `json:"platform"`
-	GitCommit               *string                   `json:"gitCommit"`
-	GitDirty                bool                      `json:"gitDirty"`
-	BootstrapTimestamp      *string                   `json:"bootstrapTimestamp"`
+	SupportedSchemaVersions SchemaVersionRange     `json:"supportedSchemaVersions"`
+	Commands                map[string]CommandInfo `json:"commands"`
+	Features                FeaturesInfo           `json:"features"`
+	Platform                PlatformInfo           `json:"platform"`
+	GitCommit               *string                `json:"gitCommit"`
+	GitDirty                bool                   `json:"gitDirty"`
+	BootstrapTimestamp      *string                `json:"bootstrapTimestamp"`
 }
 
 // SchemaVersionRange expresses the inclusive range of JSON schema versions this
@@ -41,12 +41,12 @@ type CommandInfo struct {
 
 // FeaturesInfo is the features capability map returned in the capabilities response.
 type FeaturesInfo struct {
-	Streaming       bool                 `json:"streaming"`
-	ParallelInstall bool                 `json:"parallelInstall"`
-	ConfigModules   bool                 `json:"configModules"`
-	JSONOutput      bool                 `json:"jsonOutput"`
-	ManualApps      bool                 `json:"manualApps"`
-	HostedBackup    HostedBackupFeature  `json:"hostedBackup"`
+	Streaming       bool                `json:"streaming"`
+	ParallelInstall bool                `json:"parallelInstall"`
+	ConfigModules   bool                `json:"configModules"`
+	JSONOutput      bool                `json:"jsonOutput"`
+	ManualApps      bool                `json:"manualApps"`
+	HostedBackup    HostedBackupFeature `json:"hostedBackup"`
 }
 
 // HostedBackupFeature is the GUI-facing capability advertisement for the
@@ -131,7 +131,7 @@ func RunCapabilities() (interface{}, *envelope.Error) {
 			},
 			"backup": {
 				Supported: true,
-				Flags:     []string{"--email", "--backup-id", "--version-id", "--profile", "--name", "--to", "--confirm", "--json", "--events"},
+				Flags:     []string{"--email", "--backup-id", "--version-id", "--profile", "--name", "--if-changed", "--to", "--confirm", "--json", "--events"},
 			},
 			"account": {
 				Supported: true,
@@ -151,7 +151,7 @@ func RunCapabilities() (interface{}, *envelope.Error) {
 				Audience:         backup.Audience(),
 			},
 		},
-		Platform: platformInfoFor(runtime.GOOS),
+		Platform:           platformInfoFor(runtime.GOOS),
 		GitCommit:          nil,
 		GitDirty:           false,
 		BootstrapTimestamp: nil,


### PR DESCRIPTION
Closes #62. Unblocks automatic hosted backup in `endstate-gui` (the GUI gates on this).

## The issue's premise didn't hold
#62 proposed deduping on the stored `manifestSha256`. That can't work: chunks **and** the manifest are sealed with a **fresh random AES-GCM nonce on every push** (`crypto/aead.go`), and the manifest also embeds a random `versionId` + timestamp — so every stored hash differs on every push. The tar bytes are deterministic (`tarProfile` zeroes mod-times), but that plaintext hash isn't stored anywhere, and substrate (zero-knowledge) only ever sees ciphertext.

## Approach — content hash inside the encrypted manifest
- Add `contentSha256` = `sha256(plaintext tar)` to the manifest struct. It rides **inside the encrypted manifest**, so only the engine (with the DEK) can read it — substrate never sees it (no erosion of the zero-knowledge property).
- `download.LatestManifest()` peeks the latest version's manifest (list → select-latest → download **only the manifest blob** + decrypt).
- On `backup push --if-changed`: compare the candidate's `contentSha256` to the latest version's.
  - **Match** → skip: no new version, return the existing `versionId` with `data.skipped: true`.
  - **Differ / no prior version / pre-field manifest** → upload as normal.
- **Best-effort**: a failed/absent peek falls through to a normal upload, so a transient hiccup never blocks a backup ("when in doubt, back up").

## Capability advertisement (task 0.3)
`capabilities.commands.backup.flags` now includes `--if-changed`, so the GUI flips its auto-backup gate on only for engines that support it (stays dark otherwise).

## Tests
- `--if-changed` on **unchanged** content → skipped, **no** create-version call.
- `--if-changed` on **changed** content → uploads a new version.
- `--if-changed` **first push** (no prior version) → uploads.

Full engine suite green; `gofmt` + `go vet` clean.

## Notes / follow-ups
- The manifest gains a backward-compatible `contentSha256` field (omitempty; old versions lack it → treated as changed → upload once, then self-heals). Worth a line in the hosted-backup contract §3 — left to a maintainer who owns the contract doc.
- Pairs with #59 (status `lastBackupAt` + quota), still open — the GUI gates auto-backup on **both**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)