### PR TITLE
feat(engine): nix package capture (close apply↔capture loop on realizer)

### DIFF
--- a/go-engine/internal/commands/capture.go
+++ b/go-engine/internal/commands/capture.go
@@ -163,6 +163,13 @@ func RunCapture(flags CaptureFlags) (interface{}, *envelope.Error) {
 	runID := buildRunID("capture")
 	emitter := events.NewEmitter(runID, flags.Events == "jsonl")
 
+	// --- 0. Realizer path (whole-set, e.g. Nix on linux/darwin) ---
+	// On Windows newRealizerFn returns ErrNoRealizer and control falls through to
+	// the winget capture path below, byte-identical to prior behavior.
+	if rz, rerr := newRealizerFn(); rerr == nil {
+		return runCaptureRealizer(flags, rz, emitter)
+	}
+
 	// --- 1. Emit phase event (first event per event-contract.md) ---
 	emitter.EmitPhase("capture")
 

--- a/go-engine/internal/commands/capture_realizer.go
+++ b/go-engine/internal/commands/capture_realizer.go
@@ -1,0 +1,190 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sort"
+	"time"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/events"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+// runCaptureRealizer is the capture path for a realizer backend (Nix on
+// linux/darwin). It reads the installed set via Current() and emits each element
+// as a manifest app keyed by the host OS, using the same manifest shape, output-
+// path resolution, and write/verify invariants as the winget path.
+//
+// It is package-scoped: no config modules, manual apps, or config bundle are
+// synthesized (those are the winget app catalog). The emitted ref is the
+// element's bare attr (its Name) — NOT its AttrPath — so apply's
+// ResolveInstallable expands it against the pin and the manifest stays portable
+// across realizer hosts (no system tuple baked in). A capture therefore
+// round-trips: apply of the produced manifest re-installs the same set.
+func runCaptureRealizer(flags CaptureFlags, r realizer.Realizer, emitter *events.Emitter) (interface{}, *envelope.Error) {
+	driverName := r.Name()
+
+	// --- 1. Emit phase event (first event per event-contract.md) ---
+	emitter.EmitPhase("capture")
+
+	// --- 2. Read the installed set ---
+	cur, cerr := r.Current()
+	if cerr != nil {
+		if rerr, ok := cerr.(*realizer.Error); ok && isSystemic(rerr.Code) {
+			return nil, realizerEnvelopeError(rerr)
+		}
+		// Non-systemic read issue: treat as empty (capture an empty set),
+		// mirroring runVerifyRealizer.
+	}
+
+	// --- 3. Convert the set to captured apps (deterministic order) ---
+	names := make([]string, 0, len(cur.Elements))
+	for name := range cur.Elements {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	goos := runtime.GOOS
+	captured := make([]capturedApp, 0, len(names))
+	for _, name := range names {
+		el := cur.Elements[name]
+		ref := el.Name // bare attr -> apply's ResolveInstallable expands against the pin
+		captured = append(captured, capturedApp{
+			ID:   name,
+			Refs: map[string]string{goos: ref},
+			Name: name,
+		})
+		emitter.EmitItem(ref, driverName, "captured", "", fmt.Sprintf("Captured %s", name), name)
+	}
+
+	// --- 4. If --update and --manifest: merge with existing manifest (host-keyed) ---
+	if flags.Update && flags.Manifest != "" {
+		existingMf, loadErr := loadManifest(flags.Manifest)
+		if loadErr != nil {
+			return nil, loadErr
+		}
+		existingRefs := make(map[string]bool)
+		for _, app := range existingMf.Apps {
+			if ref, ok := app.Refs[goos]; ok {
+				existingRefs[ref] = true
+			}
+		}
+		merged := make([]capturedApp, 0, len(existingMf.Apps)+len(captured))
+		for _, app := range existingMf.Apps {
+			merged = append(merged, capturedApp{ID: app.ID, Refs: app.Refs})
+		}
+		for _, app := range captured {
+			if !existingRefs[app.Refs[goos]] {
+				merged = append(merged, app)
+			}
+		}
+		captured = merged
+	}
+
+	included := len(captured)
+
+	// --- 5. Sanitize / sort by id ---
+	var outputApps interface{}
+	if flags.Sanitize {
+		sorted := make([]cleanApp, len(captured))
+		for i, app := range captured {
+			sorted[i] = cleanApp{ID: app.ID, Refs: app.Refs}
+		}
+		sort.Slice(sorted, func(i, j int) bool { return sorted[i].ID < sorted[j].ID })
+		outputApps = sorted
+	} else {
+		sort.Slice(captured, func(i, j int) bool { return captured[i].ID < captured[j].ID })
+		outputApps = captured
+	}
+
+	// --- 6. Determine output path and manifest name ---
+	outputPath := resolveOutputPath(flags)
+	manifestName := "captured"
+	if flags.Name != "" {
+		manifestName = flags.Name
+	} else if flags.Profile != "" {
+		manifestName = flags.Profile
+	}
+
+	outManifest := captureManifestOutput{
+		Version:  1,
+		Name:     manifestName,
+		Captured: time.Now().UTC().Format(time.RFC3339),
+		Apps:     outputApps,
+	}
+
+	// --- 7. Write manifest as pretty-printed JSON (same as the winget path) ---
+	data, marshalErr := json.MarshalIndent(outManifest, "", "  ")
+	if marshalErr != nil {
+		return nil, envelope.NewError(
+			envelope.ErrCaptureFailed,
+			fmt.Sprintf("Failed to marshal manifest: %v", marshalErr),
+		)
+	}
+	if dir := filepath.Dir(outputPath); dir != "" && dir != "." {
+		if mkdirErr := os.MkdirAll(dir, 0755); mkdirErr != nil {
+			return nil, envelope.NewError(
+				envelope.ErrManifestWriteFailed,
+				fmt.Sprintf("Failed to create output directory: %v", mkdirErr),
+			).WithRemediation("Check directory permissions and ensure the path is writable.")
+		}
+	}
+	if writeErr := os.WriteFile(outputPath, data, 0644); writeErr != nil {
+		return nil, envelope.NewError(
+			envelope.ErrManifestWriteFailed,
+			fmt.Sprintf("Failed to write manifest file: %v", writeErr),
+		).WithRemediation("Check directory permissions and ensure the path is writable.")
+	}
+
+	// --- 8. INV-CAPTURE-2: verify file exists and is non-empty ---
+	if fileInfo, statErr := os.Stat(outputPath); statErr != nil || fileInfo.Size() == 0 {
+		return nil, envelope.NewError(
+			envelope.ErrManifestWriteFailed,
+			"Manifest file is empty or does not exist after write.",
+		).WithRemediation("Check disk space and directory permissions.")
+	}
+
+	absPath, absErr := filepath.Abs(outputPath)
+	if absErr != nil {
+		absPath = outputPath
+	}
+
+	// --- 9. Build appsIncluded (package-scoped; source is the backend name) ---
+	appsIncluded := make([]CaptureApp, 0, len(captured))
+	for _, ca := range captured {
+		appsIncluded = append(appsIncluded, CaptureApp{Source: driverName, ID: ca.ID, Name: ca.Name})
+	}
+
+	// --- 10. Emit artifact and summary events ---
+	emitter.EmitArtifact("capture", "manifest", absPath)
+	emitter.EmitSummary("capture", included, included, 0, 0)
+
+	// No config modules / bundle on the realizer path (packages only).
+	return &CaptureResult{
+		AppsIncluded:         appsIncluded,
+		ConfigModules:        []CaptureModuleResult{},
+		ConfigModuleMap:      map[string]string{},
+		OutputPath:           absPath,
+		OutputFormat:         "jsonc",
+		ConfigsIncluded:      []string{},
+		ConfigsSkipped:       []string{},
+		ConfigsCaptureErrors: []string{},
+		Sanitized:            flags.Sanitize,
+		IsExample:            false,
+		Counts: CaptureCountsFull{
+			Included:   included,
+			TotalFound: included,
+		},
+		Manifest: CaptureManifest{
+			Name: manifestName,
+			Path: absPath,
+		},
+	}, nil
+}

--- a/go-engine/internal/commands/capture_realizer_test.go
+++ b/go-engine/internal/commands/capture_realizer_test.go
@@ -1,0 +1,301 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers for the realizer capture path
+// ---------------------------------------------------------------------------
+
+// nixSet builds a realizer.Set from element names. Each element's Name is the
+// bare attr (its map key, as `nix profile list` reports a nixpkgs install) while
+// AttrPath carries a realistic, system-qualified path that DIFFERS from Name —
+// so a test asserting the emitted ref equals Name proves we emit the portable
+// bare attr, not the arch-baked AttrPath.
+func nixSet(names ...string) realizer.Set {
+	els := map[string]realizer.Element{}
+	for _, n := range names {
+		els[n] = realizer.Element{
+			Name:       n,
+			AttrPath:   "legacyPackages.x86_64-linux." + n,
+			StorePaths: []string{"/nix/store/0000000000000000000000000000-" + n + "-1.0.0"},
+		}
+	}
+	return realizer.Set{Generation: 1, Elements: els}
+}
+
+// capturedManifestFile is the on-disk capture manifest shape, for read-back.
+type capturedManifestFile struct {
+	Version  int    `json:"version"`
+	Name     string `json:"name"`
+	Captured string `json:"captured"`
+	Apps     []struct {
+		ID      string            `json:"id"`
+		Refs    map[string]string `json:"refs"`
+		Version string            `json:"version"`
+	} `json:"apps"`
+}
+
+func readCapturedManifest(t *testing.T, path string) capturedManifestFile {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read manifest %s: %v", path, err)
+	}
+	var mf capturedManifestFile
+	if err := json.Unmarshal(data, &mf); err != nil {
+		t.Fatalf("manifest is not valid JSON: %v\n%s", err, data)
+	}
+	return mf
+}
+
+// ---------------------------------------------------------------------------
+// runCaptureRealizer — core behavior
+// ---------------------------------------------------------------------------
+
+// Each element is emitted as a manifest app whose only ref is host-keyed
+// (runtime.GOOS) and equal to the element's bare attr Name — NOT its AttrPath.
+// Apps are sorted by id; the manifest is version 1; no version is recorded; and
+// the result synthesizes no config modules (packages only).
+func TestRunCaptureRealizer_EmitsBareAttrHostKeyedRefs(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "nix-capture.jsonc")
+	fr := &fakeRealizer{currentSet: nixSet("ripgrep", "jq")}
+
+	raw, eerr := runCaptureRealizer(CaptureFlags{Out: out, Name: "nixbox"}, fr, noopEmitter())
+	if eerr != nil {
+		t.Fatalf("runCaptureRealizer returned envelope error: %+v", eerr)
+	}
+	res, ok := raw.(*CaptureResult)
+	if !ok {
+		t.Fatalf("expected *CaptureResult, got %T", raw)
+	}
+	if res.Counts.Included != 2 {
+		t.Errorf("Counts.Included = %d, want 2", res.Counts.Included)
+	}
+	if res.Counts.TotalFound != 2 {
+		t.Errorf("Counts.TotalFound = %d, want 2", res.Counts.TotalFound)
+	}
+	if res.OutputFormat != "jsonc" {
+		t.Errorf("OutputFormat = %q, want jsonc", res.OutputFormat)
+	}
+	if len(res.ConfigModules) != 0 {
+		t.Errorf("realizer path must not synthesize config modules, got %d", len(res.ConfigModules))
+	}
+
+	mf := readCapturedManifest(t, out)
+	if mf.Version != 1 {
+		t.Errorf("manifest version = %d, want 1", mf.Version)
+	}
+	if mf.Name != "nixbox" {
+		t.Errorf("manifest name = %q, want nixbox", mf.Name)
+	}
+	if len(mf.Apps) != 2 {
+		t.Fatalf("manifest apps = %d, want 2", len(mf.Apps))
+	}
+	// Deterministic order: sorted by id (jq before ripgrep).
+	if mf.Apps[0].ID != "jq" || mf.Apps[1].ID != "ripgrep" {
+		t.Errorf("apps not sorted by id: %q, %q", mf.Apps[0].ID, mf.Apps[1].ID)
+	}
+	for _, a := range mf.Apps {
+		ref, ok := a.Refs[runtime.GOOS]
+		if !ok {
+			t.Errorf("app %q missing host ref %q: %+v", a.ID, runtime.GOOS, a.Refs)
+			continue
+		}
+		if ref != a.ID {
+			t.Errorf("app %q: ref = %q, want bare attr %q (must not emit AttrPath)", a.ID, ref, a.ID)
+		}
+		if len(a.Refs) != 1 {
+			t.Errorf("app %q: expected exactly the host ref, got %+v", a.ID, a.Refs)
+		}
+		if a.Version != "" {
+			t.Errorf("app %q: version = %q, want empty (out of scope)", a.ID, a.Version)
+		}
+	}
+}
+
+// An empty realizer set produces a valid manifest with an empty apps array (not
+// null) and no error.
+func TestRunCaptureRealizer_EmptyProfile_WritesValidEmptyManifest(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "empty.jsonc")
+	fr := &fakeRealizer{currentSet: realizer.Set{Elements: map[string]realizer.Element{}}}
+
+	raw, eerr := runCaptureRealizer(CaptureFlags{Out: out}, fr, noopEmitter())
+	if eerr != nil {
+		t.Fatalf("runCaptureRealizer returned envelope error: %+v", eerr)
+	}
+	res := raw.(*CaptureResult)
+	if res.Counts.Included != 0 {
+		t.Errorf("Counts.Included = %d, want 0", res.Counts.Included)
+	}
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if !strings.Contains(string(data), `"apps": []`) {
+		t.Errorf("expected empty apps array (not null), got:\n%s", data)
+	}
+	mf := readCapturedManifest(t, out)
+	if mf.Version != 1 {
+		t.Errorf("manifest version = %d, want 1", mf.Version)
+	}
+	if len(mf.Apps) != 0 {
+		t.Errorf("manifest apps = %d, want 0", len(mf.Apps))
+	}
+}
+
+// A systemic backend failure (unavailable / permission denied) surfaces as a
+// top-level envelope error and writes no manifest.
+func TestRunCaptureRealizer_SystemicError_ReturnsEnvelopeError(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "systemic.jsonc")
+	fr := &fakeRealizer{currentErr: &realizer.Error{Code: envelope.ErrRealizerUnavailable, Raw: "daemon down"}}
+
+	raw, eerr := runCaptureRealizer(CaptureFlags{Out: out}, fr, noopEmitter())
+	if eerr == nil {
+		t.Fatal("expected envelope error for systemic Current() failure, got nil")
+	}
+	if eerr.Code != envelope.ErrRealizerUnavailable {
+		t.Errorf("error code = %q, want REALIZER_UNAVAILABLE", eerr.Code)
+	}
+	if raw != nil {
+		t.Errorf("expected nil data on systemic error, got %T", raw)
+	}
+	if _, statErr := os.Stat(out); statErr == nil {
+		t.Error("expected no manifest written on systemic error")
+	}
+}
+
+// A non-systemic read issue is treated as an empty set (mirrors verify): capture
+// writes a valid empty manifest rather than failing the whole command.
+func TestRunCaptureRealizer_NonSystemicError_CapturesEmpty(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "nonsystemic.jsonc")
+	fr := &fakeRealizer{currentErr: errors.New("transient read glitch")}
+
+	raw, eerr := runCaptureRealizer(CaptureFlags{Out: out}, fr, noopEmitter())
+	if eerr != nil {
+		t.Fatalf("non-systemic error should not fail capture, got: %+v", eerr)
+	}
+	res := raw.(*CaptureResult)
+	if res.Counts.Included != 0 {
+		t.Errorf("Counts.Included = %d, want 0", res.Counts.Included)
+	}
+}
+
+// --update merges with the existing manifest, host-keyed, without duplicating a
+// package already present under the host key.
+func TestRunCaptureRealizer_Update_HostKeyedDedup(t *testing.T) {
+	tmp := t.TempDir()
+	existing := filepath.Join(tmp, "existing.jsonc")
+	existingJSON := fmt.Sprintf(`{"version":1,"name":"box","apps":[{"id":"ripgrep","refs":{"%s":"ripgrep"}}]}`, runtime.GOOS)
+	if err := os.WriteFile(existing, []byte(existingJSON), 0644); err != nil {
+		t.Fatalf("write existing manifest: %v", err)
+	}
+	out := filepath.Join(tmp, "merged.jsonc")
+	fr := &fakeRealizer{currentSet: nixSet("ripgrep", "jq")}
+
+	raw, eerr := runCaptureRealizer(CaptureFlags{Out: out, Update: true, Manifest: existing}, fr, noopEmitter())
+	if eerr != nil {
+		t.Fatalf("runCaptureRealizer returned envelope error: %+v", eerr)
+	}
+	_ = raw
+
+	mf := readCapturedManifest(t, out)
+	if len(mf.Apps) != 2 {
+		t.Fatalf("merged apps = %d, want 2 (ripgrep deduped + jq added)", len(mf.Apps))
+	}
+	count := map[string]int{}
+	for _, a := range mf.Apps {
+		count[a.ID]++
+	}
+	if count["ripgrep"] != 1 {
+		t.Errorf("ripgrep appears %d times, want 1 (no duplicate on merge)", count["ripgrep"])
+	}
+	if count["jq"] != 1 {
+		t.Errorf("jq appears %d times, want 1", count["jq"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// RunCapture fork
+// ---------------------------------------------------------------------------
+
+// When a realizer is available (newRealizerFn succeeds), RunCapture takes the
+// realizer capture path and emits host-keyed refs — not winget "windows" refs.
+func TestRunCapture_ForksToRealizerWhenAvailable(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "fork.jsonc")
+	fr := &fakeRealizer{currentSet: nixSet("ripgrep")}
+
+	var raw interface{}
+	var eerr *envelope.Error
+	withFakeRealizer(fr, func() {
+		raw, eerr = RunCapture(CaptureFlags{Out: out})
+	})
+	if eerr != nil {
+		t.Fatalf("RunCapture returned envelope error: %+v", eerr)
+	}
+	res := raw.(*CaptureResult)
+	if res.Counts.Included != 1 {
+		t.Errorf("Counts.Included = %d, want 1", res.Counts.Included)
+	}
+
+	mf := readCapturedManifest(t, out)
+	if len(mf.Apps) != 1 {
+		t.Fatalf("apps = %d, want 1", len(mf.Apps))
+	}
+	if _, ok := mf.Apps[0].Refs[runtime.GOOS]; !ok {
+		t.Errorf("fork did not take the realizer path; refs = %+v", mf.Apps[0].Refs)
+	}
+	if _, win := mf.Apps[0].Refs["windows"]; win && runtime.GOOS != "windows" {
+		t.Errorf("unexpected windows ref — winget path was taken: %+v", mf.Apps[0].Refs)
+	}
+}
+
+// When no realizer is available (Windows: newRealizerFn → ErrNoRealizer),
+// RunCapture falls through to the winget path unchanged (windows-keyed refs).
+func TestRunCapture_NoRealizer_UsesWingetPath(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "winget.jsonc")
+
+	orig := newRealizerFn
+	newRealizerFn = func() (realizer.Realizer, error) { return nil, ErrNoRealizer }
+	defer func() { newRealizerFn = orig }()
+
+	withMockSnapshot(sampleApps(), nil, func() {
+		noopDisplayNames(func() {
+			emptyCatalog(func() {
+				_, eerr := RunCapture(CaptureFlags{Out: out})
+				if eerr != nil {
+					t.Fatalf("RunCapture returned envelope error: %+v", eerr)
+				}
+			})
+		})
+	})
+
+	mf := readCapturedManifest(t, out)
+	if len(mf.Apps) == 0 {
+		t.Fatal("expected winget apps captured")
+	}
+	foundWin := false
+	for _, a := range mf.Apps {
+		if _, ok := a.Refs["windows"]; ok {
+			foundWin = true
+		}
+	}
+	if !foundWin {
+		t.Errorf("expected winget path (windows refs) when no realizer, got %+v", mf.Apps)
+	}
+}

--- a/go-engine/internal/commands/capture_test.go
+++ b/go-engine/internal/commands/capture_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/Artexis10/endstate/go-engine/internal/modules"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
 	"github.com/Artexis10/endstate/go-engine/internal/snapshot"
 )
 
@@ -23,13 +24,20 @@ import (
 
 // withMockSnapshot replaces takeSnapshotFn (which defaults to WingetExport)
 // with one that returns the given apps and error, calls f, then restores the
-// original.
+// original. It also forces the no-realizer path so RunCapture's realizer fork
+// does not divert these winget-path tests to the Nix realizer on linux/darwin
+// (mirrors withMockDriver); restored on exit.
 func withMockSnapshot(apps []snapshot.SnapshotApp, err error, f func()) {
 	orig := takeSnapshotFn
 	takeSnapshotFn = func() ([]snapshot.SnapshotApp, error) {
 		return apps, err
 	}
-	defer func() { takeSnapshotFn = orig }()
+	origRealizer := newRealizerFn
+	newRealizerFn = func() (realizer.Realizer, error) { return nil, ErrNoRealizer }
+	defer func() {
+		takeSnapshotFn = orig
+		newRealizerFn = origRealizer
+	}()
 	f()
 }
 
@@ -113,7 +121,14 @@ func withMockSnapshotSequence(calls []snapshotCall, f func()) {
 		callIdx++
 		return calls[idx].apps, calls[idx].err
 	}
-	defer func() { takeSnapshotFn = orig }()
+	// Force the no-realizer path (see withMockSnapshot) so the capture fork does
+	// not divert these winget-path tests to the Nix realizer on linux/darwin.
+	origRealizer := newRealizerFn
+	newRealizerFn = func() (realizer.Realizer, error) { return nil, ErrNoRealizer }
+	defer func() {
+		takeSnapshotFn = orig
+		newRealizerFn = origRealizer
+	}()
 	f()
 }
 
@@ -1654,6 +1669,12 @@ func TestRunCapture_NormalCapture_NoRetry(t *testing.T) {
 		return sampleApps(), nil
 	}
 	defer func() { takeSnapshotFn = orig }()
+
+	// Force the no-realizer path so the capture fork does not divert this
+	// winget-path test to the Nix realizer on linux/darwin.
+	origRealizer := newRealizerFn
+	newRealizerFn = func() (realizer.Realizer, error) { return nil, ErrNoRealizer }
+	defer func() { newRealizerFn = origRealizer }()
 
 	withRetryDelay(0, func() {
 		noopDisplayNames(func() {

--- a/openspec/changes/nix-package-capture/.openspec.yaml
+++ b/openspec/changes/nix-package-capture/.openspec.yaml
@@ -1,0 +1,10 @@
+id: nix-package-capture
+title: "Nix Package Capture: close the apply↔capture loop on the realizer"
+status: implementing
+spec: nix-package-capture
+created: "2026-06-02"
+author: Hugo Ander Kivi
+artifacts:
+  - proposal.md
+  - design.md
+  - tasks.md

--- a/openspec/changes/nix-package-capture/design.md
+++ b/openspec/changes/nix-package-capture/design.md
@@ -1,0 +1,114 @@
+## Context
+
+The realizer abstraction and apply/verify forks already exist; this change only adds a capture path.
+Today:
+- `RunCapture` (`internal/commands/capture.go`) is winget-only: `takeSnapshotFn = snapshot.WingetExport`
+  enumerates packages, each app is keyed `Refs["windows"] = sApp.ID`, and a host without winget errors
+  `WINGET_NOT_AVAILABLE`. The output manifest is `captureManifestOutput{version:1, name, captured, apps}`
+  written with `json.MarshalIndent` + `os.WriteFile` to `resolveOutputPath(flags)`, with an
+  INV-CAPTURE-2 non-empty-after-write check.
+- `RunVerify`/`RunApply` already fork on `newRealizerFn()` (shared seam, `verify.go:37`): a successful
+  realizer takes the whole-set path, else control falls through to the winget driver path. On Windows
+  `selectRealizer` returns `ErrNoRealizer`.
+- `realizer.Realizer.Current() (Set, error)` returns `Set{Generation, Elements map[string]Element}`,
+  `Element{Name, AttrPath, StorePaths}` (parsed from `nix profile list --json`). For a nixpkgs install
+  the element key/`Name` is the bare attr leaf (e.g. `ripgrep`).
+- `apply` reads `app.Refs[runtime.GOOS]` **strictly** (`apply_realizer.go`), then
+  `Backend.ResolveInstallable` expands a bare attr against the pin (`nixpkgs#ripgrep`); `verify`/`plan`
+  present-detection matches by **leaf attr** (`presentInSet`/`isPresent`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- `capture` produces a manifest from the current Nix profile on linux/darwin.
+- The emitted manifest **round-trips**: `apply` of it re-installs the same `Current()` set.
+- Zero winget/Windows regression; reuse the existing manifest output shape and write/verify invariants.
+
+**Non-Goals:**
+- **No config/settings capture** — that is the separate home-manager paradigm (a future effort).
+- **No config modules / manual apps / zip bundle** on the Nix path — those are the Windows app catalog.
+- **No version capture** — no `App.Version` on the Nix path; store-path version parsing belongs with
+  the separate nix-version-capture effort.
+- **No original-flakeref recovery** — power-user flake sources are a documented round-trip limitation.
+
+## Decisions (maintainer, confirmed)
+
+- **Ref form = bare attr** (`Refs[runtime.GOOS] = element.Name`). Justification: apply's
+  `ResolveInstallable` expands it against the pin; present-detection matches by leaf; it carries no
+  system tuple, so it round-trips through apply/verify/plan **and** is portable linux↔darwin. The
+  `AttrPath` form (`legacyPackages.x86_64-linux.ripgrep`) was rejected — it bakes in the arch and
+  breaks cross-OS rebuild. Explicit `nixpkgs#attr` was rejected — strictly less portable (hardcodes
+  the pin name) with no benefit over bare attr. Confirmed via round-trip analysis + smoke.
+- **Version out of scope** — packages only; keeps the change minimal and avoids fragile store-path
+  parsing.
+- **Mirror the verify fork exactly** — reuse `newRealizerFn` so the same Windows no-op + the same test
+  injection (`withFakeRealizer`) apply, and exactly one of `newDriverFn`/`newRealizerFn` drives a host.
+
+## Design
+
+### Fork (capture.go — only edit to the existing file)
+
+At the very top of `RunCapture`, after the emitter is built and **before** `EmitPhase("capture")`:
+
+```go
+func RunCapture(flags CaptureFlags) (interface{}, *envelope.Error) {
+    runID := buildRunID("capture")
+    emitter := events.NewEmitter(runID, flags.Events == "jsonl")
+
+    // Realizer path (Nix on linux/darwin). On Windows newRealizerFn returns
+    // ErrNoRealizer and control falls through to the winget path below,
+    // byte-identical to prior behavior.
+    if rz, rerr := newRealizerFn(); rerr == nil {
+        return runCaptureRealizer(flags, rz, emitter)
+    }
+
+    emitter.EmitPhase("capture")   // existing winget path, unchanged from here down
+    ...
+}
+```
+
+`EmitPhase("capture")` stays the first event on the winget path; `runCaptureRealizer` emits its own.
+
+### Nix capture path (capture_realizer.go — new)
+
+```go
+func runCaptureRealizer(flags CaptureFlags, r realizer.Realizer, emitter *events.Emitter) (interface{}, *envelope.Error) {
+    driverName := r.Name()
+    emitter.EmitPhase("capture")
+
+    cur, cerr := r.Current()
+    if cerr != nil {
+        if rerr, ok := cerr.(*realizer.Error); ok && isSystemic(rerr.Code) {
+            return nil, realizerEnvelopeError(rerr)   // reuse apply_realizer helpers
+        }
+        // non-systemic read issue: treat as empty (capture an empty set)
+    }
+
+    // Deterministic order: sort element names.
+    // For each element: capturedApp{ID: name, Refs: {runtime.GOOS: el.Name}, Name: name};
+    // emit a captured ItemEvent.
+    // --update + --manifest: merge with existing manifest, host-keyed (dedup on Refs[GOOS]).
+    // Sanitize/sort, build captureManifestOutput{version:1, name, captured, apps}, write to
+    // resolveOutputPath(flags) with MarshalIndent + WriteFile + INV-CAPTURE-2 non-empty check.
+    // Return *CaptureResult (same type as the winget path): AppsIncluded (Source = driverName),
+    // empty ConfigModules/config slices, OutputPath, OutputFormat "jsonc", Sanitized,
+    // Counts{TotalFound, Included}, Manifest{Name, Path}.
+}
+```
+
+Reuses existing symbols: `capturedApp`, `cleanApp`, `captureManifestOutput`, `CaptureResult`,
+`resolveOutputPath`, and the realizer error helpers `isSystemic`/`realizerEnvelopeError`. The small
+write block is reproduced (not refactored out of the winget path) so the winget path stays
+byte-identical.
+
+## Risks / Verification
+
+- **Round-trip is the bar.** Hermetic tests assert the emitted refs are bare-attr host-keyed and the
+  manifest shape is valid. The real proof is the **apply → capture → apply** smoke on the Linux box:
+  `apply` `[jq, ripgrep]` → `capture` → `apply` the captured manifest into a **fresh**
+  `ENDSTATE_NIX_PROFILE` → `nix profile list` shows the same set.
+- **No winget on the Linux box / no regression.** The winget path is unchanged below the fork and is
+  unreachable on Linux (realizer wins); Windows is covered by `GOOS=windows go build`/`go vet` and a
+  host-aware driver-path guard test (`newRealizerFn → ErrNoRealizer` forces the winget path).
+- **Non-pin flake sources** may not round-trip identically (bare attr resolves against the pin) —
+  documented limitation, not a regression of the common nixpkgs case.

--- a/openspec/changes/nix-package-capture/proposal.md
+++ b/openspec/changes/nix-package-capture/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+`apply` and `verify` already work on the **Nix realizer** (Linux/macOS) — but `capture` does not.
+`capture` is winget-only: it enumerates winget-managed packages via `winget export` and errors with
+`WINGET_NOT_AVAILABLE` on a host without winget. So Endstate's core promise — *snapshot this machine
+→ manifest → rebuild elsewhere* — is **half-open on Unix**: you can apply a Nix manifest, but you
+cannot produce one from the current Nix profile.
+
+This change closes that loop. `capture` gains a realizer path, parallel to the existing winget export
+path, that reads the installed Nix profile and emits each element as a manifest app with a host-keyed
+ref. The round-trip is the acceptance bar: **capture → apply re-installs the same set**, and the
+emitted manifest is portable to another machine/OS.
+
+## What Changes
+
+- **Realizer fork in `capture` (always on, Linux/macOS).** `RunCapture` gains a realizer fork at the
+  top, mirroring `RunVerify`/`RunApply`: when `newRealizerFn()` succeeds (Nix on linux/darwin) it
+  takes a new Nix capture path; otherwise (Windows → `ErrNoRealizer`) it falls through to the
+  existing winget path, byte-identical.
+- **Nix capture path.** Reads the current set via `realizer.Realizer.Current()` and, for each
+  element, emits `manifest.App{ID: <element name>, Refs: {runtime.GOOS: <ref>}}`. The output manifest
+  is written exactly like the winget path (same `version`/`name`/`captured`/`apps` shape, same output
+  path resolution, same non-empty-after-write check), sorted by id for deterministic output.
+- **Ref form = bare attr.** Each element is emitted as `Refs[runtime.GOOS] = element.Name` (e.g.
+  `"linux": "ripgrep"`). On `apply`, `Backend.ResolveInstallable` expands the bare attr against the
+  pin (`nixpkgs#ripgrep`); `verify`/`plan` present-detection matches by leaf attr. This is the most
+  portable form — no system tuple (`x86_64-linux`) is baked in, so a manifest captured on Linux
+  re-applies on macOS — and it round-trips through all three commands.
+- **Packages only.** The Nix path does **not** synthesize config modules, manual apps, or a zip
+  bundle (those are the Windows app catalog). It emits a minimal, valid packages manifest.
+- **Known limitation.** A package installed from a non-pin flake source (not the configured
+  nixpkgs pin) may not round-trip identically — its bare attr resolves against the pin. This is
+  acceptable and documented; preserving original flakerefs is out of scope.
+
+## Capabilities
+
+### New Capabilities
+
+- `nix-package-capture`: `capture` works on realizer backends (Nix on linux/darwin). It emits the
+  installed Nix package set as a manifest whose host-keyed refs round-trip through `apply` to the
+  same set. Config/settings capture is out of scope. The winget capture path is unchanged.
+
+### Modified Capabilities
+
+- None. This extends `capture` to a second backend within the existing capture contract
+  (the manifest output shape and write/verify invariants are reused unchanged). The winget path is
+  byte-identical and Windows behavior does not change.
+
+## Impact
+
+- `internal/commands/capture.go` — add the realizer fork at the top of `RunCapture` (the only edit
+  to the existing file; the winget path below the fork is untouched).
+- `internal/commands/capture_realizer.go` — **new**: `runCaptureRealizer` (the Nix capture path).
+- `internal/commands/capture_realizer_test.go` — **new**: hermetic, host-aware tests (fake realizer
+  injected via the shared `newRealizerFn` seam).
+- **Zero winget / Windows regression.** On Windows `newRealizerFn` returns `ErrNoRealizer`, so the
+  fork is a no-op and the winget path runs unchanged. Proven by host-aware tests + `GOOS=windows`
+  build/vet. The real-nix round-trip smoke (apply → capture → apply into a fresh profile) is run on
+  the Linux dev box.

--- a/openspec/changes/nix-package-capture/specs/nix-package-capture/spec.md
+++ b/openspec/changes/nix-package-capture/specs/nix-package-capture/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Capture works on realizer backends
+
+The engine SHALL support `capture` on a whole-set realizer backend (the Nix realizer on linux/darwin),
+not only the winget driver. When the host has a realizer, `capture` SHALL read the installed package
+set from the realizer and produce a manifest from it, rather than requiring winget. When the host has
+no realizer (e.g. Windows), `capture` SHALL continue to use the winget export path unchanged.
+
+#### Scenario: Capture emits the installed realizer set as a manifest
+
+- **WHEN** `capture` runs on a host with a realizer and the realizer reports a set of installed
+  packages
+- **THEN** the engine SHALL write a manifest containing one app per installed package
+- **AND** the manifest SHALL use the same output shape and output-path resolution as the winget path
+
+#### Scenario: Empty realizer set produces a valid empty manifest
+
+- **WHEN** `capture` runs on a host with a realizer that reports no installed packages
+- **THEN** the engine SHALL write a valid manifest with an empty apps list and SHALL NOT error
+
+#### Scenario: A backend infrastructure failure surfaces as an error
+
+- **WHEN** `capture` runs and reading the realizer set fails with a systemic backend failure
+  (the backend is unavailable, or permission is denied)
+- **THEN** the engine SHALL return a top-level error rather than writing a partial manifest
+
+### Requirement: Captured realizer refs round-trip through apply
+
+The engine SHALL emit, for each captured realizer package, a host-keyed reference (keyed by the host
+operating system) that `apply` can consume to re-install the same package. A `capture` followed by an
+`apply` of the produced manifest SHALL converge to the same installed set. The emitted reference SHALL
+NOT embed host-architecture detail, so a manifest captured on one operating system remains usable on
+another supported realizer host.
+
+#### Scenario: Each captured package carries a host-keyed reference
+
+- **WHEN** `capture` emits a package from the realizer set
+- **THEN** the app's refs SHALL contain an entry keyed by the host operating system
+- **AND** that reference SHALL be the one `apply` resolves to re-install the same package
+
+#### Scenario: Capture then apply converges to the same set
+
+- **WHEN** a manifest produced by `capture` from a realizer set is applied on a realizer host
+- **THEN** the installed set after apply SHALL match the set that was captured
+
+#### Scenario: Updating an existing manifest does not duplicate packages
+
+- **WHEN** `capture` updates an existing manifest and a captured package is already present in it
+  under the host key
+- **THEN** the engine SHALL NOT add a duplicate entry for that package
+
+### Requirement: Realizer capture is package-scoped
+
+Realizer capture SHALL capture installed packages only. It SHALL NOT synthesize config modules,
+manual-app entries, or a configuration bundle on the realizer path; those belong to the winget app
+catalog. Configuration/settings capture is out of scope for realizer capture.
+
+#### Scenario: No config modules on the realizer path
+
+- **WHEN** `capture` runs on a realizer host
+- **THEN** the produced result SHALL contain no config-module entries and no configuration bundle
+- **AND** the manifest SHALL contain only package apps

--- a/openspec/changes/nix-package-capture/tasks.md
+++ b/openspec/changes/nix-package-capture/tasks.md
@@ -1,0 +1,45 @@
+> TDD: write each test RED first, then implement to green. Hermetic + host-aware (inject a fake
+> realizer via the shared `newRealizerFn` seam with `withFakeRealizer`; key fixtures by
+> `runtime.GOOS`; for the Windows guard override `newRealizerFn → ErrNoRealizer`).
+> Verify: `cd go-engine && go test ./...` (Linux) + `GOOS=windows go build ./...` + `go vet`. The
+> real-nix apply→capture→apply round-trip smoke runs on the Linux dev box.
+
+## 1. Nix capture path
+
+- [x] 1.1 RED tests (`capture_realizer_test.go`, `withFakeRealizer` + scripted `currentSet`):
+      a profile of two elements → manifest with `apps` sorted by id, each
+      `Refs[runtime.GOOS] = <element name>` (bare attr), `version: 1`, no `configModules`; empty
+      profile → valid empty-apps manifest (no error); systemic `Current()` error → envelope error
+- [x] 1.2 `internal/commands/capture_realizer.go`: `runCaptureRealizer(flags, r, emitter)` —
+      `EmitPhase("capture")`; `r.Current()` (systemic error → `realizerEnvelopeError`, else empty);
+      per element (sorted) build `capturedApp{ID, Refs:{GOOS: el.Name}, Name}` + captured ItemEvent
+- [x] 1.3 `runCaptureRealizer`: write the manifest exactly like the winget path
+      (`captureManifestOutput` → `MarshalIndent` → `resolveOutputPath` → `WriteFile` + INV-CAPTURE-2
+      non-empty stat); return `*CaptureResult` (Source = `r.Name()`, no config modules/zip)
+
+## 2. Fork
+
+- [x] 2.1 `internal/commands/capture.go`: add the realizer fork at the top of `RunCapture` (after the
+      emitter, before `EmitPhase`), mirroring `RunVerify`; leave the winget path below byte-identical
+- [x] 2.2 RED test: Windows guard — `newRealizerFn → ErrNoRealizer` (like `withMockDriver`) keeps the
+      winget path (no realizer capture). The winget-path test helpers (`withMockSnapshot`,
+      `withMockSnapshotSequence`) were updated to force the no-realizer path so the new fork does not
+      divert them to the Nix realizer on linux/darwin.
+
+## 3. --update merge (host-keyed)
+
+- [x] 3.1 RED test: `--update` + `--manifest` with an existing host-keyed manifest → newly captured
+      elements appended, no duplicates (dedup on `Refs[runtime.GOOS]`)
+- [x] 3.2 `runCaptureRealizer`: merge with the existing manifest, host-keyed, mirroring the winget
+      merge but on the `runtime.GOOS` key
+
+## 4. Verification
+
+- [x] 4.1 `cd go-engine && go test ./...` green on Linux
+- [x] 4.2 `GOOS=windows go build ./...` + `go vet ./...` clean (winget path untouched)
+- [x] 4.3 `npm run openspec:validate` (strict, 59/59) + `npx openspec validate nix-package-capture --strict`
+- [x] 4.4 Real-nix round-trip smoke (isolated `ENDSTATE_ROOT` + `ENDSTATE_NIX_PROFILE`): `apply`
+      `[jq, ripgrep]` → `capture` → `apply` the captured manifest into a fresh profile →
+      `nix profile list` shows the same set. **PASS** — both profiles resolve to
+      `legacyPackages.x86_64-linux.{jq,ripgrep}`; the captured manifest emitted bare-attr host-keyed
+      refs (`"linux": "jq"`, `"linux": "ripgrep"`) that re-applied cleanly.


### PR DESCRIPTION
## Why

`apply` and `verify` already run on the **Nix realizer** (Linux/macOS), but `capture` was **winget-only** — it enumerated packages via `winget export` and errored `WINGET_NOT_AVAILABLE` without winget. So Endstate's core loop — *snapshot this machine → manifest → rebuild elsewhere* — was **half-open on Unix**: you could apply a Nix manifest but not produce one from the installed profile.

This closes the loop.

## What

- **Realizer fork in `RunCapture`** (`capture.go`), mirroring `RunVerify`/`RunApply`: when `newRealizerFn()` succeeds (Nix on linux/darwin), capture takes a new realizer path; on Windows it returns `ErrNoRealizer`, so the fork is a no-op and the winget path runs **byte-identical**.
- **`runCaptureRealizer`** (`capture_realizer.go`, new): reads `realizer.Current()` and emits each element as `manifest.App{ID: <name>, Refs: {runtime.GOOS: <bare attr>}}`, written with the same manifest shape / output-path resolution / `INV-CAPTURE-2` non-empty check as the winget path, sorted by id.
- **Ref form = bare attr** (e.g. `"linux": "ripgrep"`). apply's `ResolveInstallable` expands it against the pin (`nixpkgs#ripgrep`) and present-detection matches by leaf, so it round-trips through apply/verify/plan. No system tuple is baked in → portable linux↔darwin.
- **Package-scoped**: no config modules, manual apps, or zip bundle on the realizer path (those are the winget app catalog). Config/settings capture is out of scope (separate home-manager effort).

## Design decisions (confirmed with maintainer)

- **Bare attr** over `AttrPath` (bakes in `x86_64-linux`, breaks cross-OS) or explicit `nixpkgs#attr` (strictly less portable).
- **No version capture** — store-path version parsing belongs with the separate nix-version-capture effort.
- **Known limitation**: a package installed from a non-pin flake source may not round-trip identically (it resolves against the pin). Documented in the spec.

## Verification

- ✅ `go test ./...` green on Linux (7 new hermetic, host-aware tests in `capture_realizer_test.go`).
- ✅ `GOOS=windows go build ./...` + `go vet ./...` clean (winget path untouched).
- ✅ `npm run openspec:validate` strict (59/59) + `npx openspec validate nix-package-capture --strict`.
- ✅ **Real-nix round-trip smoke**: `apply [jq, ripgrep]` → `capture` → `apply` the captured manifest into a **fresh** profile → both profiles resolve to `legacyPackages.x86_64-linux.{jq,ripgrep}`. The captured manifest emitted bare-attr host-keyed refs that re-applied cleanly. **The loop closes.**

## OpenSpec

New change `nix-package-capture` (proposal/design/tasks + `nix-package-capture` capability spec). Archive post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)