### PR TITLE
fix(engine): correct winget version-column parse + uninstall not-found exit code

### DIFF
--- a/go-engine/internal/commands/verify.go
+++ b/go-engine/internal/commands/verify.go
@@ -95,9 +95,12 @@ type VerifyItem struct {
 //     an ItemEvent per app.
 //  3. Emit a SummaryEvent("verify", ...) and return the VerifyResult.
 //
-// Partial failures (missing apps) are encoded in the result data — they do NOT
-// produce a non-nil *envelope.Error; the caller sets success=false in the
-// envelope based on the fail count.
+// Partial failures (missing apps, version drift) are encoded in the result data
+// — they do NOT produce a non-nil *envelope.Error and do NOT flip the envelope's
+// top-level `success` flag. Per docs/contracts/cli-json-contract.md, `success`
+// reflects whether the command ran and produced a valid result (it is false only
+// for a non-nil *envelope.Error, e.g. infrastructure/command errors); per-item
+// outcomes live in summary.fail and each result's status/reason.
 func RunVerify(flags VerifyFlags) (interface{}, *envelope.Error) {
 	// Build a run-scoped emitter. Streaming is enabled only when --events jsonl
 	// was passed. The emitter is a no-op when disabled, so no guard is needed.

--- a/go-engine/internal/driver/winget/uninstall.go
+++ b/go-engine/internal/driver/winget/uninstall.go
@@ -18,14 +18,15 @@ import (
 var _ driver.Uninstaller = (*WingetDriver)(nil)
 
 // noPackageFoundExitCode is winget's APPINSTALLER_CLI_ERROR_NO_APPLICATIONS_FOUND
-// (HRESULT 0x8A15002B), returned by `winget uninstall` when no installed package
-// matches. As with the install codes, Windows may surface the signed or unsigned
-// 32-bit interpretation, and (also like the install codes) an HRESULT cannot
-// survive POSIX 8-bit exit-code truncation — so on non-Windows this path is
-// untested and the output-substring check below is the primary "absent" signal.
-// NOTE: confirm the exact value against a real winget on Windows.
-const noPackageFoundExitCodeSigned = -1978335211
-const noPackageFoundExitCodeUnsigned = 2316632085
+// (HRESULT 0x8A150014), returned by `winget uninstall` when no installed package
+// matches. Confirmed empirically against winget v1.28.240: `winget uninstall` of
+// a non-existent id exits -1978335212 (the signed 32-bit form). As with the
+// install codes, Windows may surface the signed or unsigned interpretation, and
+// an HRESULT cannot survive POSIX 8-bit exit-code truncation — so on non-Windows
+// this path is untested and the output-substring check below is the primary
+// "absent" signal.
+const noPackageFoundExitCodeSigned = -1978335212
+const noPackageFoundExitCodeUnsigned = 2316632084
 
 // noPackageFoundPattern matches winget output indicating nothing matched the
 // uninstall request. This is the cross-platform-reliable "absent" signal (the

--- a/go-engine/internal/driver/winget/uninstall_test.go
+++ b/go-engine/internal/driver/winget/uninstall_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -58,6 +59,29 @@ func TestUninstall_AbsentViaOutput(t *testing.T) {
 	}
 	if res.Status != driver.StatusAbsent {
 		t.Errorf("Status = %q, want %q (already-absent is a no-op)", res.Status, driver.StatusAbsent)
+	}
+}
+
+func TestUninstall_AbsentViaExitCode(t *testing.T) {
+	// Ground truth: real `winget uninstall` for a non-existent package returns
+	// HRESULT 0x8A150014 (APPINSTALLER_CLI_ERROR_NO_APPLICATIONS_FOUND, signed
+	// -1978335212), confirmed empirically against winget v1.28.240. With NO
+	// matching output substring, the exit code is the only "absent" signal — it
+	// must classify as a no-op (StatusAbsent), not a failure.
+	//
+	// Windows-only: the HRESULT cannot survive POSIX 8-bit exit-code truncation;
+	// winget is a Windows-only backend in production.
+	if runtime.GOOS != "windows" {
+		t.Skip("HRESULT exit code cannot survive POSIX 8-bit truncation; winget is Windows-only in production")
+	}
+	const realNotFoundExitCode = -1978335212 // 0x8A150014, confirmed on winget v1.28.240
+	d := &WingetDriver{ExecCommand: fakeUninstallCmd(realNotFoundExitCode, "", "", nil)}
+	res, err := d.Uninstall("Endstate.NoSuchApp.XYZ123")
+	if err != nil {
+		t.Fatalf("Uninstall returned unexpected error: %v", err)
+	}
+	if res.Status != driver.StatusAbsent {
+		t.Errorf("Status = %q, want %q (not-found exit code is a no-op for rollback idempotency)", res.Status, driver.StatusAbsent)
 	}
 }
 

--- a/go-engine/internal/driver/winget/winget.go
+++ b/go-engine/internal/driver/winget/winget.go
@@ -58,7 +58,7 @@ func (w *WingetDriver) Name() string { return "winget" }
 //
 // Exit code semantics:
 //   - 0                 → StatusInstalled
-//   - -1978335189 (0x8A150019) → StatusPresent / ReasonAlreadyInstalled
+//   - -1978335189 (0x8A15002B) → StatusPresent / ReasonAlreadyInstalled
 //   - other non-zero    → StatusFailed / ReasonInstallFailed
 //
 // If combined stdout+stderr contains cancellation keywords the reason is

--- a/go-engine/internal/driver/winget/winget.go
+++ b/go-engine/internal/driver/winget/winget.go
@@ -17,10 +17,12 @@ import (
 )
 
 // alreadyInstalledExitCode is the winget exit code that means the package is
-// already installed. The HRESULT is 0x8A150019. On Windows, ExitProcess() takes
-// a UINT (uint32), so Go's ExitCode() may return either the signed int32
-// interpretation (-1978335189) or the unsigned uint32 interpretation (2316632107)
-// depending on the Go version and platform. We check both.
+// already installed. The HRESULT is 0x8A15002B; confirmed empirically against
+// winget v1.28.240 (re-installing a pinned, already-present version exits
+// -1978335189). On Windows, ExitProcess() takes a UINT (uint32), so Go's
+// ExitCode() may return either the signed int32 interpretation (-1978335189) or
+// the unsigned uint32 interpretation (2316632107) depending on the Go version
+// and platform. We check both.
 const alreadyInstalledExitCodeSigned = -1978335189
 const alreadyInstalledExitCodeUnsigned = 2316632107
 

--- a/go-engine/internal/driver/winget/winget_test.go
+++ b/go-engine/internal/driver/winget/winget_test.go
@@ -139,12 +139,12 @@ func TestInstall_Success(t *testing.T) {
 }
 
 func TestInstall_AlreadyInstalled(t *testing.T) {
-	// alreadyInstalledExitCode = -1978335189 (0x8A150019). On Windows,
+	// alreadyInstalledExitCode = -1978335189 (0x8A15002B). On Windows,
 	// os.Exit propagates the full 32-bit value and exec.ExitError.ExitCode()
 	// recovers it correctly via GetExitCodeProcess. This test is therefore
 	// Windows-only by design; the production target is Windows.
 	if runtime.GOOS != "windows" {
-		t.Skip("HRESULT exit code 0x8A150019 cannot survive POSIX 8-bit exit-code truncation; winget is Windows-only in production")
+		t.Skip("HRESULT exit code 0x8A15002B cannot survive POSIX 8-bit exit-code truncation; winget is Windows-only in production")
 	}
 	d := &WingetDriver{ExecCommand: fakeCommand(alreadyInstalledExitCodeSigned, "", "")}
 	result, err := d.Install("Git.Git")

--- a/go-engine/internal/snapshot/snapshot.go
+++ b/go-engine/internal/snapshot/snapshot.go
@@ -271,6 +271,7 @@ func parseWingetList(output []byte) ([]SnapshotApp, error) {
 
 	// Phase 1: Find the header row and record column positions.
 	var nameCol, idCol, versionCol, sourceCol int
+	versionEnd := -1 // right boundary of the Version column; -1 means end of line
 	headerFound := false
 	var headerLine string
 
@@ -288,10 +289,20 @@ func parseWingetList(output []byte) ([]SnapshotApp, error) {
 			idCol = idIdx
 			versionCol = versionIdx
 
-			// Source column is optional; find it if present.
+			// Columns after Version vary by winget invocation: `--source winget`
+			// drops the Source column, and an "Available" (pending-upgrade) column
+			// appears whenever any listed app has an upgrade. The Version value must
+			// be bounded at whichever column comes next (Available or Source),
+			// otherwise it swallows that trailing column's value (e.g. capturing
+			// "1.7.1   1.8.1" instead of "1.7.1"). Source, when present, is last.
 			sourceIdx := strings.Index(line, "Source")
 			if sourceIdx > versionIdx {
 				sourceCol = sourceIdx
+				versionEnd = sourceIdx
+			}
+			availableIdx := strings.Index(line, "Available")
+			if availableIdx > versionIdx && (versionEnd < 0 || availableIdx < versionEnd) {
+				versionEnd = availableIdx
 			}
 
 			headerFound = true
@@ -332,11 +343,13 @@ func parseWingetList(output []byte) ([]SnapshotApp, error) {
 		id := extractColumn(line, idCol, versionCol)
 
 		var version, source string
-		if sourceCol > 0 {
-			version = extractColumn(line, versionCol, sourceCol)
-			source = extractColumnToEnd(line, sourceCol)
+		if versionEnd >= 0 {
+			version = extractColumn(line, versionCol, versionEnd)
 		} else {
 			version = extractColumnToEnd(line, versionCol)
+		}
+		if sourceCol > 0 {
+			source = extractColumnToEnd(line, sourceCol)
 		}
 
 		// Skip entries with empty ID — they're not useful.

--- a/go-engine/internal/snapshot/snapshot_test.go
+++ b/go-engine/internal/snapshot/snapshot_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 )
 
@@ -135,6 +136,94 @@ Git                              Git.Git                           2.43.0       
 	}
 	if apps[1].ID != "Git.Git" {
 		t.Errorf("expected second app ID=%q, got %q", "Git.Git", apps[1].ID)
+	}
+}
+
+// layoutRow renders one winget-list row by left-padding each field to the
+// real column offsets observed from `winget list --source winget` on winget
+// v1.28: Name@0, Id@44, Version@89, Available@109. Passing available="" models
+// an app that is up to date (no upgrade in the Available column).
+func layoutRow(name, id, version, available string) string {
+	pad := func(s string, width int) string {
+		if len(s) >= width {
+			return s
+		}
+		return s + strings.Repeat(" ", width-len(s))
+	}
+	return pad(name, 44) + pad(id, 45) + pad(version, 20) + available
+}
+
+// TestTakeSnapshot_SourceWingetWithAvailableColumn is a regression guard for the
+// real `winget list --source winget` layout: it omits the Source column and
+// inserts an "Available" (upgrade) column when any listed app has an upgrade
+// pending. The Version column must be bounded at Available, not extended to end
+// of line — otherwise a pinned app's version is captured as "1.7.1   1.8.1",
+// producing phantom version_drift in verify and apply --repin.
+func TestTakeSnapshot_SourceWingetWithAvailableColumn(t *testing.T) {
+	header := layoutRow("Name", "Id", "Version", "Available")
+	sep := strings.Repeat("-", 120)
+	jq := layoutRow("jq", "jqlang.jq", "1.7.1", "1.8.1") // upgrade pending
+	git := layoutRow("Git", "Git.Git", "2.43.0", "")     // up to date
+	out := strings.Join([]string{header, sep, jq, git}, "\n") + "\n"
+
+	cleanup := withFakeExec([]byte(out), nil)
+	defer cleanup()
+
+	apps, err := TakeSnapshot()
+	if err != nil {
+		t.Fatalf("TakeSnapshot returned unexpected error: %v", err)
+	}
+	if len(apps) != 2 {
+		t.Fatalf("expected 2 apps, got %d: %+v", len(apps), apps)
+	}
+
+	if apps[0].ID != "jqlang.jq" {
+		t.Errorf("expected apps[0].ID=%q, got %q", "jqlang.jq", apps[0].ID)
+	}
+	if apps[0].Version != "1.7.1" {
+		t.Errorf("expected apps[0].Version=%q (Available column must not leak in), got %q", "1.7.1", apps[0].Version)
+	}
+	if apps[1].ID != "Git.Git" {
+		t.Errorf("expected apps[1].ID=%q, got %q", "Git.Git", apps[1].ID)
+	}
+	if apps[1].Version != "2.43.0" {
+		t.Errorf("expected apps[1].Version=%q, got %q", "2.43.0", apps[1].Version)
+	}
+}
+
+// TestTakeSnapshot_AvailableAndSourceColumns covers the multi-source list layout
+// (no --source filter) where BOTH Available and Source columns are present:
+// Version must be bounded at Available, and Source still captured.
+func TestTakeSnapshot_AvailableAndSourceColumns(t *testing.T) {
+	pad := func(s string, width int) string {
+		if len(s) >= width {
+			return s
+		}
+		return s + strings.Repeat(" ", width-len(s))
+	}
+	row := func(name, id, version, available, source string) string {
+		return pad(name, 44) + pad(id, 45) + pad(version, 20) + pad(available, 16) + source
+	}
+	header := row("Name", "Id", "Version", "Available", "Source")
+	sep := strings.Repeat("-", 130)
+	jq := row("jq", "jqlang.jq", "1.7.1", "1.8.1", "winget")
+	out := strings.Join([]string{header, sep, jq}, "\n") + "\n"
+
+	cleanup := withFakeExec([]byte(out), nil)
+	defer cleanup()
+
+	apps, err := TakeSnapshot()
+	if err != nil {
+		t.Fatalf("TakeSnapshot returned unexpected error: %v", err)
+	}
+	if len(apps) != 1 {
+		t.Fatalf("expected 1 app, got %d: %+v", len(apps), apps)
+	}
+	if apps[0].Version != "1.7.1" {
+		t.Errorf("expected Version=%q (Available must not leak in), got %q", "1.7.1", apps[0].Version)
+	}
+	if apps[0].Source != "winget" {
+		t.Errorf("expected Source=%q, got %q", "winget", apps[0].Source)
 	}
 }
 

--- a/openspec/changes/version-drift-enforcement/design.md
+++ b/openspec/changes/version-drift-enforcement/design.md
@@ -79,5 +79,20 @@ The realizer apply path never reads `App.Version`/`Repin` — nix is unaffected.
   dispatch is hermetic (mock asserts `ReinstallVersion` under `--repin --confirm`), but whether
   `winget install --version X --force` actually downgrades is **maintainer-verified on Windows**;
   documented fallback = uninstall + InstallVersion.
+
+  **RESOLVED (winget v1.28.240, jqlang.jq smoke):** `winget install --version X --force` converges in
+  BOTH directions — it upgrades (1.7.1→1.8.1) AND downgrades (1.8.1→1.7.1). Mechanism A is correct as
+  shipped; the uninstall+install fallback is NOT required. Two real-winget bugs were found and fixed
+  while validating the surrounding paths (both were invisible to the hermetic fixtures):
+  1. **Version-parser (`snapshot.parseWingetList`)** — real `winget list --source winget` emits no
+     `Source` column and inserts an `Available` (pending-upgrade) column whenever an upgrade exists.
+     The parser bounded the Version field at `Source`/EOL, so it swallowed the Available value
+     ("1.7.1   1.8.1"), producing **phantom `version_drift`** in `verify` and `apply --repin`. Fixed by
+     bounding Version at the next header column (Available or Source, whichever is first).
+  2. **Uninstall not-found exit code (`uninstall.go`)** — the real HRESULT is `0x8A150014`
+     (`-1978335212`), not the coded `0x8A150015` (`-1978335211`). Masked in practice by the output
+     substring (the primary signal), but the secondary exit-code anchor was off by one. Corrected.
+     (The already-installed code `-1978335189` is correct; only its comment hex `0x8A150019` was wrong —
+     it is `0x8A15002B`.)
 - **CI gotcha (Phase 4):** `RunApply`/`RunVerify` tests override BOTH `newDriverFn` AND
   `newRealizerFn` or windows-latest exercises the wrong backend.

--- a/openspec/changes/version-drift-enforcement/tasks.md
+++ b/openspec/changes/version-drift-enforcement/tasks.md
@@ -47,6 +47,11 @@
 - [x] 5.1 `cd go-engine && go test ./...` green on Linux
 - [x] 5.2 `GOOS=windows go build ./...` + `go vet ./...` clean
 - [x] 5.3 `npm run openspec:validate` (strict) passes
-- [ ] 5.4 (Maintainer, Windows) real-winget smoke: a drifted pinned app → `verify` reports
-      `version_drift`; `apply --repin --confirm` reinstalls the declared version (`--force` downgrades;
-      else fall back to uninstall+install); `--repin` without `--confirm` refuses
+- [x] 5.4 (Maintainer, Windows) real-winget smoke — done on winget v1.28.240 with `jqlang.jq`
+      (OLD 1.7.1 / NEW 1.8.1). Results: drifted pin → `verify` reports `version_drift` (clean
+      `version`/`expected`); `apply --repin --confirm` converges in BOTH directions — `--force`
+      **upgrades** 1.7.1→1.8.1 AND **downgrades** 1.8.1→1.7.1, so mechanism A holds and the
+      uninstall+install fallback is NOT needed; `--repin` without `--confirm` refuses (INTERNAL_ERROR),
+      drift left in place. Smoke also surfaced and fixed a snapshot version-parser bug (the winget
+      `Available` column was swallowed into the captured version, causing phantom `version_drift`) and
+      an off-by-one in the uninstall not-found exit code (0x8A150014, not 0x8A150015).


### PR DESCRIPTION
## Summary

Real-winget verification of Phases 4/6/7 (best-effort rollback, version capture/pin, drift enforcement) on **winget v1.28.240** surfaced two bugs that the Linux hermetic fixtures could not catch, because the fixtures assumed a `Name Id Version Source` layout that real winget does not always produce.

### Bug 1 — version parser swallowed the `Available` column (caused phantom `version_drift`)
Real `winget list --source winget` emits **no `Source` column** and inserts an **`Available`** (pending-upgrade) column whenever a listed app has an upgrade available. `snapshot.parseWingetList` bounded the Version field at `Source`/EOL, so it captured `"1.7.1   1.8.1"` instead of `"1.7.1"`. Effect: `verify` and `apply --repin` reported **false `version_drift`** for a correctly-pinned app whenever an upgrade existed.

**Fix:** bound the Version field at the next header column (`Available` or `Source`, whichever comes first), falling back to EOL.

Confirmed end-to-end: before fix, `verify` on a matched pin (jq 1.7.1 declared & installed, 1.8.1 available) returned `version_drift` with `version: "1.7.1               1.8.1"`; after fix it returns `pass`, `version: "1.7.1"`.

### Bug 2 — uninstall not-found exit code off by one
Real winget returns `0x8A150014` (`-1978335212`, `APPINSTALLER_CLI_ERROR_NO_APPLICATIONS_FOUND`) when `winget uninstall` matches nothing; the code had `0x8A150015` (`-1978335211`). Masked in practice by the output-substring check (the primary signal), but the secondary exit-code anchor was wrong. Also corrected the already-installed comment hex (`0x8A15002B`, not `0x8A150019`; the constant `-1978335189` was already correct, confirmed empirically).

## Tests
- New hermetic tests reproduce the real winget layouts: `--source winget` with `Available` (no Source), and `Available`+`Source` together; plus a Windows-only test locking the corrected not-found exit code.
- Full `go test ./...` and `go vet ./...` **green on Windows**.

## Real-winget smoke results (Phase 7 §5.4)
Done with `jqlang.jq` (OLD 1.7.1 / NEW 1.8.1):
- ✅ P6 pin: `apply` installs exactly the declared version; generation records it.
- ✅ P7 drift: `verify` reports `version_drift` with clean `version`/`expected`.
- ✅ P7 repin refuse: `apply --repin` without `--confirm` → `INTERNAL_ERROR`, drift left in place.
- ✅ P7 repin: `apply --repin --confirm` converges.
- ✅ P6 unavailable: a non-existent pinned version → `install_failed` (never silently satisfied).
- ✅ P4 rollback: `rollback --to 1 --confirm` uninstalls the gen-2 ref; re-running on the already-absent ref is a no-op success (exercises the not-found uninstall path).

### Headline verdict (the big unknown)
**`winget install --version X --force` converges in BOTH directions** on winget v1.28.240 — it upgrades (1.7.1→1.8.1) **and** downgrades (1.8.1→1.7.1). Mechanism A is correct as shipped; the documented uninstall+install fallback is **not needed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)