### PR TITLE
feat(engine): Nix home-manager orchestration core (config stage)

### DIFF
--- a/docs/contracts/cli-json-contract.md
+++ b/docs/contracts/cli-json-contract.md
@@ -387,6 +387,25 @@ A manifest app MAY declare a `version` to **pin** the install:
 
 A converged app is recorded `installed` at the declared version in the Provisioning Generation. Drift is evaluated only for apps that declare a `version`; default `apply` (no `--repin`) leaves a drifted version untouched.
 
+### Configuration stage (home-manager, realizer-only)
+
+When the manifest declares a `homeManager` block and `apply` runs with `--enable-restore` on the Nix realizer, `apply` activates a [home-manager](https://github.com/nix-community/home-manager) configuration as a **configuration stage** after the package phases. This is the realizer's config story (the winget driver path uses the restore-module layer instead).
+
+```jsonc
+{
+  "homeManager": { "flake": "/home/me/dotfiles#hugo" }  // a home-manager flakeref
+}
+```
+
+- `homeManager.flake` is a home-manager flakeref (e.g. `/home/me/dotfiles#hugo` or `github:me/dotfiles#hugo`) — a power-user escape hatch. The engine activates whatever flakeref it is given; engine-generated inputs may produce this flakeref in a later release without changing the stage.
+- **Engine-owned and gated.** The engine itself runs the activation (`nix run <pinned home-manager> -- switch --flake <ref> -b endstate-backup`); the user does not install or run home-manager. The home-manager version is pinned by the engine (overridable via `ENDSTATE_HOME_MANAGER_PIN`, mirroring `ENDSTATE_NIXPKGS_PIN`). The stage runs **only** when both `--enable-restore` is set and `homeManager.flake` is non-empty; otherwise apply is byte-identical to a package-only apply.
+- **Backup-on-clobber.** `-b endstate-backup` makes home-manager move any pre-existing file it would replace to `<file>.endstate-backup` instead of failing (honors *backup-before-overwrite*).
+- **Recorded.** A successful activation is recorded in the Provisioning Generation under `homeManager` (the activated flakeref and the resulting home-manager generation number). A config-only apply (no package changed) still records a generation.
+- **Realizer-only.** The winget/driver path never activates home-manager (a declared `homeManager` block is ignored there).
+- **Errors (the moat).** A systemic failure (daemon unavailable → `REALIZER_UNAVAILABLE`, permission → `PERMISSION_DENIED`) surfaces as a top-level envelope error; any other activation failure surfaces as `INSTALL_FAILED`. Raw home-manager / Nix output appears only in `error.detail`, never in `error.message`.
+
+> **Rollback of an activated home-manager configuration is not yet supported** (a documented follow-on). home-manager keeps its own numbered generations; re-activating a prior one ships separately.
+
 ---
 
 ## Command: `verify`
@@ -548,7 +567,7 @@ Lists recorded Provisioning Generations, newest first. Read-only. Additive in sc
 }
 ```
 
-`backend` is `"nix"` or `"winget"`. `native` is the backend-native generation number (the Nix generation) or empty for non-atomic backends. `partial` is true when a non-atomic backend (winget) committed only a subset of the requested set. `addedRefs` lists only refs installed in that run (status `installed`); already-present refs appear in `items` but not `addedRefs`. A generation is recorded only when at least one package was installed in the run. `rollback` (optional, omitted when false; additive in schema 1.x) is `true` when the generation was produced by a `rollback` rather than an `apply`; such generations snapshot the now-active set and have an empty `addedRefs`.
+`backend` is `"nix"` or `"winget"`. `native` is the backend-native generation number (the Nix generation) or empty for non-atomic backends. `partial` is true when a non-atomic backend (winget) committed only a subset of the requested set. `addedRefs` lists only refs installed in that run (status `installed`); already-present refs appear in `items` but not `addedRefs`. A generation is recorded when at least one package was installed in the run **or** a home-manager configuration was activated by the config stage. `rollback` (optional, omitted when false; additive in schema 1.x) is `true` when the generation was produced by a `rollback` rather than an `apply`; such generations snapshot the now-active set and have an empty `addedRefs`. `homeManager` (optional, omitted when absent; additive in schema 1.x) records a home-manager configuration activated by `apply --enable-restore`: `{ "flake": "<flakeref>", "generation": <hm generation number> }`.
 
 ## Command: `rollback`
 

--- a/go-engine/internal/commands/apply.go
+++ b/go-engine/internal/commands/apply.go
@@ -453,7 +453,8 @@ func RunApply(flags ApplyFlags) (interface{}, *envelope.Error) {
 		// Record a Provisioning Generation for the install stage (best-effort,
 		// install-only). Written only when >=1 package was installed this run;
 		// Partial when any attempted install failed. Never touches restore state.
-		writeProvisioningGeneration(runID, d.Name(), finalActions, nil, "", failedCount > 0)
+		// Driver (winget) path: home-manager is realizer-only, so no config record.
+		writeProvisioningGeneration(runID, d.Name(), finalActions, nil, "", failedCount > 0, nil)
 
 		// Version convergence (--repin) is destructive (reinstall / possible
 		// downgrade), so it requires --confirm. Refuse without it — the install

--- a/go-engine/internal/commands/apply_generation.go
+++ b/go-engine/internal/commands/apply_generation.go
@@ -10,15 +10,17 @@ import (
 )
 
 // writeProvisioningGeneration records a Provisioning Generation for an apply, but
-// only when the committed package set changed — i.e. at least one ref was
-// installed OR removed (pruned) this run. Idempotent re-runs (nothing added or
-// removed) write no generation. It is best-effort: a write error never fails the
-// apply, mirroring run-history persistence.
+// only when something was committed — i.e. at least one ref was installed OR
+// removed (pruned) this run, OR a home-manager config was activated. Idempotent
+// re-runs (nothing added, removed, or activated) write no generation. It is
+// best-effort: a write error never fails the apply, mirroring run-history
+// persistence.
 //
-// Separation of concerns: this records package facts only (the installed,
-// already-present, and pruned refs). It never touches the config backup directory
-// (state/backups/) or the restore revert journal.
-func writeProvisioningGeneration(runID, backend string, actions []ApplyAction, removed []string, native string, partial bool) {
+// Separation of concerns: this records package facts plus the engine-owned
+// home-manager config reference (a flakeref + generation number — still install/
+// provisioning facts, not config file contents). It never touches the config
+// backup directory (state/backups/) or the restore revert journal.
+func writeProvisioningGeneration(runID, backend string, actions []ApplyAction, removed []string, native string, partial bool, home *provision.HomeGenRef) {
 	items := make([]provision.ProvItem, 0, len(actions))
 	added := make([]string, 0)
 	for _, a := range actions {
@@ -31,8 +33,8 @@ func writeProvisioningGeneration(runID, backend string, actions []ApplyAction, r
 			items = append(items, provision.ProvItem{ID: a.ID, Ref: derefRef(a.Ref), Status: "present", Version: a.Version})
 		}
 	}
-	if len(added) == 0 && len(removed) == 0 {
-		return // nothing added or removed → no new generation
+	if len(added) == 0 && len(removed) == 0 && home == nil {
+		return // nothing added, removed, or activated → no new generation
 	}
 	_ = provision.Write(&provision.Generation{
 		RunID:       runID,
@@ -43,6 +45,7 @@ func writeProvisioningGeneration(runID, backend string, actions []ApplyAction, r
 		RemovedRefs: removed,
 		Native:      native,
 		Partial:     partial,
+		HomeManager: home,
 	})
 }
 

--- a/go-engine/internal/commands/apply_generation_test.go
+++ b/go-engine/internal/commands/apply_generation_test.go
@@ -25,7 +25,7 @@ func TestWriteProvisioningGeneration_RecordsInstalledOnly(t *testing.T) {
 		{ID: "jq", Ref: stringPtr("nixpkgs#jq"), Status: "present"},
 		{ID: "bad", Ref: stringPtr("nixpkgs#bad"), Status: "failed"},
 	}
-	writeProvisioningGeneration("apply-x", "nix", actions, nil, "7", false)
+	writeProvisioningGeneration("apply-x", "nix", actions, nil, "7", false, nil)
 
 	gens, err := provision.List()
 	if err != nil {
@@ -50,7 +50,7 @@ func TestWriteProvisioningGeneration_NoInstallsNoGeneration(t *testing.T) {
 	t.Setenv("ENDSTATE_ROOT", t.TempDir())
 
 	actions := []ApplyAction{{ID: "jq", Ref: stringPtr("nixpkgs#jq"), Status: "present"}}
-	writeProvisioningGeneration("apply-x", "nix", actions, nil, "", false)
+	writeProvisioningGeneration("apply-x", "nix", actions, nil, "", false, nil)
 
 	gens, _ := provision.List()
 	if len(gens) != 0 {
@@ -65,7 +65,7 @@ func TestWriteProvisioningGeneration_WingetPartialSubset(t *testing.T) {
 		{ID: "a", Ref: stringPtr("A.A"), Status: "installed"},
 		{ID: "b", Ref: stringPtr("B.B"), Status: "failed"},
 	}
-	writeProvisioningGeneration("apply-x", "winget", actions, nil, "", true)
+	writeProvisioningGeneration("apply-x", "winget", actions, nil, "", true, nil)
 
 	gens, _ := provision.List()
 	if len(gens) != 1 {

--- a/go-engine/internal/commands/apply_realizer.go
+++ b/go-engine/internal/commands/apply_realizer.go
@@ -11,6 +11,7 @@ import (
 	"github.com/Artexis10/endstate/go-engine/internal/envelope"
 	"github.com/Artexis10/endstate/go-engine/internal/events"
 	"github.com/Artexis10/endstate/go-engine/internal/manifest"
+	"github.com/Artexis10/endstate/go-engine/internal/provision"
 	"github.com/Artexis10/endstate/go-engine/internal/realizer"
 )
 
@@ -351,17 +352,57 @@ func runApplyRealizer(flags ApplyFlags, mf *manifest.Manifest, r realizer.Realiz
 	}
 	emitter.EmitSummary("verify", verifyPass+verifyFail, verifyPass, 0, verifyFail)
 
-	// Record one Provisioning Generation reflecting the converged set: refs added
-	// this run and refs removed (pruned) this run. Native = the final advancing
-	// op's generation (prune's if it advanced, else install's). Write only when a
-	// mutating phase advanced a generation; an atomic backend that did not advance
-	// (idempotent re-run / no-op convergence) records nothing.
-	if installAdvanced || pruneAdvanced {
-		finalGen := installGen
-		if pruneAdvanced {
-			finalGen = pruneGen
+	// --- Phase 4: Config (home-manager) ---
+	// Realizer-only config stage, gated by --enable-restore AND a declared
+	// homeManager.flake. The engine owns the home-manager invocation (the user
+	// installs nothing). A backend without home-manager support simply does not
+	// implement HomeActivator and this stage no-ops; the winget/driver path never
+	// reaches here. On failure the stage mirrors the prune precedent: a systemic
+	// failure becomes a top-level envelope error, anything else INSTALL_FAILED with
+	// raw text confined to error.detail (the moat).
+	var homeRef *provision.HomeGenRef
+	if flags.EnableRestore && mf.HomeManager != nil && mf.HomeManager.Flake != "" {
+		if activator, ok := r.(realizer.HomeActivator); ok {
+			flake := mf.HomeManager.Flake
+			emitter.EmitPhase("config")
+			emitter.EmitItem(flake, driverName, "configuring", "", "Activating home-manager configuration", "home-manager")
+			hmGen, herr := activator.ActivateHome(flake)
+			if herr != nil {
+				rerr, ok := herr.(*realizer.Error)
+				if !ok || rerr == nil {
+					rerr = &realizer.Error{Code: envelope.ErrInstallFailed, Raw: herr.Error()}
+				}
+				emitter.EmitItem(flake, driverName, "failed", "install_failed", "Home-manager configuration activation failed", "home-manager")
+				emitter.EmitSummary("config", 1, 0, 0, 1)
+				if isSystemic(rerr.Code) {
+					return nil, realizerEnvelopeError(rerr)
+				}
+				return nil, envelope.NewError(envelope.ErrInstallFailed, "Home-manager configuration activation failed.").
+					WithDetail(map[string]string{"subcode": rerr.Subcode, "stage": rerr.Stage, "raw": rerr.Raw})
+			}
+			homeRef = &provision.HomeGenRef{Flake: flake, Generation: hmGen}
+			emitter.EmitItem(flake, driverName, "configured", "", fmt.Sprintf("Activated home-manager generation %d", hmGen), "home-manager")
+			emitter.EmitSummary("config", 1, 1, 0, 0)
 		}
-		writeProvisioningGeneration(runID, driverName, actions, removed, fmt.Sprintf("%d", finalGen), failedCount > 0)
+	}
+
+	// Record one Provisioning Generation reflecting the converged set: refs added
+	// this run, refs removed (pruned) this run, and any home-manager config
+	// activated this run. Native = the final advancing package op's generation
+	// (prune's if it advanced, else install's), empty for a config-only apply.
+	// Write when a mutating package phase advanced a generation OR a config was
+	// activated; an idempotent re-run (no install, no prune, no config) records
+	// nothing.
+	if installAdvanced || pruneAdvanced || homeRef != nil {
+		native := ""
+		if installAdvanced || pruneAdvanced {
+			finalGen := installGen
+			if pruneAdvanced {
+				finalGen = pruneGen
+			}
+			native = fmt.Sprintf("%d", finalGen)
+		}
+		writeProvisioningGeneration(runID, driverName, actions, removed, native, failedCount > 0, homeRef)
 	}
 
 	return &ApplyResult{

--- a/go-engine/internal/commands/apply_realizer_test.go
+++ b/go-engine/internal/commands/apply_realizer_test.go
@@ -51,6 +51,21 @@ type fakeRealizer struct {
 	removeResult   realizer.Result // scripted Remove return
 	removeCalls    int
 	lastRemoveArgs []string
+
+	// --- home-manager activation (config stage) ---
+	homeGenNum      int    // scripted ActivateHome generation
+	homeErr         error  // scripted ActivateHome error
+	activateCalls   int
+	lastActivateArg string
+}
+
+// ActivateHome satisfies realizer.HomeActivator, recording the requested flake
+// and returning the scripted generation/error. Its presence makes *fakeRealizer a
+// HomeActivator, so the config stage is exercised host-independently.
+func (f *fakeRealizer) ActivateHome(flake string) (int, error) {
+	f.activateCalls++
+	f.lastActivateArg = flake
+	return f.homeGenNum, f.homeErr
 }
 
 // Remove satisfies realizer.Pruner, recording the requested element names and
@@ -456,5 +471,224 @@ func TestRunApplyRealizer_DryRun_ViaPackageVar(t *testing.T) {
 	}
 	if fr.realizeCalls != 0 {
 		t.Errorf("Realize called %d times in dry-run via RunApply, want 0", fr.realizeCalls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// home-manager config stage (gated by --enable-restore + homeManager.flake)
+// ---------------------------------------------------------------------------
+
+// TestRunApplyRealizer_HomeManager_ActivatesAndRecords: with --enable-restore
+// and a declared homeManager.flake, the config stage activates the config with
+// the right flake and records it (flakeref + hm generation) in the Provisioning
+// Generation, alongside the package install.
+func TestRunApplyRealizer_HomeManager_ActivatesAndRecords(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	app := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := nixManifest(app)
+	mf.HomeManager = &manifest.HomeManagerConfig{Flake: "/home/me/dotfiles#hugo"}
+
+	ins := realizer.Installable{ID: "ripgrep", Ref: hostRef(app)}
+	fr := &fakeRealizer{
+		planDiff: realizer.Diff{ToAdd: []realizer.Installable{ins}},
+		realizeResult: realizer.Result{
+			Advanced: true, FromGeneration: 1, ToGeneration: 2,
+			After: realizer.Set{Generation: 2, Elements: map[string]realizer.Element{"ripgrep": {Name: "ripgrep", AttrPath: "ripgrep"}}},
+		},
+		homeGenNum: 5,
+	}
+
+	flags := ApplyFlags{Manifest: "nix-test", EnableRestore: true}
+	raw, eerr := runApplyRealizer(flags, mf, fr, noopEmitter(), "run-hm1", nil, nil)
+	if eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+	if _, ok := raw.(*ApplyResult); !ok {
+		t.Fatalf("expected *ApplyResult, got %T", raw)
+	}
+	if fr.activateCalls != 1 {
+		t.Errorf("ActivateHome called %d times, want 1", fr.activateCalls)
+	}
+	if fr.lastActivateArg != "/home/me/dotfiles#hugo" {
+		t.Errorf("ActivateHome flake = %q, want the manifest flake", fr.lastActivateArg)
+	}
+	gens, _ := provision.List()
+	if len(gens) != 1 {
+		t.Fatalf("want 1 generation, got %d", len(gens))
+	}
+	hm := gens[0].HomeManager
+	if hm == nil || hm.Flake != "/home/me/dotfiles#hugo" || hm.Generation != 5 {
+		t.Fatalf("generation HomeManager = %+v, want flake=/home/me/dotfiles#hugo gen=5", hm)
+	}
+}
+
+// TestRunApplyRealizer_HomeManager_NoFlag_NoActivation: a declared flake without
+// --enable-restore does NOT activate (the config gate).
+func TestRunApplyRealizer_HomeManager_NoFlag_NoActivation(t *testing.T) {
+	app := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := nixManifest(app)
+	mf.HomeManager = &manifest.HomeManagerConfig{Flake: "/dot#me"}
+	fr := &fakeRealizer{planDiff: realizer.Diff{Present: []realizer.Installable{{ID: "ripgrep", Ref: hostRef(app)}}}}
+
+	flags := ApplyFlags{Manifest: "nix-test", EnableRestore: false}
+	if _, eerr := runApplyRealizer(flags, mf, fr, noopEmitter(), "run-hm2", nil, nil); eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+	if fr.activateCalls != 0 {
+		t.Errorf("ActivateHome called %d times without --enable-restore, want 0", fr.activateCalls)
+	}
+}
+
+// TestRunApplyRealizer_HomeManager_NoField_NoActivation: --enable-restore with no
+// homeManager field does NOT activate (default apply unchanged).
+func TestRunApplyRealizer_HomeManager_NoField_NoActivation(t *testing.T) {
+	app := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := nixManifest(app) // no HomeManager
+	fr := &fakeRealizer{planDiff: realizer.Diff{Present: []realizer.Installable{{ID: "ripgrep", Ref: hostRef(app)}}}}
+
+	flags := ApplyFlags{Manifest: "nix-test", EnableRestore: true}
+	if _, eerr := runApplyRealizer(flags, mf, fr, noopEmitter(), "run-hm3", nil, nil); eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+	if fr.activateCalls != 0 {
+		t.Errorf("ActivateHome called %d times with no homeManager field, want 0", fr.activateCalls)
+	}
+}
+
+// TestRunApplyRealizer_HomeManager_EmptyFlake_NoActivation: a homeManager block
+// with an empty flake does NOT activate.
+func TestRunApplyRealizer_HomeManager_EmptyFlake_NoActivation(t *testing.T) {
+	app := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := nixManifest(app)
+	mf.HomeManager = &manifest.HomeManagerConfig{Flake: ""}
+	fr := &fakeRealizer{planDiff: realizer.Diff{Present: []realizer.Installable{{ID: "ripgrep", Ref: hostRef(app)}}}}
+
+	flags := ApplyFlags{Manifest: "nix-test", EnableRestore: true}
+	if _, eerr := runApplyRealizer(flags, mf, fr, noopEmitter(), "run-hm4", nil, nil); eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+	if fr.activateCalls != 0 {
+		t.Errorf("ActivateHome called %d times with empty flake, want 0", fr.activateCalls)
+	}
+}
+
+// TestRunApplyRealizer_HomeManager_SystemicError: a systemic activation failure
+// surfaces a top-level envelope error (nil data), raw text confined to detail.
+func TestRunApplyRealizer_HomeManager_SystemicError(t *testing.T) {
+	app := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := nixManifest(app)
+	mf.HomeManager = &manifest.HomeManagerConfig{Flake: "/dot#me"}
+	rawText := "error: cannot connect to socket"
+	fr := &fakeRealizer{
+		planDiff: realizer.Diff{Present: []realizer.Installable{{ID: "ripgrep", Ref: hostRef(app)}}},
+		homeErr:  &realizer.Error{Code: envelope.ErrRealizerUnavailable, Subcode: "daemon", Stage: "spawn", Raw: rawText},
+	}
+
+	flags := ApplyFlags{Manifest: "nix-test", EnableRestore: true}
+	data, eerr := runApplyRealizer(flags, mf, fr, noopEmitter(), "run-hm5", nil, nil)
+	if eerr == nil {
+		t.Fatal("expected envelope error for systemic activation failure, got nil")
+	}
+	if data != nil {
+		t.Errorf("expected nil data on systemic error, got %T", data)
+	}
+	if eerr.Code != envelope.ErrRealizerUnavailable {
+		t.Errorf("code = %q, want REALIZER_UNAVAILABLE", eerr.Code)
+	}
+	if strings.Contains(eerr.Message, rawText) {
+		t.Errorf("raw text leaked into envelope Message: %q", eerr.Message)
+	}
+}
+
+// TestRunApplyRealizer_HomeManager_ActivationFailed: a non-systemic activation
+// failure surfaces INSTALL_FAILED with raw text confined to detail (the moat),
+// mirroring the prune-failure precedent.
+func TestRunApplyRealizer_HomeManager_ActivationFailed(t *testing.T) {
+	app := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := nixManifest(app)
+	mf.HomeManager = &manifest.HomeManagerConfig{Flake: "/dot#bad"}
+	rawText := "error: flake does not provide attribute 'homeConfigurations.bad'"
+	fr := &fakeRealizer{
+		planDiff: realizer.Diff{Present: []realizer.Installable{{ID: "ripgrep", Ref: hostRef(app)}}},
+		homeErr:  &realizer.Error{Code: envelope.ErrInstallFailed, Subcode: "eval", Stage: "eval", Raw: rawText},
+	}
+
+	flags := ApplyFlags{Manifest: "nix-test", EnableRestore: true}
+	_, eerr := runApplyRealizer(flags, mf, fr, noopEmitter(), "run-hm6", nil, nil)
+	if eerr == nil {
+		t.Fatal("expected envelope error for activation failure, got nil")
+	}
+	if eerr.Code != envelope.ErrInstallFailed {
+		t.Errorf("code = %q, want INSTALL_FAILED", eerr.Code)
+	}
+	if strings.Contains(eerr.Message, rawText) {
+		t.Errorf("raw text leaked into envelope Message: %q", eerr.Message)
+	}
+	detail, ok := eerr.Detail.(map[string]string)
+	if !ok || detail["raw"] != rawText {
+		t.Errorf("raw text not confined to detail: %+v", eerr.Detail)
+	}
+}
+
+// TestRunApplyRealizer_HomeManager_ConfigOnlyRecordsGeneration: when no package
+// changed (all present) but a config was activated, a generation is STILL
+// recorded (the write-gate counts an activation as "something happened").
+func TestRunApplyRealizer_HomeManager_ConfigOnlyRecordsGeneration(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	app := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := nixManifest(app)
+	mf.HomeManager = &manifest.HomeManagerConfig{Flake: "/dot#me"}
+	fr := &fakeRealizer{
+		planDiff:   realizer.Diff{Present: []realizer.Installable{{ID: "ripgrep", Ref: hostRef(app)}}},
+		homeGenNum: 3,
+	}
+
+	flags := ApplyFlags{Manifest: "nix-test", EnableRestore: true}
+	if _, eerr := runApplyRealizer(flags, mf, fr, noopEmitter(), "run-hm7", nil, nil); eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+	if fr.activateCalls != 1 {
+		t.Fatalf("ActivateHome called %d times, want 1", fr.activateCalls)
+	}
+	gens, _ := provision.List()
+	if len(gens) != 1 {
+		t.Fatalf("config-only activation must still record a generation, got %d", len(gens))
+	}
+	if gens[0].HomeManager == nil || gens[0].HomeManager.Generation != 3 {
+		t.Fatalf("generation HomeManager = %+v, want gen=3", gens[0].HomeManager)
+	}
+	if len(gens[0].AddedRefs) != 0 || len(gens[0].RemovedRefs) != 0 {
+		t.Errorf("config-only generation must record no package changes: added=%v removed=%v", gens[0].AddedRefs, gens[0].RemovedRefs)
+	}
+}
+
+// TestRunApply_WingetPath_NeverActivatesHome: on the driver (winget) path a
+// declared homeManager.flake is ignored — no activation, no recorded config.
+func TestRunApply_WingetPath_NeverActivatesHome(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	md := &mockDriver{installed: map[string]bool{}}
+	tmpDir := t.TempDir()
+	manifestPath := tmpDir + "/m.jsonc"
+	manifestContent := `{
+		"name": "winget-hm-test",
+		"apps": [ { "id": "a", "refs": { "windows": "Vendor.A" } } ],
+		"homeManager": { "flake": "/home/me/dotfiles#hugo" }
+	}`
+	if err := os.WriteFile(manifestPath, []byte(manifestContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var eerr *envelope.Error
+	withMockDriver(md, func() {
+		_, eerr = RunApply(ApplyFlags{Manifest: manifestPath, EnableRestore: true})
+	})
+	if eerr != nil {
+		t.Fatalf("winget path with homeManager set must not error: %v", eerr)
+	}
+	gens, _ := provision.List()
+	for _, g := range gens {
+		if g.HomeManager != nil {
+			t.Fatalf("winget path recorded a home-manager config: %+v", g.HomeManager)
+		}
 	}
 }

--- a/go-engine/internal/manifest/loader_test.go
+++ b/go-engine/internal/manifest/loader_test.go
@@ -515,6 +515,47 @@ func TestLoadManifestIncludes_MergesRestoreAndVerify(t *testing.T) {
 	}
 }
 
+// TestLoadManifest_HomeManager verifies the homeManager.flake field round-trips
+// through JSONC load (comments + the nested object), and that an absent block
+// yields a nil HomeManager (so the config stage is a strict no-op by default).
+func TestLoadManifest_HomeManager(t *testing.T) {
+	dir := t.TempDir()
+
+	withHM := filepath.Join(dir, "with-hm.jsonc")
+	withHMContent := `{
+  "version": 1,
+  "name": "hm-test",
+  "apps": [],
+  // power-user home-manager flakeref escape hatch
+  "homeManager": { "flake": "/home/me/dotfiles#hugo" }
+}`
+	if err := os.WriteFile(withHM, []byte(withHMContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := LoadManifest(withHM)
+	if err != nil {
+		t.Fatalf("unexpected error loading manifest with homeManager: %v", err)
+	}
+	if m.HomeManager == nil {
+		t.Fatal("HomeManager = nil, want non-nil for a manifest declaring homeManager.flake")
+	}
+	if m.HomeManager.Flake != "/home/me/dotfiles#hugo" {
+		t.Errorf("HomeManager.Flake = %q, want %q", m.HomeManager.Flake, "/home/me/dotfiles#hugo")
+	}
+
+	without := filepath.Join(dir, "without-hm.jsonc")
+	if err := os.WriteFile(without, []byte(`{ "version": 1, "name": "no-hm", "apps": [] }`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	m2, err := LoadManifest(without)
+	if err != nil {
+		t.Fatalf("unexpected error loading manifest without homeManager: %v", err)
+	}
+	if m2.HomeManager != nil {
+		t.Errorf("HomeManager = %+v, want nil when the block is absent", m2.HomeManager)
+	}
+}
+
 func TestLoadManifestIncludes_ParentAppsBeforeChild(t *testing.T) {
 	// Pester: "Should contain local app from root manifest" +
 	//         "Should contain apps from included base-apps.jsonc"

--- a/go-engine/internal/manifest/types.go
+++ b/go-engine/internal/manifest/types.go
@@ -18,6 +18,21 @@ type Manifest struct {
 	Verify         []VerifyEntry  `json:"verify,omitempty"`
 	ConfigModules  []string       `json:"configModules,omitempty"`
 	ExcludeConfigs []string       `json:"excludeConfigs,omitempty"`
+
+	// HomeManager declares a home-manager configuration the Nix realizer activates
+	// as a config stage of apply (opt-in via --enable-restore). Absent ⇒ no config
+	// stage (default apply unchanged). Realizer-only; the winget path ignores it.
+	HomeManager *HomeManagerConfig `json:"homeManager,omitempty"`
+}
+
+// HomeManagerConfig is the manifest input to the home-manager config stage. Flake
+// is a home-manager flakeref (e.g. "/home/me/dotfiles#hugo" or
+// "github:me/dotfiles#hugo") that the engine activates with an engine-owned,
+// pinned home-manager — a permanent power-user escape hatch. The orchestrator is
+// input-agnostic, so engine-generated inputs (a home.nix wrapper, a programs.*
+// catalog) layer on later by producing a flakeref this same stage consumes.
+type HomeManagerConfig struct {
+	Flake string `json:"flake"`
 }
 
 // App represents a single application entry in the manifest. The Refs map

--- a/go-engine/internal/provision/provision.go
+++ b/go-engine/internal/provision/provision.go
@@ -42,6 +42,20 @@ type Generation struct {
 	Partial       bool       `json:"partial"`          // true when a non-atomic backend committed a partial set
 	Rollback      bool       `json:"rollback,omitempty"`    // true when this generation was produced by a rollback (AddedRefs is empty)
 	RemovedRefs   []string   `json:"removedRefs,omitempty"` // refs uninstalled by a best-effort (winget) rollback; empty for native/apply generations
+
+	// HomeManager records a home-manager configuration activated by this apply's
+	// config stage (realizer-only, opt-in via --enable-restore). nil when no
+	// config was activated. Config is recorded alongside packages so it is part of
+	// the same audit trail; it stays a pointer so package-only generations omit it.
+	HomeManager *HomeGenRef `json:"homeManager,omitempty"`
+}
+
+// HomeGenRef records a home-manager configuration the engine activated: the
+// flakeref applied and the resulting home-manager generation number. It is the
+// config analogue of the package Native anchor.
+type HomeGenRef struct {
+	Flake      string `json:"flake"`
+	Generation int    `json:"generation"`
 }
 
 // Capabilities describes what a package backend can do. It is discovered at

--- a/go-engine/internal/provision/provision_test.go
+++ b/go-engine/internal/provision/provision_test.go
@@ -46,6 +46,39 @@ func TestWriteTo_AssignsMonotonicNumbersAndDefaultsSchema(t *testing.T) {
 	}
 }
 
+// TestWriteTo_RecordsHomeManager verifies the optional HomeManager config record
+// (the home-manager flakeref + its resulting generation number) round-trips
+// through write/read, so an activated config joins the same audit trail as
+// packages.
+func TestWriteTo_RecordsHomeManager(t *testing.T) {
+	dir := t.TempDir()
+	g := &Generation{
+		RunID:       "apply-hm",
+		Backend:     "nix",
+		HomeManager: &HomeGenRef{Flake: "/home/me/dotfiles#hugo", Generation: 7},
+	}
+	if err := WriteTo(dir, g); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	gens, err := ListFrom(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gens) != 1 {
+		t.Fatalf("len = %d, want 1", len(gens))
+	}
+	hm := gens[0].HomeManager
+	if hm == nil {
+		t.Fatal("HomeManager = nil after round-trip, want non-nil")
+	}
+	if hm.Flake != "/home/me/dotfiles#hugo" {
+		t.Errorf("HomeManager.Flake = %q, want %q", hm.Flake, "/home/me/dotfiles#hugo")
+	}
+	if hm.Generation != 7 {
+		t.Errorf("HomeManager.Generation = %d, want 7", hm.Generation)
+	}
+}
+
 func TestListFrom_NewestFirstAndIgnoresNonRecords(t *testing.T) {
 	dir := t.TempDir()
 	for i := 0; i < 3; i++ {

--- a/go-engine/internal/realizer/nix/home_manager.go
+++ b/go-engine/internal/realizer/nix/home_manager.go
@@ -1,0 +1,116 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package nix
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+// compile-time assertion: the Nix backend implements realizer.HomeActivator, so
+// the apply path can discover home-manager config support by type-assertion.
+var _ realizer.HomeActivator = (*Backend)(nil)
+
+// ActivateHome activates a declared home-manager configuration as the realizer's
+// config stage of apply. The engine owns the invocation — it runs the
+// home-manager CLI via `nix run <HomePin> -- switch --flake <flake> -b
+// endstate-backup` so the user never installs or learns home-manager (the moat).
+// `-b endstate-backup` makes home-manager move any pre-existing file it would
+// replace to `<file>.endstate-backup` instead of failing (honors
+// backup-before-overwrite — confirmed against real home-manager).
+//
+// On success it returns the resulting home-manager generation number (read from
+// the home-manager profile symlink, the same way the package generation is
+// read). On failure it returns a classified *realizer.Error through the existing
+// anchor path: spawn/daemon → REALIZER_UNAVAILABLE, permission →
+// PERMISSION_DENIED, anything else → INSTALL_FAILED (the config-activation
+// failure class), with raw home-manager/Nix text confined to Error.Raw (destined
+// only for envelope error.detail). home-manager's switch output is plain text
+// (not nix internal-json), so classification anchors against the raw stderr.
+func (b *Backend) ActivateHome(flake string) (int, error) {
+	pin := b.HomePin
+	if pin == "" {
+		pin = defaultHomePin()
+	}
+	// `--` separates nix's args from the home-manager program's args; the runner
+	// inserts the experimental-features flag before it (see nixArgs).
+	args := []string{"run", pin, "--", "switch", "--flake", flake, "-b", "endstate-backup"}
+
+	_, stderr, exit, err := b.Run(args...)
+	if err != nil { // spawn failure (nix missing/unrunnable)
+		return 0, classify(-1, parsePlainLog(stderr), false)
+	}
+	if exit != 0 {
+		return 0, classify(exit, parsePlainLog(stderr), false)
+	}
+	return b.homeGen(), nil
+}
+
+// homeGen returns the active home-manager generation number, via homeGenFn when
+// set (tests) else by reading the home-manager profile symlink.
+func (b *Backend) homeGen() int {
+	if b.homeGenFn != nil {
+		return b.homeGenFn()
+	}
+	return homeGeneration()
+}
+
+// homeGeneration reads the active home-manager generation number from the
+// home-manager nix-profile symlink (<...>/nix/profiles/home-manager ->
+// home-manager-<N>-link). Returns 0 when the profile does not exist. The path
+// and `-<N>-link` naming were confirmed against real home-manager.
+func homeGeneration() int {
+	target, err := os.Readlink(homeProfilePath())
+	if err != nil {
+		return 0
+	}
+	base := strings.TrimSuffix(filepath.Base(target), "-link")
+	if i := strings.LastIndex(base, "-"); i >= 0 {
+		if n, err := strconv.Atoi(base[i+1:]); err == nil {
+			return n
+		}
+	}
+	return 0
+}
+
+// homeProfilePath returns the home-manager nix-profile path under the XDG state
+// dir ($XDG_STATE_HOME/nix/profiles/home-manager, default
+// ~/.local/state/nix/profiles/home-manager), following the same XDG convention
+// as DefaultProfile rather than a hardcoded absolute path.
+func homeProfilePath() string {
+	base := os.Getenv("XDG_STATE_HOME")
+	if base == "" {
+		home, _ := os.UserHomeDir()
+		base = filepath.Join(home, ".local", "state")
+	}
+	return filepath.Join(base, "nix", "profiles", "home-manager")
+}
+
+// parsePlainLog builds a parsedLog from home-manager's PLAIN-TEXT switch stderr
+// (not nix internal-json). Any `@nix {...}` lines the outer build emits are
+// folded in via parseInternalJSON (so those structural signals are kept), then
+// every remaining non-empty plain line becomes an error candidate so the locked
+// anchor table can match systemic classes and the raw text is retained for
+// error.detail. This is the home-manager analogue of parseInternalJSON, which
+// alone would miss home-manager's plain output.
+func parsePlainLog(stderr []byte) parsedLog {
+	p := parseInternalJSON(stderr)
+	var sb strings.Builder
+	sb.WriteString(p.blob)
+	for _, ln := range strings.Split(string(stderr), "\n") {
+		t := stripANSI(strings.TrimSpace(ln))
+		if t == "" || strings.HasPrefix(t, "@nix ") {
+			continue
+		}
+		p.errorMsgs = append(p.errorMsgs, t)
+		sb.WriteString(strings.ToLower(t))
+		sb.WriteByte('\n')
+	}
+	p.blob = sb.String()
+	return p
+}

