### PR TITLE
feat(backup): map lastBackupAt + quota into backup status (#59)

### DIFF
--- a/go-engine/internal/backup/auth/authenticator.go
+++ b/go-engine/internal/backup/auth/authenticator.go
@@ -32,11 +32,11 @@ var stdBase64 = stdBase64Pkg.StdEncoding
 // the SessionStore (for in-memory + keychain persistence), and the
 // crypto package (for KDF / DEK wrap, currently STUBS).
 type Authenticator struct {
-	issuer       Issuer
-	oidc         *oidc.Client
-	httpc        *client.Client
-	session      *SessionStore
-	refreshLock  string // absolute path to the cross-process refresh lock file (F5)
+	issuer      Issuer
+	oidc        *oidc.Client
+	httpc       *client.Client
+	session     *SessionStore
+	refreshLock string // absolute path to the cross-process refresh lock file (F5)
 }
 
 // NewAuthenticator constructs an Authenticator. The supplied client.Client
@@ -111,7 +111,7 @@ type preHandshakeRequest struct {
 
 // preHandshakeResponse matches the contract §5 step-1 response shape.
 type preHandshakeResponse struct {
-	Salt      string          `json:"salt"`
+	Salt      string           `json:"salt"`
 	KDFParams crypto.KDFParams `json:"kdfParams"`
 }
 
@@ -438,8 +438,8 @@ func (a *Authenticator) Claim(ctx context.Context, claimToken string, body Claim
 
 // RecoverBody is the contract §6 POST /api/auth/recover body.
 type RecoverBody struct {
-	Email             string `json:"email"`
-	RecoveryKeyProof  string `json:"recoveryKeyProof"`
+	Email            string `json:"email"`
+	RecoveryKeyProof string `json:"recoveryKeyProof"`
 }
 
 // RecoverResponse mirrors the substrate response per contract §6 v2.0.
@@ -532,6 +532,12 @@ type MeResponse struct {
 	Email              string `json:"email"`
 	SubscriptionStatus string `json:"subscriptionStatus"`
 	CreatedAt          string `json:"createdAt"`
+	// Backup freshness + quota (issue #59). Populated by substrate; decode to
+	// zero values against an older substrate that doesn't send them yet.
+	LastBackupAt    string `json:"lastBackupAt"`
+	QuotaUsedBytes  int64  `json:"quotaUsedBytes"`
+	QuotaTotalBytes int64  `json:"quotaTotalBytes"`
+	VersionCount    int    `json:"versionCount"`
 }
 
 // Me fetches the current user's profile from the backend. Used by the

--- a/go-engine/internal/commands/backup_status.go
+++ b/go-engine/internal/commands/backup_status.go
@@ -13,15 +13,18 @@ import (
 //
 // Field shape locked in the plan §"Envelope shapes (Question 6)":
 //
-//   {
-//     "signedIn":            bool,
-//     "email":               string?,
-//     "userId":              string?,
-//     "subscriptionStatus":  string?,
-//     "issuerUrl":           string,
-//     "lastBackupAt":        string?,
-//     "keychainError":       string?
-//   }
+//	{
+//	  "signedIn":            bool,
+//	  "email":               string?,
+//	  "userId":              string?,
+//	  "subscriptionStatus":  string?,
+//	  "issuerUrl":           string,
+//	  "lastBackupAt":        string?,
+//	  "quotaUsedBytes":      number?,
+//	  "quotaTotalBytes":     number?,
+//	  "versionCount":        number?,
+//	  "keychainError":       string?
+//	}
 //
 // Optional fields are present only when the user is signed in. issuerUrl
 // is always present so the GUI can show "you're configured to talk to <X>"
@@ -36,6 +39,9 @@ type StatusResult struct {
 	SubscriptionStatus string `json:"subscriptionStatus,omitempty"`
 	IssuerURL          string `json:"issuerUrl"`
 	LastBackupAt       string `json:"lastBackupAt,omitempty"`
+	QuotaUsedBytes     int64  `json:"quotaUsedBytes,omitempty"`
+	QuotaTotalBytes    int64  `json:"quotaTotalBytes,omitempty"`
+	VersionCount       int    `json:"versionCount,omitempty"`
 	KeychainError      string `json:"keychainError,omitempty"`
 }
 
@@ -67,5 +73,11 @@ func runBackupStatus(flags BackupFlags) (interface{}, *envelope.Error) {
 	res.Email = me.Email
 	res.UserID = me.UserID
 	res.SubscriptionStatus = me.SubscriptionStatus
+	// Backup freshness + quota (issue #59) for the GUI's last-sync indicator +
+	// quota meter. Absent against an older substrate → zero values → omitted.
+	res.LastBackupAt = me.LastBackupAt
+	res.QuotaUsedBytes = me.QuotaUsedBytes
+	res.QuotaTotalBytes = me.QuotaTotalBytes
+	res.VersionCount = me.VersionCount
 	return res, nil
 }

--- a/go-engine/internal/commands/backup_test.go
+++ b/go-engine/internal/commands/backup_test.go
@@ -32,9 +32,9 @@ func fakeBackend(t *testing.T) *httptest.Server {
 	srv := httptest.NewServer(mux)
 	mux.HandleFunc("/.well-known/openid-configuration", func(w http.ResponseWriter, r *http.Request) {
 		_ = json.NewEncoder(w).Encode(oidc.Document{
-			Issuer:                            srv.URL,
-			JWKSURI:                           srv.URL + "/api/.well-known/jwks.json",
-			IDTokenSigningAlgValuesSupported:  []string{"EdDSA"},
+			Issuer:                           srv.URL,
+			JWKSURI:                          srv.URL + "/api/.well-known/jwks.json",
+			IDTokenSigningAlgValuesSupported: []string{"EdDSA"},
 			EndstateExtensions: oidc.EndstateExtensions{
 				AuthSignupEndpoint:        srv.URL + "/api/auth/signup",
 				AuthLoginEndpoint:         srv.URL + "/api/auth/login",
@@ -82,11 +82,15 @@ func fakeBackend(t *testing.T) *httptest.Server {
 	})
 	mux.HandleFunc("/api/account/me", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("X-Endstate-API-Version", "2.0")
-		_ = json.NewEncoder(w).Encode(map[string]string{
+		_ = json.NewEncoder(w).Encode(map[string]any{
 			"userId":             "user-1",
 			"email":              "user@example.com",
 			"subscriptionStatus": "active",
 			"createdAt":          "2026-05-02T00:00:00Z",
+			"lastBackupAt":       "2026-05-30T12:04:20Z",
+			"quotaUsedBytes":     272500,
+			"quotaTotalBytes":    1073741824,
+			"versionCount":       3,
 		})
 	})
 	mux.HandleFunc("/api/billing/checkout", func(w http.ResponseWriter, r *http.Request) {
@@ -182,6 +186,19 @@ func TestBackupStatus_SignedIn(t *testing.T) {
 	}
 	if res.SubscriptionStatus != "active" {
 		t.Errorf("subscription = %q, want active", res.SubscriptionStatus)
+	}
+	// #59: backup freshness + quota map through from /api/account/me.
+	if res.LastBackupAt != "2026-05-30T12:04:20Z" {
+		t.Errorf("lastBackupAt = %q, want 2026-05-30T12:04:20Z", res.LastBackupAt)
+	}
+	if res.QuotaUsedBytes != 272500 {
+		t.Errorf("quotaUsedBytes = %d, want 272500", res.QuotaUsedBytes)
+	}
+	if res.QuotaTotalBytes != 1073741824 {
+		t.Errorf("quotaTotalBytes = %d, want 1073741824", res.QuotaTotalBytes)
+	}
+	if res.VersionCount != 3 {
+		t.Errorf("versionCount = %d, want 3", res.VersionCount)
 	}
 }
 


### PR DESCRIPTION
Engine half of #59. `backup status` reported subscription state but never the freshness/quota fields the GUI binds to — so a freshly-saved backup showed "No backups yet" and the quota meter stayed invisible. This maps the new `/api/account/me` fields through.

## Changes
- `MeResponse` gains `lastBackupAt` + `quotaUsedBytes` / `quotaTotalBytes` / `versionCount` (decode to zero values against an older substrate that doesn't send them yet).
- `StatusResult` gains `quotaUsedBytes` / `quotaTotalBytes` / `versionCount`; `runBackupStatus` copies all four from `/me`. `omitempty` keeps a signed-out / pre-backup status clean.

## Tests
The `/api/account/me` test fixture now returns the fields and `TestBackupStatus_SignedIn` asserts they map through. Full engine suite green; `gofmt` + `go vet` clean.

## Coupling
Substrate companion: **substrate-systems/substrate#19** computes the values on `/api/account/me`. Both must deploy for the fields to appear live. The **GUI needs no change** — `types.ts` + `backup-pane.tsx` already bind `lastBackupAt` / `quotaUsedBytes` / `quotaTotalBytes` / `versionCount`. End-to-end correctness lands with the live backup-status round-trip.

Part of #59.

🤖 Generated with [Claude Code](https://claude.com/claude-code)