--- a/go-engine/internal/realizer/nix/home_manager_test.go
+++ b/go-engine/internal/realizer/nix/home_manager_test.go
@@ -1,0 +1,157 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package nix
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// TestNixArgs_InsertsBeforeSeparator: for a `nix run <pin> -- <prog args>`
+// invocation the experimental-features flag MUST be inserted before the bare
+// `--` separator, so it is consumed by nix (not passed through to the
+// downstream home-manager program, which would reject it).
+func TestNixArgs_InsertsBeforeSeparator(t *testing.T) {
+	got := nixArgs([]string{"run", "github:nix-community/home-manager", "--", "switch", "--flake", "/dot#me", "-b", "endstate-backup"})
+	joined := strings.Join(got, " ")
+	feat := "--extra-experimental-features nix-command flakes"
+	if !strings.Contains(joined, feat) {
+		t.Fatalf("experimental features not present: %q", joined)
+	}
+	// The flag must appear BEFORE the bare `--` separator.
+	featIdx := strings.Index(joined, "--extra-experimental-features")
+	sepIdx := strings.Index(joined, " -- ")
+	if sepIdx < 0 {
+		t.Fatalf("separator `--` not found in %q", joined)
+	}
+	if featIdx > sepIdx {
+		t.Errorf("experimental flag landed AFTER `--` (would break the downstream program): %q", joined)
+	}
+}
+
+// TestNixArgs_AppendsWhenNoSeparator: the `nix profile` verbs carry no bare
+// `--`, so the flag is appended at the end exactly as before (package path
+// behavior is unchanged).
+func TestNixArgs_AppendsWhenNoSeparator(t *testing.T) {
+	got := nixArgs([]string{"profile", "add", "--profile", "/p", "nixpkgs#ripgrep", "--log-format", "internal-json"})
+	joined := strings.Join(got, " ")
+	if !strings.HasSuffix(joined, "--extra-experimental-features nix-command flakes") {
+		t.Errorf("expected experimental features appended at end, got %q", joined)
+	}
+}
+
+// TestActivateHome_Success_ArgvAndGeneration: a clean activation emits
+// `run <pin> -- switch --flake <ref> -b endstate-backup` and returns the new
+// home-manager generation number (read hermetically via the homeGenFn seam).
+func TestActivateHome_Success_ArgvAndGeneration(t *testing.T) {
+	run, got := captureRun(nil, 0, nil)
+	b := &Backend{
+		HomePin:   "github:nix-community/home-manager",
+		Run:       run,
+		homeGenFn: func() int { return 7 },
+	}
+
+	gen, err := b.ActivateHome("/home/me/dotfiles#hugo")
+	if err != nil {
+		t.Fatalf("expected nil error on successful activation, got %v", err)
+	}
+	if gen != 7 {
+		t.Errorf("generation = %d, want 7 (from homeGenFn)", gen)
+	}
+	joined := strings.Join(*got, " ")
+	want := "run github:nix-community/home-manager -- switch --flake /home/me/dotfiles#hugo -b endstate-backup"
+	if !strings.Contains(joined, want) {
+		t.Errorf("argv = %q, want it to contain %q", joined, want)
+	}
+}
+
+// TestActivateHome_DefaultPin: when HomePin is empty the engine default
+// home-manager pin is used.
+func TestActivateHome_DefaultPin(t *testing.T) {
+	t.Setenv("ENDSTATE_HOME_MANAGER_PIN", "")
+	run, got := captureRun(nil, 0, nil)
+	b := &Backend{Run: run, homeGenFn: func() int { return 1 }}
+	if _, err := b.ActivateHome("/dot#me"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	joined := strings.Join(*got, " ")
+	if !strings.Contains(joined, "run github:nix-community/home-manager --") {
+		t.Errorf("default pin not used: %q", joined)
+	}
+}
+
+// TestActivateHome_EnvPin: ENDSTATE_HOME_MANAGER_PIN overrides the pin.
+func TestActivateHome_EnvPin(t *testing.T) {
+	t.Setenv("ENDSTATE_HOME_MANAGER_PIN", "github:nix-community/home-manager/release-25.05")
+	run, got := captureRun(nil, 0, nil)
+	b := &Backend{Run: run, homeGenFn: func() int { return 1 }}
+	if _, err := b.ActivateHome("/dot#me"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	joined := strings.Join(*got, " ")
+	if !strings.Contains(joined, "run github:nix-community/home-manager/release-25.05 --") {
+		t.Errorf("env pin not used: %q", joined)
+	}
+}
+
+// TestActivateHome_Eval_InstallFailed: a non-zero exit whose plain-text stderr
+// carries an eval anchor classifies as INSTALL_FAILED with the raw text
+// confined to Err.Raw (the moat). home-manager prints plain text, not
+// internal-json, so classification anchors against the raw stderr.
+func TestActivateHome_Eval_InstallFailed(t *testing.T) {
+	raw := "error: flake 'path:/home/me/dotfiles' does not provide attribute 'homeConfigurations.bad'"
+	run, _ := captureRun([]byte(raw), 1, nil)
+	b := &Backend{HomePin: "github:nix-community/home-manager", Run: run}
+
+	_, err := b.ActivateHome("/home/me/dotfiles#bad")
+	rerr := asRealizerErr(t, err)
+	if rerr.Code != envelope.ErrInstallFailed {
+		t.Errorf("Code = %q, want INSTALL_FAILED", rerr.Code)
+	}
+	if !strings.Contains(rerr.Raw, "does not provide attribute") {
+		t.Errorf("raw text not retained in Err.Raw: %q", rerr.Raw)
+	}
+}
+
+// TestActivateHome_Permission_Systemic: a permission-class anchor in the
+// plain-text stderr surfaces PERMISSION_DENIED.
+func TestActivateHome_Permission_Systemic(t *testing.T) {
+	run, _ := captureRun([]byte("error: opening file '/nix/store/.lock': Permission denied"), 1, nil)
+	b := &Backend{HomePin: "github:nix-community/home-manager", Run: run}
+
+	_, err := b.ActivateHome("/dot#me")
+	rerr := asRealizerErr(t, err)
+	if rerr.Code != envelope.ErrPermissionDenied {
+		t.Errorf("Code = %q, want PERMISSION_DENIED", rerr.Code)
+	}
+}
+
+// TestActivateHome_Daemon_Systemic: a daemon-class anchor surfaces
+// REALIZER_UNAVAILABLE.
+func TestActivateHome_Daemon_Systemic(t *testing.T) {
+	run, _ := captureRun([]byte("error: cannot connect to socket at '/nix/var/nix/daemon-socket/socket'"), 1, nil)
+	b := &Backend{HomePin: "github:nix-community/home-manager", Run: run}
+
+	_, err := b.ActivateHome("/dot#me")
+	rerr := asRealizerErr(t, err)
+	if rerr.Code != envelope.ErrRealizerUnavailable {
+		t.Errorf("Code = %q, want REALIZER_UNAVAILABLE", rerr.Code)
+	}
+}
+
+// TestActivateHome_Spawn: a spawn failure (runner returns a non-nil error)
+// surfaces REALIZER_UNAVAILABLE regardless of any text.
+func TestActivateHome_Spawn(t *testing.T) {
+	run, _ := captureRun(nil, -1, errors.New("exec: nix not found"))
+	b := &Backend{HomePin: "github:nix-community/home-manager", Run: run}
+
+	_, err := b.ActivateHome("/dot#me")
+	rerr := asRealizerErr(t, err)
+	if rerr.Code != envelope.ErrRealizerUnavailable {
+		t.Errorf("Code = %q, want REALIZER_UNAVAILABLE", rerr.Code)
+	}
+}

--- a/go-engine/internal/realizer/nix/nix.go
+++ b/go-engine/internal/realizer/nix/nix.go
@@ -35,12 +35,21 @@ type Backend struct {
 	// Pin is the base flakeref a bare attribute is expanded against (e.g.
 	// "nixpkgs" or a rev-pinned "github:NixOS/nixpkgs/<rev>").
 	Pin string
+	// HomePin is the pinned home-manager flakeref the engine runs the
+	// home-manager CLI from (`nix run <HomePin> -- switch`), so the user never
+	// installs home-manager. Overridable via ENDSTATE_HOME_MANAGER_PIN; mirrors
+	// Pin/ENDSTATE_NIXPKGS_PIN.
+	HomePin string
 	// Run executes nix; defaults to the real exec runner.
 	Run Runner
 	// genFn overrides generation reading; nil means read the profile symlink.
 	// Tests (in-package) set this to drive Realize's atomicity detection
 	// hermetically without a real generation switch.
 	genFn func() int
+	// homeGenFn overrides home-manager generation reading; nil means read the
+	// home-manager profile symlink. Tests set it so ActivateHome's success path
+	// is exercised hermetically without a real home-manager switch.
+	homeGenFn func() int
 }
 
 // gen returns the active generation number, via genFn when set (tests) else by
@@ -55,7 +64,7 @@ func (b *Backend) gen() int {
 // New returns a Backend with the default Endstate-managed profile, pin, and a
 // real exec runner.
 func New() *Backend {
-	return &Backend{Profile: DefaultProfile(), Pin: defaultPin(), Run: defaultRunner}
+	return &Backend{Profile: DefaultProfile(), Pin: defaultPin(), HomePin: defaultHomePin(), Run: defaultRunner}
 }
 
 // Name satisfies realizer.Realizer.
@@ -87,6 +96,40 @@ func defaultPin() string {
 	return "nixpkgs"
 }
 
+// defaultHomePin returns the pinned home-manager flakeref the engine runs the
+// home-manager CLI from, overridable via ENDSTATE_HOME_MANAGER_PIN (mirrors
+// ENDSTATE_NIXPKGS_PIN). The default tracks the home-manager flake's default
+// branch; a production deployment pins a rev or release branch
+// ("github:nix-community/home-manager/<rev|release>") for full reproducibility.
+// This pin only selects the home-manager CLI binary — the user's flake supplies
+// its own home-manager library and nixpkgs.
+func defaultHomePin() string {
+	if p := os.Getenv("ENDSTATE_HOME_MANAGER_PIN"); p != "" {
+		return p
+	}
+	return "github:nix-community/home-manager"
+}
+
+// nixArgs returns the full nix argv with the experimental features the
+// flake/nix-command verbs require. They are inserted BEFORE the first bare `--`
+// separator so a `nix run <pin> -- <prog args>` invocation passes the flag to
+// nix rather than to the downstream program (e.g. home-manager, which would
+// reject it). When there is no bare `--` (the `nix profile` verbs) the flag is
+// appended at the end, exactly as before.
+func nixArgs(args []string) []string {
+	feat := []string{"--extra-experimental-features", "nix-command flakes"}
+	for i, a := range args {
+		if a == "--" {
+			out := make([]string, 0, len(args)+len(feat))
+			out = append(out, args[:i]...)
+			out = append(out, feat...)
+			out = append(out, args[i:]...)
+			return out
+		}
+	}
+	return append(append([]string{}, args...), feat...)
+}
+
 // nixBin resolves the nix binary: ENDSTATE_NIX_BIN, else PATH, else the
 // Determinate default install location.
 func nixBin() string {
@@ -102,9 +145,7 @@ func nixBin() string {
 // defaultRunner runs the real nix CLI, forcing the experimental features the
 // `nix profile`/flake commands require (harmless if already enabled).
 func defaultRunner(args ...string) ([]byte, []byte, int, error) {
-	full := append([]string{}, args...)
-	full = append(full, "--extra-experimental-features", "nix-command flakes")
-	cmd := exec.Command(nixBin(), full...)
+	cmd := exec.Command(nixBin(), nixArgs(args)...)
 	var out, errb bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &errb

--- a/go-engine/internal/realizer/realizer.go
+++ b/go-engine/internal/realizer/realizer.go
@@ -99,3 +99,17 @@ type Pruner interface {
 	// element names as they appear in Current().Elements. Remove(nil) is a no-op.
 	Remove(names []string) (Result, error)
 }
+
+// HomeActivator is an OPTIONAL realizer capability: activating a declared
+// home-manager configuration as the config stage of apply. Like Pruner it is
+// discovered by type-assertion on a Realizer, so only a backend that owns a
+// home-manager lifecycle (the Nix realizer) implements it; other backends (the
+// winget driver path) simply do not, and the config stage no-ops. The engine
+// owns the invocation (an engine-owned `home-manager switch`), so the user never
+// installs home-manager.
+type HomeActivator interface {
+	// ActivateHome activates the home-manager configuration named by the given
+	// flakeref and returns the resulting home-manager generation number. On
+	// failure it returns a classified *Error (raw backend text in Error.Raw only).
+	ActivateHome(flake string) (generation int, err error)
+}

--- a/openspec/changes/nix-home-manager-config/design.md
+++ b/openspec/changes/nix-home-manager-config/design.md
@@ -76,3 +76,25 @@ text confined to `error.detail`. No Windows path, no default-apply change.
 - Hermetic: inject the runner; assert the stage fires only with the flag + manifest field, passes
   the right argv, records the generation field, and no-ops otherwise. `GOOS=windows` build/vet clean
   (realizer path is non-Windows; winget path untouched). `go test ./...`; openspec strict.
+
+## Smoke verdict (resolved — real Determinate Nix 3.21.0)
+
+The home-manager unknown is resolved by a real-nix smoke on a throwaway `$HOME`. Findings:
+
+- **Activation:** `nix run github:nix-community/home-manager -- switch --flake <ref> -b endstate-backup`
+  activates cleanly (exit 0); the engine path (`apply --enable-restore`) reflects the flake in the managed
+  file, moves a clobbered file to `<file>.endstate-backup`, and records the config. Without the flag the
+  config is untouched (default apply byte-identical).
+- **Generation-number source:** the home-manager **nix-profile symlink**
+  `$XDG_STATE_HOME/nix/profiles/home-manager -> home-manager-<N>-link` — read identically to the package
+  generation (no second nix invocation). The pin default is `github:nix-community/home-manager` (overridable
+  via `ENDSTATE_HOME_MANAGER_PIN`).
+- **Classification:** switch output is **plain text** (not nix internal-json), so classification anchors the
+  raw stderr through the existing anchor table; the engine runner must place the experimental-features flag
+  **before** the `nix run` `--` separator (the `nixArgs` fix), or it would be passed to home-manager.
+- **Rollback → fast-follow (confirmed).** Mechanism is feasible — re-running a prior generation's
+  `<store-path>/activate` (store path + id from `home-manager generations` / the `-<N>-link` symlink) exits
+  0 — but it creates a NEW forward generation mirroring the old content rather than moving the pointer back
+  (unlike `nix profile rollback --to`). That is a distinct mechanism from the package `Rollbacker`, so
+  home-manager rollback ships as its own change with its own tests; this orchestration core de-risks it but
+  does not include it.

--- a/openspec/changes/nix-home-manager-config/design.md
+++ b/openspec/changes/nix-home-manager-config/design.md
@@ -1,0 +1,78 @@
+## Context
+
+The Nix realizer (`internal/realizer/nix`) owns packages only: `Current`/`Plan`/`Realize`(+`Pruner`/
+`Rollbacker`), via `nix profile`. The realizer `apply` path (`runApplyRealizer`) has plan/install/
+prune/verify phases — **no config stage**. The Windows config layer (`modules/`+`internal/restore`)
+is imperative file/registry plumbing keyed to `%ProgramFiles%`/winget — not reusable for Nix.
+home-manager is the Nix-native config tool: `home-manager switch --flake <ref>#<name>` activates a
+user's declarative config (dotfiles via `home.file`, typed settings via `programs.*`), creating a
+numbered home-manager generation. There is no automated "machine → home.nix" capture (Nix community
+guidance is manual migration), so this change is **apply/orchestration only**.
+
+## Goals / Non-Goals
+
+**Goals:** apply a user's home-manager config as the realizer's config stage; engine-owned
+invocation (user installs nothing); record it in the Provisioning Generation; back up clobbered
+files; zero Windows/default regression.
+
+**Non-Goals (follow-ons):** home-manager rollback (smoke-gated fast-follow); config *capture*;
+hiding the flake behind engine-generated `home.nix`/JSON (the catalog); nix-darwin/NixOS.
+
+## Decisions (maintainer, brainstormed)
+
+- **Start = orchestration core** (run switch + record), not capture or catalog.
+- **Invocation = engine-owned `nix run home-manager/<pin> -- switch`** (no user install; pinned;
+  preserves the moat) — not "assume home-manager installed".
+- **Surface = a config stage in `apply`**, gated by the existing **`--enable-restore`** (the config
+  gate; no weird new `--enable-home`) — not a separate command.
+- **Input = `homeManager.flake` (flakeref passthrough)** as a permanent power-user escape hatch; the
+  orchestrator is input-agnostic, so engine-generated inputs layer on later without rework.
+
+## Design
+
+### Manifest
+`manifest.Manifest` gains `HomeManager *HomeManagerConfig` with `Flake string` (`json:"flake"`).
+Absent ⇒ no config stage (default apply unchanged).
+
+### Activation (engine-owned, realizer-only)
+New `internal/realizer/nix/home_manager.go`: a function that runs, through the realizer's existing
+runner (which already injects `--extra-experimental-features 'nix-command flakes'`):
+
+`nix run <home-manager-pin> -- switch --flake <ref> -b endstate-backup`
+
+- `<home-manager-pin>` defaults to a pinned `github:nix-community/home-manager/<rev|release>`,
+  overridable via `ENDSTATE_HOME_MANAGER_PIN` (mirrors `ENDSTATE_NIXPKGS_PIN`).
+- `-b endstate-backup` makes home-manager move any pre-existing file it would replace to
+  `<file>.endstate-backup` instead of failing (honors *backup-before-overwrite*).
+- Result classified through the existing `classify`/anchor path: spawn/daemon → `REALIZER_UNAVAILABLE`,
+  permission → `PERMISSION_DENIED`, eval/activation error → `INSTALL_FAILED` (reuse), raw text →
+  `error.detail` only. Returns the new home-manager generation number on success (read from
+  `home-manager generations` or the switch output) for the record.
+
+### Pipeline
+In `runApplyRealizer`, after the prune/verify phases, a **config stage**: `if flags.EnableRestore &&
+mf.HomeManager != nil && mf.HomeManager.Flake != ""` → activate. Emits config-stage item/summary
+events consistent with the event contract. The winget/driver `apply` path is untouched.
+
+### Generation record
+`provision.Generation` gains optional `HomeManager *HomeGenRef{ Flake string; Generation int }`. The
+config stage populates it; `writeProvisioningGeneration` carries it. Recorded even when no package
+changed (a config-only apply is still a recorded provisioning event) — refine the write-gate so a
+home-manager activation counts as "something happened".
+
+### Safety / moat
+Opt-in (`--enable-restore` + manifest field); backup-on-clobber; realizer-only; raw Nix/home-manager
+text confined to `error.detail`. No Windows path, no default-apply change.
+
+## Risks / Verification
+
+- **home-manager behavior is the unknown** (like winget was): does `nix run home-manager -- switch
+  --flake` activate cleanly here, what does it print, what's the generation number source, and
+  (deferred) how does rollback re-activate a prior generation. Resolve with a **real-nix smoke** on
+  this box using a **throwaway `$HOME`** (so activation can't touch the real user profile): a tiny
+  `home.nix` setting e.g. `programs.git.userName`, `apply --enable-restore`, assert the generated
+  `~/.gitconfig` + the recorded generation. The smoke decides whether rollback joins this change or
+  becomes the fast-follow.
+- Hermetic: inject the runner; assert the stage fires only with the flag + manifest field, passes
+  the right argv, records the generation field, and no-ops otherwise. `GOOS=windows` build/vet clean
+  (realizer path is non-Windows; winget path untouched). `go test ./...`; openspec strict.

--- a/openspec/changes/nix-home-manager-config/proposal.md
+++ b/openspec/changes/nix-home-manager-config/proposal.md
@@ -1,0 +1,76 @@
+## Why
+
+Phases 1–7 gave the Nix realizer the full **package** loop on Linux/macOS (install, generation,
+rollback, prune, version). But Endstate has a second concern — **config** (settings/dotfiles) — and
+on Nix it is entirely absent: the realizer `apply` path is package-only, and the existing config
+layer (`modules/`+`restore/`) is Windows-oriented (winget matches, `%ProgramFiles%`, registry, copy/
+merge-ini). Meanwhile Nix's signature config capability, **home-manager** (declarative dotfiles +
+typed program settings), is exactly the "settings management" that can make the Linux/macOS side
+*richer* than Windows.
+
+This change is the **first step** toward Nix config management: the **home-manager orchestration
+core**. Endstate applies a user's home-manager config as a config stage of `apply`, records it, and
+keeps the **engine the lifecycle owner** — the user never installs or learns home-manager (the same
+"moat" the package realizer preserves). It is deliberately the smallest piece — orchestration only.
+Capturing config from a machine, and a curated declarative catalog, are explicit follow-ons.
+
+## What Changes
+
+- New manifest field **`homeManager.flake`** — a home-manager flakeref (e.g.
+  `/home/me/dotfiles#hugo` or `github:me/dotfiles#hugo`) pointing Endstate at a real home-manager
+  flake to activate. This is a **power-user escape hatch** (parallel to a power user pinning a raw
+  per-app nix ref); hiding it behind engine-generated config (a `home.nix` wrapper, or JSON settings
+  → the `programs.*` catalog) is future work. All such inputs ultimately produce a flakeref this
+  stage consumes, so the orchestrator is input-agnostic.
+- New **config stage in the realizer apply path** (`runApplyRealizer`), after the package phases,
+  gated by the existing **`--enable-restore`** flag: when the manifest declares `homeManager.flake`,
+  Endstate runs an **engine-owned** `nix run home-manager/<pin> -- switch --flake <ref> -b <ext>` to
+  activate the config. The home-manager version is **pinned by the engine** (the user installs
+  nothing); `-b` makes home-manager **back up** any file it would clobber (honors
+  *backup-before-overwrite*).
+- The applied config is recorded in the **Provisioning Generation** (the flakeref + the resulting
+  home-manager generation number), so config is part of the audit trail alongside packages.
+- **Realizer-only.** The winget/driver path is untouched (Windows config = the restore-module
+  layer). Without `homeManager.flake` or without `--enable-restore`, behavior is byte-identical. Raw
+  home-manager/Nix failure text is confined to `error.detail` via the realizer's existing
+  classification approach (the moat).
+
+## Capabilities
+
+### New Capabilities
+
+- `nix-home-manager-config`: `apply --enable-restore` on the Nix realizer activates a declared
+  home-manager config (`homeManager.flake`) via an engine-owned `home-manager switch`, backing up
+  clobbered files and recording the applied config in the Provisioning Generation. Realizer-only and
+  opt-in; the winget path and a default (no-config) apply are unaffected.
+
+### Modified Capabilities
+
+- None — additive. *Backup-before-overwrite* is honored via home-manager's `-b`; *separation of
+  concerns* is preserved (this is the config stage, distinct from package install).
+
+## Impact
+
+- `internal/manifest/types.go` — add `HomeManager *HomeManagerConfig{ Flake string }` to the manifest.
+- `internal/realizer/nix/` (new home_manager.go) — engine-owned `nix run home-manager -- switch`
+  activation; classify failures via the existing anchor path; pin overridable via env.
+- `internal/commands/apply_realizer.go` — a config stage after the package phases, gated by
+  `flags.EnableRestore`, when the manifest declares `homeManager`; record in the generation.
+- `internal/provision/provision.go` — optional `HomeManager` field on the `Generation` record.
+- `docs/contracts/cli-json-contract.md` — **PROTECTED (maintainer-approved, additive)**: document
+  `homeManager.flake` + the config stage.
+- **Zero Windows/default regression.** Proven by host-aware tests + `GOOS=windows` build/vet; a
+  **real-nix home-manager smoke** on this box validates the actual `switch` behavior.
+
+## Non-Goals (explicit follow-ons)
+
+- **Rollback of the home-manager config.** home-manager keeps its own numbered generations, but the
+  rollback mechanics are an empirical unknown — rollback ships as a **fast-follow** once a real-nix
+  smoke confirms how to re-activate a prior home-manager generation (same discipline as the winget
+  `--force` unknown).
+- **Config capture** (machine → home-manager config) — only raw-file capture is automatable; a
+  separate sub-project.
+- **Hiding the flake** — engine-generated `home.nix` / a `programs.*` declarative catalog (the
+  "richer than Windows" end-state); a separate sub-project that produces a flakeref this same stage
+  consumes.
+- **nix-darwin / NixOS system config** — user-scoped home-manager only.

--- a/openspec/changes/nix-home-manager-config/specs/nix-home-manager-config/spec.md
+++ b/openspec/changes/nix-home-manager-config/specs/nix-home-manager-config/spec.md
@@ -1,0 +1,64 @@
+## ADDED Requirements
+
+### Requirement: Apply activates a declared home-manager config
+
+The engine SHALL activate a declared home-manager configuration as a configuration stage of `apply`
+on a realizer backend, when configuration changes are enabled. The home-manager tool SHALL be
+invoked by the engine itself (the user does not install or run it), at a version the engine controls.
+
+#### Scenario: Declared config is activated when config is enabled
+
+- **WHEN** `apply` runs on the Nix realizer with configuration changes enabled and the manifest
+  declares a home-manager config reference
+- **THEN** the engine SHALL activate that home-manager configuration (a `home-manager switch`)
+- **AND** it SHALL do so without requiring the user to have installed home-manager
+
+#### Scenario: No declared config is a no-op
+
+- **WHEN** `apply` runs and the manifest declares no home-manager config
+- **THEN** the engine SHALL NOT run any home-manager activation
+- **AND** the apply behavior SHALL be unchanged from a package-only apply
+
+### Requirement: The config stage is opt-in and scoped to the realizer
+
+Activating a home-manager configuration SHALL require the configuration-changes flag, and SHALL apply
+only on a backend that supports it (the Nix realizer). A backend without home-manager support, or an
+apply without the configuration flag, SHALL NOT activate any configuration.
+
+#### Scenario: Without the config flag, nothing is activated
+
+- **WHEN** `apply` runs with a declared home-manager config but without the configuration-changes flag
+- **THEN** the engine SHALL NOT activate the home-manager configuration
+
+#### Scenario: The driver (winget) path does not run home-manager
+
+- **WHEN** `apply` runs through the winget driver path
+- **THEN** the engine SHALL NOT attempt any home-manager activation
+
+### Requirement: Existing files are backed up before being overwritten
+
+The engine SHALL back up any existing file that activating the home-manager configuration would
+replace, rather than failing or destroying it, honoring the backup-before-overwrite guarantee.
+
+#### Scenario: A clobbered file is backed up
+
+- **WHEN** activating the home-manager configuration would replace a file the user already has
+- **THEN** the engine SHALL preserve the existing file as a backup
+- **AND** the activation SHALL proceed rather than aborting on the conflict
+
+### Requirement: The applied config is recorded in the Provisioning Generation
+
+After activating a home-manager configuration, the engine SHALL record the applied configuration in
+the Provisioning Generation, so configuration is part of the same audit trail as packages.
+
+#### Scenario: Generation records the activated config
+
+- **WHEN** `apply` activates a home-manager configuration
+- **THEN** the engine SHALL write a Provisioning Generation that records the activated configuration
+  reference and its resulting home-manager generation
+
+#### Scenario: Raw backend text stays out of the user message
+
+- **WHEN** a home-manager activation fails
+- **THEN** the engine SHALL report a stable error with a human-readable message
+- **AND** the raw home-manager / Nix output SHALL appear only in the error detail, not the message

--- a/openspec/changes/nix-home-manager-config/tasks.md
+++ b/openspec/changes/nix-home-manager-config/tasks.md
@@ -5,47 +5,65 @@
 
 ## 1. Manifest field
 
-- [ ] 1.1 `internal/manifest/types.go`: add `HomeManager *HomeManagerConfig` (`json:"homeManager,omitempty"`)
+- [x] 1.1 `internal/manifest/types.go`: add `HomeManager *HomeManagerConfig` (`json:"homeManager,omitempty"`)
       with `Flake string` (`json:"flake"`); ensure JSONC load round-trips it
-- [ ] 1.2 RED test: a manifest with `homeManager.flake` parses; absent ⇒ nil
+- [x] 1.2 RED test: a manifest with `homeManager.flake` parses; absent ⇒ nil
 
 ## 2. Engine-owned activation (realizer/nix)
 
-- [ ] 2.1 RED tests (`internal/realizer/nix/home_manager_test.go`, injected `Runner`): activation runs
+- [x] 2.1 RED tests (`internal/realizer/nix/home_manager_test.go`, injected `Runner`): activation runs
       `nix run <pin> -- switch --flake <ref> -b endstate-backup`; success returns the new hm
       generation; non-zero/spawn/permission → classified `*realizer.Error` (raw text in `Raw` only)
-- [ ] 2.2 `internal/realizer/nix/home_manager.go`: implement the activation via the existing runner;
+- [x] 2.2 `internal/realizer/nix/home_manager.go`: implement the activation via the existing runner;
       pin via `ENDSTATE_HOME_MANAGER_PIN` (default pinned `github:nix-community/home-manager/<rev>`);
       classify through the existing anchor path
 
 ## 3. Provisioning Generation record
 
-- [ ] 3.1 `internal/provision/provision.go`: add optional `HomeManager *HomeGenRef{ Flake string;
+- [x] 3.1 `internal/provision/provision.go`: add optional `HomeManager *HomeGenRef{ Flake string;
       Generation int }` to `Generation`
-- [ ] 3.2 Adjust the write so a config-only activation still records a generation (home-manager
+- [x] 3.2 Adjust the write so a config-only activation still records a generation (home-manager
       activation counts as "something happened")
 
 ## 4. Config stage in apply (realizer path)
 
-- [ ] 4.1 `internal/commands/apply_realizer.go`: after the package phases, when `flags.EnableRestore
+- [x] 4.1 `internal/commands/apply_realizer.go`: after the package phases, when `flags.EnableRestore
       && mf.HomeManager != nil && mf.HomeManager.Flake != ""`, activate; emit config-stage events;
       populate the generation's `HomeManager`; systemic failure → top-level envelope error, else
       `INSTALL_FAILED` with raw text in detail
-- [ ] 4.2 RED tests (inject a fake realizer/runner; override BOTH seams): stage fires only with the
+- [x] 4.2 RED tests (inject a fake realizer/runner; override BOTH seams): stage fires only with the
       flag + manifest field, passes the right argv, records the generation field; no flag / no field
       ⇒ no activation; winget path never activates
 
 ## 5. Contract (PROTECTED — maintainer-approved, additive)
 
-- [ ] 5.1 `docs/contracts/cli-json-contract.md`: document `homeManager.flake` + the `apply
+- [x] 5.1 `docs/contracts/cli-json-contract.md`: document `homeManager.flake` + the `apply
       --enable-restore` config stage (realizer-only, engine-owned, backup-on-clobber, recorded)
 
 ## 6. Verification
 
-- [ ] 6.1 `cd go-engine && go test ./...` green on Linux
-- [ ] 6.2 `GOOS=windows go build ./...` + `go vet ./...` clean (winget/default path untouched)
-- [ ] 6.3 `npm run openspec:validate` (strict) passes
-- [ ] 6.4 **Real-nix home-manager smoke** (throwaway `$HOME` + isolated `ENDSTATE_ROOT`): a tiny
+- [x] 6.1 `cd go-engine && go test ./...` green on Linux
+- [x] 6.2 `GOOS=windows go build ./...` + `go vet ./...` clean (winget/default path untouched)
+- [x] 6.3 `npm run openspec:validate` (strict) passes
+- [x] 6.4 **Real-nix home-manager smoke** (throwaway `$HOME` + isolated `ENDSTATE_ROOT`): a tiny
       `home.nix` (e.g. `programs.git.userName`) flake → `apply --enable-restore` activates it →
       generated `~/.gitconfig` reflects it, clobbered file backed up, generation records the config.
       Probe rollback mechanics → decide if rollback joins this change or becomes the fast-follow.
+
+### Smoke outcome (real Determinate Nix 3.21.0, throwaway `$HOME`)
+
+- `nix run github:nix-community/home-manager -- switch --flake <ref> -b endstate-backup` activates cleanly
+  (exit 0). Engine `apply --enable-restore` end-to-end: managed `~/.config/git/config` reflects the flake;
+  the clobbered file is moved to `config.endstate-backup`; the generation records
+  `homeManager: { flake, generation }` (hm gen read from the `$XDG_STATE_HOME/nix/profiles/home-manager`
+  `-<N>-link` symlink). Without `--enable-restore` the config is untouched (default apply byte-identical).
+- **Generation-number source:** the home-manager nix-profile symlink (`-<N>-link`), read the same way as the
+  package generation — no second nix invocation. **Switch output is plain text** (not internal-json), so
+  classification anchors the raw stderr; the runner's experimental-features flag must precede the `nix run`
+  `--` (the `nixArgs` fix).
+- **Rollback verdict: DEFER to fast-follow (as designed).** The mechanism is confirmed feasible —
+  re-activate a prior generation's `<store-path>/activate` (store path + id from `home-manager generations`
+  / the `-<N>-link` symlink), exit 0 — BUT it produces a NEW forward generation (mirroring the old content)
+  rather than moving the pointer back, unlike `nix profile rollback --to`. That is a distinct mechanism from
+  the package `Rollbacker` and warrants its own focused change + tests. The probe de-risks the follow-on; the
+  orchestration core ships without hm rollback.

--- a/openspec/changes/nix-home-manager-config/tasks.md
+++ b/openspec/changes/nix-home-manager-config/tasks.md
@@ -1,0 +1,51 @@
+> TDD: write each test RED first, then implement to green. Hermetic (inject the realizer runner;
+> override `newRealizerFn`) + host-aware. Verify: `cd go-engine && go test ./...` (Linux) +
+> `GOOS=windows go build ./...` + `go vet`. A **real-nix home-manager smoke** (throwaway `$HOME`)
+> on this box validates actual `switch` behavior and decides whether rollback joins this change.
+
+## 1. Manifest field
+
+- [ ] 1.1 `internal/manifest/types.go`: add `HomeManager *HomeManagerConfig` (`json:"homeManager,omitempty"`)
+      with `Flake string` (`json:"flake"`); ensure JSONC load round-trips it
+- [ ] 1.2 RED test: a manifest with `homeManager.flake` parses; absent ⇒ nil
+
+## 2. Engine-owned activation (realizer/nix)
+
+- [ ] 2.1 RED tests (`internal/realizer/nix/home_manager_test.go`, injected `Runner`): activation runs
+      `nix run <pin> -- switch --flake <ref> -b endstate-backup`; success returns the new hm
+      generation; non-zero/spawn/permission → classified `*realizer.Error` (raw text in `Raw` only)
+- [ ] 2.2 `internal/realizer/nix/home_manager.go`: implement the activation via the existing runner;
+      pin via `ENDSTATE_HOME_MANAGER_PIN` (default pinned `github:nix-community/home-manager/<rev>`);
+      classify through the existing anchor path
+
+## 3. Provisioning Generation record
+
+- [ ] 3.1 `internal/provision/provision.go`: add optional `HomeManager *HomeGenRef{ Flake string;
+      Generation int }` to `Generation`
+- [ ] 3.2 Adjust the write so a config-only activation still records a generation (home-manager
+      activation counts as "something happened")
+
+## 4. Config stage in apply (realizer path)
+
+- [ ] 4.1 `internal/commands/apply_realizer.go`: after the package phases, when `flags.EnableRestore
+      && mf.HomeManager != nil && mf.HomeManager.Flake != ""`, activate; emit config-stage events;
+      populate the generation's `HomeManager`; systemic failure → top-level envelope error, else
+      `INSTALL_FAILED` with raw text in detail
+- [ ] 4.2 RED tests (inject a fake realizer/runner; override BOTH seams): stage fires only with the
+      flag + manifest field, passes the right argv, records the generation field; no flag / no field
+      ⇒ no activation; winget path never activates
+
+## 5. Contract (PROTECTED — maintainer-approved, additive)
+
+- [ ] 5.1 `docs/contracts/cli-json-contract.md`: document `homeManager.flake` + the `apply
+      --enable-restore` config stage (realizer-only, engine-owned, backup-on-clobber, recorded)
+
+## 6. Verification
+
+- [ ] 6.1 `cd go-engine && go test ./...` green on Linux
+- [ ] 6.2 `GOOS=windows go build ./...` + `go vet ./...` clean (winget/default path untouched)
+- [ ] 6.3 `npm run openspec:validate` (strict) passes
+- [ ] 6.4 **Real-nix home-manager smoke** (throwaway `$HOME` + isolated `ENDSTATE_ROOT`): a tiny
+      `home.nix` (e.g. `programs.git.userName`) flake → `apply --enable-restore` activates it →
+      generated `~/.gitconfig` reflects it, clobbered file backed up, generation records the config.
+      Probe rollback mechanics → decide if rollback joins this change or becomes the fast-follow.


### PR DESCRIPTION
## What & why

First **config** piece for the Nix realizer (Linux/macOS): a **home-manager orchestration core**. Endstate activates a user's declared home-manager configuration as a **config stage of `apply`**, gated by the existing `--enable-restore` flag, and records it — keeping the engine the lifecycle owner so the user never installs or learns home-manager (the same "moat" the package realizer preserves). Deliberately the smallest piece: orchestration only. Config *capture* and a `programs.*` catalog are explicit follow-ons.

Implements OpenSpec change `nix-home-manager-config` (proposal/design/tasks/spec included; decisions locked with the maintainer in brainstorming).

## What changes

- **Manifest** — new `homeManager.flake` field: a home-manager flakeref (e.g. `/home/me/dotfiles#hugo` or `github:me/dotfiles#hugo`), a permanent power-user escape hatch. The orchestrator is input-agnostic, so later "hide the flake" inputs layer on without rework.
- **Activation** (`internal/realizer/nix/home_manager.go`) — engine-owned `nix run <pin> -- switch --flake <ref> -b endstate-backup`. Pin via `ENDSTATE_HOME_MANAGER_PIN` (mirrors `ENDSTATE_NIXPKGS_PIN`). Returns the resulting hm generation (read from the home-manager nix-profile symlink, like the package generation). Failures classified through the existing anchor path — raw Nix/home-manager text confined to `error.detail`. New optional `realizer.HomeActivator` capability (mirrors `Pruner`).
- **Config stage** (`runApplyRealizer`) — runs after the package phases when `--enable-restore` **and** `homeManager.flake` are set; emits `config`-phase events; records the config in the Provisioning Generation. Systemic failure → top-level envelope error, else `INSTALL_FAILED` with raw in detail (mirrors the prune precedent). Realizer-only; the winget/driver path never activates.
- **Provisioning Generation** — optional `homeManager: { flake, generation }`; a config-only apply still records a generation.
- **Backup-on-clobber** — `-b endstate-backup` moves any clobbered file to `<file>.endstate-backup`.
- **Contract** (`docs/contracts/cli-json-contract.md`) — additive docs for the field, the stage, and the generation record.
- Fix: `defaultRunner` now places `--extra-experimental-features` **before** `nix run`'s `--` separator (the `nixArgs` helper), so the flag reaches nix rather than home-manager (package `nix profile` path unchanged).

Without `homeManager.flake` or without `--enable-restore`, behavior is **byte-identical** to a package-only apply.

## Verification

- `cd go-engine && go test ./...` green (Linux); `GOOS=windows go build ./...` + `go vet ./...` clean (realizer path is non-Windows; winget/default path untouched).
- `openspec validate --all --strict` passes.
- **Real-nix home-manager smoke** (throwaway `$HOME`, isolated `ENDSTATE_ROOT`): `apply --enable-restore` activated the config (managed `~/.config/git/config` reflects the flake), the clobbered file was backed up to `config.endstate-backup`, and the generation recorded `homeManager: { flake, generation: 1 }`. A control run without `--enable-restore` left the file untouched.

## Deferred (non-goal, documented fast-follow)

**home-manager config rollback.** The smoke confirmed the mechanism is feasible (re-activate a prior generation's `<store-path>/activate`) but it produces a *new forward* generation rather than moving the pointer back — a distinct mechanism from the package `Rollbacker` (`nix profile rollback --to`). It ships as its own focused change with its own tests; this PR de-risks it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
