### PR TITLE
feat(engine): home-manager config capture (close the config apply↔capture loop)

### DIFF
--- a/go-engine/internal/commands/capture.go
+++ b/go-engine/internal/commands/capture.go
@@ -46,7 +46,7 @@ type CaptureResult struct {
 	ConfigModules        []CaptureModuleResult `json:"configModules"`
 	ConfigModuleMap      map[string]string     `json:"configModuleMap"`
 	OutputPath           string                `json:"outputPath"`
-	OutputFormat         string                `json:"outputFormat"`       // "zip" or "jsonc"
+	OutputFormat         string                `json:"outputFormat"` // "zip" or "jsonc"
 	ConfigsIncluded      []string              `json:"configsIncluded"`
 	ConfigsSkipped       []string              `json:"configsSkipped"`
 	ConfigsCaptureErrors []string              `json:"configsCaptureErrors"`
@@ -139,10 +139,11 @@ type cleanApp struct {
 
 // captureManifestOutput is the manifest structure written to disk.
 type captureManifestOutput struct {
-	Version  int         `json:"version"`
-	Name     string      `json:"name,omitempty"`
-	Captured string      `json:"captured,omitempty"`
-	Apps     interface{} `json:"apps"`
+	Version     int                         `json:"version"`
+	Name        string                      `json:"name,omitempty"`
+	Captured    string                      `json:"captured,omitempty"`
+	Apps        interface{}                 `json:"apps"`
+	HomeManager *manifest.HomeManagerConfig `json:"homeManager,omitempty"`
 }
 
 // RunCapture executes the capture command with the provided flags.

--- a/go-engine/internal/commands/capture_realizer.go
+++ b/go-engine/internal/commands/capture_realizer.go
@@ -14,8 +14,15 @@ import (
 
 	"github.com/Artexis10/endstate/go-engine/internal/envelope"
 	"github.com/Artexis10/endstate/go-engine/internal/events"
+	"github.com/Artexis10/endstate/go-engine/internal/manifest"
+	"github.com/Artexis10/endstate/go-engine/internal/provision"
 	"github.com/Artexis10/endstate/go-engine/internal/realizer"
 )
+
+// listGenerationsFn reads the provisioning generations (newest-first). It
+// defaults to provision.List and is replaced in tests to make home-manager
+// flake recovery hermetic.
+var listGenerationsFn = provision.List
 
 // runCaptureRealizer is the capture path for a realizer backend (Nix on
 // linux/darwin). It reads the installed set via Current() and emits each element
@@ -114,10 +121,11 @@ func runCaptureRealizer(flags CaptureFlags, r realizer.Realizer, emitter *events
 	}
 
 	outManifest := captureManifestOutput{
-		Version:  1,
-		Name:     manifestName,
-		Captured: time.Now().UTC().Format(time.RFC3339),
-		Apps:     outputApps,
+		Version:     1,
+		Name:        manifestName,
+		Captured:    time.Now().UTC().Format(time.RFC3339),
+		Apps:        outputApps,
+		HomeManager: recoverHomeManager(flags),
 	}
 
 	// --- 7. Write manifest as pretty-printed JSON (same as the winget path) ---
@@ -187,4 +195,29 @@ func runCaptureRealizer(flags CaptureFlags, r realizer.Realizer, emitter *events
 			Path: absPath,
 		},
 	}, nil
+}
+
+// recoverHomeManager returns the home-manager configuration to record in the
+// captured manifest, or nil if none is known. The flake is recovered from the
+// engine's own provisioning history (home-manager does not persist the source
+// flakeref in a live install): the most-recent generation whose HomeManager is
+// set — provision.List is newest-first, and a later package-only apply records
+// HomeManager=nil, so the first match is the config still in effect. The read is
+// best-effort: an error or empty history simply yields nil (the field is
+// omitted; package capture is unaffected). On --update with no flake in history,
+// an existing manifest's homeManager block is preserved rather than dropped.
+func recoverHomeManager(flags CaptureFlags) *manifest.HomeManagerConfig {
+	if gens, err := listGenerationsFn(); err == nil {
+		for _, g := range gens {
+			if g.HomeManager != nil && g.HomeManager.Flake != "" {
+				return &manifest.HomeManagerConfig{Flake: g.HomeManager.Flake}
+			}
+		}
+	}
+	if flags.Update && flags.Manifest != "" {
+		if mf, loadErr := loadManifest(flags.Manifest); loadErr == nil && mf.HomeManager != nil {
+			return mf.HomeManager
+		}
+	}
+	return nil
 }

--- a/go-engine/internal/commands/capture_realizer_test.go
+++ b/go-engine/internal/commands/capture_realizer_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/provision"
 	"github.com/Artexis10/endstate/go-engine/internal/realizer"
 )
 
@@ -48,6 +49,31 @@ type capturedManifestFile struct {
 		Refs    map[string]string `json:"refs"`
 		Version string            `json:"version"`
 	} `json:"apps"`
+	HomeManager *struct {
+		Flake string `json:"flake"`
+	} `json:"homeManager"`
+}
+
+// withFakeGenerations replaces listGenerationsFn (the provisioning-history read
+// used to recover the activated home-manager flake) with one returning the given
+// generations and error, calls f, then restores the original. Generations are
+// newest-first, matching provision.List.
+func withFakeGenerations(gens []*provision.Generation, err error, f func()) {
+	orig := listGenerationsFn
+	listGenerationsFn = func() ([]*provision.Generation, error) { return gens, err }
+	defer func() { listGenerationsFn = orig }()
+	f()
+}
+
+// hmGen builds a provisioning generation that activated the given home-manager
+// flake (genNum is the home-manager generation number, irrelevant to capture).
+func hmGen(flake string, genNum int) *provision.Generation {
+	return &provision.Generation{HomeManager: &provision.HomeGenRef{Flake: flake, Generation: genNum}}
+}
+
+// pkgGen builds a package-only provisioning generation (no home-manager config).
+func pkgGen() *provision.Generation {
+	return &provision.Generation{}
 }
 
 func readCapturedManifest(t *testing.T, path string) capturedManifestFile {
@@ -297,5 +323,129 @@ func TestRunCapture_NoRealizer_UsesWingetPath(t *testing.T) {
 	}
 	if !foundWin {
 		t.Errorf("expected winget path (windows refs) when no realizer, got %+v", mf.Apps)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Home-manager config capture (engine-provisioned flake passthrough)
+// ---------------------------------------------------------------------------
+
+// The activated home-manager flake is recovered from provisioning history and
+// emitted into the manifest alongside the captured packages.
+func TestRunCaptureRealizer_EmitsHomeManagerFlakeFromHistory(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "hm.jsonc")
+	fr := &fakeRealizer{currentSet: nixSet("ripgrep")}
+
+	withFakeGenerations([]*provision.Generation{hmGen("/home/me/dots#hugo", 3)}, nil, func() {
+		if _, eerr := runCaptureRealizer(CaptureFlags{Out: out}, fr, noopEmitter()); eerr != nil {
+			t.Fatalf("runCaptureRealizer returned envelope error: %+v", eerr)
+		}
+	})
+
+	mf := readCapturedManifest(t, out)
+	if mf.HomeManager == nil {
+		t.Fatalf("expected homeManager block, got none")
+	}
+	if mf.HomeManager.Flake != "/home/me/dots#hugo" {
+		t.Errorf("homeManager.flake = %q, want /home/me/dots#hugo", mf.HomeManager.Flake)
+	}
+	if len(mf.Apps) != 1 {
+		t.Errorf("packages should still be captured: apps = %d, want 1", len(mf.Apps))
+	}
+}
+
+// When a later generation activated no config (HomeManager=nil), capture uses the
+// most-recent generation that DID — the config still in effect — not "latest".
+func TestRunCaptureRealizer_HomeManager_MostRecentNonNil(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "hm2.jsonc")
+	fr := &fakeRealizer{currentSet: nixSet("jq")}
+
+	// newest-first: newest is package-only, older activated the flake.
+	gens := []*provision.Generation{pkgGen(), hmGen("github:me/dots#box", 2)}
+	withFakeGenerations(gens, nil, func() {
+		if _, eerr := runCaptureRealizer(CaptureFlags{Out: out}, fr, noopEmitter()); eerr != nil {
+			t.Fatalf("runCaptureRealizer returned envelope error: %+v", eerr)
+		}
+	})
+
+	mf := readCapturedManifest(t, out)
+	if mf.HomeManager == nil || mf.HomeManager.Flake != "github:me/dots#box" {
+		t.Fatalf("expected the most-recent activated flake github:me/dots#box, got %+v", mf.HomeManager)
+	}
+}
+
+// No generation activated a config → the homeManager field is omitted entirely.
+func TestRunCaptureRealizer_NoHomeManagerHistory_OmitsField(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "hm3.jsonc")
+	fr := &fakeRealizer{currentSet: nixSet("ripgrep")}
+
+	withFakeGenerations([]*provision.Generation{pkgGen()}, nil, func() {
+		if _, eerr := runCaptureRealizer(CaptureFlags{Out: out}, fr, noopEmitter()); eerr != nil {
+			t.Fatalf("runCaptureRealizer returned envelope error: %+v", eerr)
+		}
+	})
+
+	data, err := os.ReadFile(out)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	if strings.Contains(string(data), "homeManager") {
+		t.Errorf("expected no homeManager field, got:\n%s", data)
+	}
+	if mf := readCapturedManifest(t, out); mf.HomeManager != nil {
+		t.Errorf("expected nil homeManager, got %+v", mf.HomeManager)
+	}
+}
+
+// A provisioning-history read error must not fail capture: the package manifest
+// is still written and the homeManager field is simply omitted (best-effort).
+func TestRunCaptureRealizer_GenerationsError_OmitsAndSucceeds(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "hm4.jsonc")
+	fr := &fakeRealizer{currentSet: nixSet("ripgrep", "jq")}
+
+	withFakeGenerations(nil, errors.New("state dir unreadable"), func() {
+		raw, eerr := runCaptureRealizer(CaptureFlags{Out: out}, fr, noopEmitter())
+		if eerr != nil {
+			t.Fatalf("history read error must not fail capture: %+v", eerr)
+		}
+		res := raw.(*CaptureResult)
+		if res.Counts.Included != 2 {
+			t.Errorf("packages still captured: Included = %d, want 2", res.Counts.Included)
+		}
+	})
+
+	mf := readCapturedManifest(t, out)
+	if mf.HomeManager != nil {
+		t.Errorf("expected nil homeManager on history error, got %+v", mf.HomeManager)
+	}
+	if len(mf.Apps) != 2 {
+		t.Errorf("apps = %d, want 2", len(mf.Apps))
+	}
+}
+
+// On --update with no config in history, an existing manifest's homeManager block
+// is preserved rather than dropped.
+func TestRunCaptureRealizer_Update_PreservesExistingHomeManager(t *testing.T) {
+	tmp := t.TempDir()
+	existing := filepath.Join(tmp, "existing.jsonc")
+	existingJSON := fmt.Sprintf(
+		`{"version":1,"name":"box","apps":[{"id":"ripgrep","refs":{"%s":"ripgrep"}}],"homeManager":{"flake":"github:me/dots#hugo"}}`,
+		runtime.GOOS,
+	)
+	if err := os.WriteFile(existing, []byte(existingJSON), 0644); err != nil {
+		t.Fatalf("write existing manifest: %v", err)
+	}
+	out := filepath.Join(tmp, "merged.jsonc")
+	fr := &fakeRealizer{currentSet: nixSet("ripgrep", "jq")}
+
+	withFakeGenerations([]*provision.Generation{pkgGen()}, nil, func() {
+		if _, eerr := runCaptureRealizer(CaptureFlags{Out: out, Update: true, Manifest: existing}, fr, noopEmitter()); eerr != nil {
+			t.Fatalf("runCaptureRealizer returned envelope error: %+v", eerr)
+		}
+	})
+
+	mf := readCapturedManifest(t, out)
+	if mf.HomeManager == nil || mf.HomeManager.Flake != "github:me/dots#hugo" {
+		t.Fatalf("expected preserved homeManager github:me/dots#hugo, got %+v", mf.HomeManager)
 	}
 }

--- a/openspec/changes/nix-home-manager-capture/.openspec.yaml
+++ b/openspec/changes/nix-home-manager-capture/.openspec.yaml
@@ -1,0 +1,10 @@
+id: nix-home-manager-capture
+title: "Home-manager config capture: close the config apply↔capture loop"
+status: implementing
+spec: nix-home-manager-capture
+created: "2026-06-02"
+author: Hugo Ander Kivi
+artifacts:
+  - proposal.md
+  - design.md
+  - tasks.md

--- a/openspec/changes/nix-home-manager-capture/design.md
+++ b/openspec/changes/nix-home-manager-capture/design.md
@@ -1,0 +1,85 @@
+## Context
+
+- `runCaptureRealizer` (`internal/commands/capture_realizer.go`) is the Nix capture path (#79): it
+  reads the installed package set via `Current()` and writes a manifest of `capturedApp` entries via
+  the local `captureManifestOutput{Version, Name, Captured, Apps}` struct in `capture.go`.
+- `apply` (#81) activates `manifest.HomeManager.Flake` via `nix run <pin> -- switch --flake <ref>`
+  and `apply_generation.go` records `provision.Generation.HomeManager = *HomeGenRef{Flake, Generation}`.
+- `provision.List() ([]*Generation, error)` returns generations **newest-first**
+  (`internal/provision/store.go`). `HomeGenRef.Flake` is the activated flakeref.
+- Home-manager does **not** persist the originating flakeref in a live install (verified against the
+  home-manager source: the generation records `hm-version` + a managed-file `manifest.json`, never the
+  flake). So the engine's own provisioning history is the only automatable source.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `capture` emits the engine-provisioned home-manager flake so a captured manifest round-trips through
+  the #81 apply config stage.
+- Zero winget / package-capture / Windows regression; reuse existing types and the provisioning store.
+
+**Non-Goals:**
+- **No config *content* capture** — no raw-file snapshot, no `home.nix` synthesis (home-manager files
+  are read-only store symlinks; can't re-apply through the flake stage; #81 declined this paradigm).
+- **No live-system flake recovery** — not possible; the flake comes from provisioning history only.
+- **No new manifest schema** — reuse `manifest.HomeManagerConfig`.
+- **No `--enable-restore` gate** — capture is read-only.
+
+## Decisions (maintainer, confirmed)
+
+- **Direction A — engine-provisioned flake passthrough.** Recover the flake from provisioning history;
+  emit `manifest.HomeManager`. Round-trips with apply; matches Endstate's "capture what it
+  provisioned" model. Rejected raw-file snapshot (foreign paradigm, no round-trip) and hybrid (YAGNI).
+- **Most-recent non-nil selection** — iterate `provision.List()` (newest-first), take the first
+  generation with `HomeManager != nil && .Flake != ""`. A later package-only apply records
+  `HomeManager=nil`, so this yields the currently-active config, not "latest overall".
+- **Best-effort** — generation read errors / empty history omit the block; never fail capture.
+- **Honest limitation (documented in spec):** only captures configs applied through Endstate; a
+  pre-existing manual home-manager setup yields no flake until declared + applied once.
+
+## Design
+
+`captureManifestOutput` (capture.go) gains:
+
+```go
+HomeManager *manifest.HomeManagerConfig `json:"homeManager,omitempty"`
+```
+
+`runCaptureRealizer` (capture_realizer.go), after building `captured`/`outputApps` and before writing:
+
+```go
+var listGenerationsFn = provision.List // package var; tests override for hermeticity
+
+func recoverHomeManager(flags CaptureFlags) *manifest.HomeManagerConfig {
+    if gens, err := listGenerationsFn(); err == nil {
+        for _, g := range gens { // newest-first
+            if g.HomeManager != nil && g.HomeManager.Flake != "" {
+                return &manifest.HomeManagerConfig{Flake: g.HomeManager.Flake}
+            }
+        }
+    }
+    // --update: preserve an existing manifest's homeManager when history has none
+    if flags.Update && flags.Manifest != "" {
+        if mf, err := loadManifest(flags.Manifest); err == nil && mf.HomeManager != nil {
+            return mf.HomeManager
+        }
+    }
+    return nil
+}
+```
+
+`outManifest.HomeManager = recoverHomeManager(flags)` — omitempty drops it when nil. No event/contract
+surface change; the package capture summary/result are unchanged.
+
+## Risks / Verification
+
+- **Hermetic tests** override `listGenerationsFn` (+ `withFakeRealizer`): flake present → emitted;
+  most-recent-non-nil selection; none → omitted; `--update` preservation; read error → omitted + no
+  failure; package capture unaffected.
+- **Real-nix round-trip smoke** (Linux dev box, local home-manager pin): `apply` a tiny
+  `homeConfigurations` flake (`--enable-restore`) → generation records the flake → `capture` → the
+  manifest carries `homeManager.flake` → `apply` the captured manifest into fresh state re-activates.
+  Proves the config loop closes. The live `switch` is the already-smoked #81 apply path; the new code
+  (capture reading history) is fully covered hermetically.
+- **No regression:** Nix-only path; Windows `newRealizerFn → ErrNoRealizer` never reaches it;
+  `GOOS=windows` build/vet + the existing capture suite stay green.

--- a/openspec/changes/nix-home-manager-capture/proposal.md
+++ b/openspec/changes/nix-home-manager-capture/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+The Nix realizer now has package `apply`/`verify`, package `capture` (#79, the apply↔capture loop
+closed for packages), and a home-manager **config apply** stage (#81: `nix run <pin> -- switch
+--flake <ref>`, recorded in the Provisioning Generation). But `capture` is **package-only** — it does
+not record the activated home-manager config. So the *config* half of the snapshot → manifest →
+rebuild loop is open: you can apply a home-manager config but cannot snapshot one back into a
+manifest.
+
+This change closes it: `capture` recovers the home-manager flake the engine activated and emits it
+into the captured manifest, so a captured manifest round-trips through #81's apply config stage.
+
+**The flake is recovered from the engine, not the system.** Home-manager does not persist the
+originating flakeref in a live install (the generation derivation records `hm-version` and a
+`manifest.json` of managed files, but never the source flake — confirmed against the home-manager
+source). However, Endstate's `apply` already records it: `apply_generation.go` writes
+`provision.Generation.HomeManager = {Flake, Generation}`. Capture reads that provisioning history.
+
+## What Changes
+
+- **Recover the config flake in the realizer capture path.** `runCaptureRealizer` reads
+  `provision.List()` (newest-first) and takes the flake from the **most-recent generation whose
+  `HomeManager` is non-nil** (a later package-only apply records `HomeManager=nil`, so "latest
+  overall" would wrongly drop it).
+- **Emit it into the manifest.** The captured manifest gains
+  `"homeManager": { "flake": "<ref>" }` when a flake is found — reusing the existing
+  `manifest.HomeManagerConfig` type, so the output is a valid manifest the #81 apply path consumes
+  unchanged. Absent ⇒ the block is omitted.
+- **`--update` preservation.** When updating an existing manifest, prefer the flake from provisioning
+  history; if history has none, preserve the existing manifest's `homeManager` block rather than
+  dropping it.
+- **Best-effort and non-destructive.** Reading generations is best-effort (mirrors run-history): a
+  read error or empty history simply omits the block; package capture proceeds and the command never
+  fails on this account. Capture has no `--enable-restore` gate (capture is read-only; the gate
+  exists on apply because it mutates).
+
+## Capabilities
+
+### New Capabilities
+
+- `nix-home-manager-capture`: `capture` records the engine-provisioned home-manager flake (from the
+  Provisioning Generation history) and emits it into the manifest, so a captured manifest round-trips
+  through the apply config stage. Home-manager config *content* capture remains out of scope.
+
+### Modified Capabilities
+
+- None. This extends `capture` within the existing contract (it emits a manifest field the apply
+  config stage already defines). The winget capture path and package capture are unchanged.
+
+## Impact
+
+- `internal/commands/capture_realizer.go` — recover the flake from `provision.List()` and attach it
+  to the output manifest; add a `listGenerationsFn` seam for hermetic tests (main change).
+- `internal/commands/capture.go` — add an `omitempty` `HomeManager` field to `captureManifestOutput`
+  (one field; winget path otherwise untouched).
+- `internal/commands/capture_realizer_test.go` — hermetic, host-aware tests.
+- **Zero winget / Windows / package-capture regression.** The realizer path is Nix-only; on Windows
+  `newRealizerFn` returns `ErrNoRealizer` and capture never reaches this code. Proven by host-aware
+  tests + `GOOS=windows` build/vet. Real-nix round-trip smoke (apply hm flake → capture → apply into
+  fresh state) run on the Linux dev box against a local home-manager pin.

--- a/openspec/changes/nix-home-manager-capture/specs/nix-home-manager-capture/spec.md
+++ b/openspec/changes/nix-home-manager-capture/specs/nix-home-manager-capture/spec.md
@@ -1,0 +1,68 @@
+## ADDED Requirements
+
+### Requirement: Capture records the engine-provisioned home-manager config
+
+The engine SHALL record, in a captured manifest, the home-manager configuration that the engine
+itself activated, so that applying the captured manifest re-activates the same configuration. The
+configuration reference SHALL be recovered from the engine's provisioning history (the recorded
+config activation), not from the live system, and SHALL be emitted in the manifest field the apply
+config stage consumes. When no engine-activated configuration is on record, the manifest SHALL omit
+the home-manager field.
+
+#### Scenario: Captured manifest carries the activated config flake
+
+- **WHEN** `capture` runs on a realizer host and the engine's provisioning history records an
+  activated home-manager configuration
+- **THEN** the written manifest SHALL include the home-manager configuration reference from that
+  history
+- **AND** that reference SHALL be the one the apply config stage uses to re-activate the configuration
+
+#### Scenario: Most recently activated configuration is used
+
+- **WHEN** the provisioning history contains a later generation that activated no home-manager
+  configuration and an earlier generation that did
+- **THEN** `capture` SHALL emit the configuration from the earlier generation (the one still in
+  effect), not omit it
+
+#### Scenario: No recorded configuration omits the field
+
+- **WHEN** `capture` runs and the provisioning history records no activated home-manager configuration
+- **THEN** the written manifest SHALL NOT include a home-manager field
+
+#### Scenario: Capture then apply re-activates the same configuration
+
+- **WHEN** a manifest produced by `capture` (carrying a home-manager configuration reference) is
+  applied on a realizer host with configuration enabled
+- **THEN** the engine SHALL re-activate the same home-manager configuration
+
+### Requirement: Home-manager config recovery is best-effort and non-destructive
+
+Recovering the home-manager configuration for capture SHALL NOT fail the capture command. If the
+provisioning history cannot be read, capture SHALL still produce a valid package manifest and simply
+omit the home-manager field. Capture SHALL remain read-only with respect to system and home-manager
+state.
+
+#### Scenario: Provisioning history unreadable
+
+- **WHEN** `capture` runs and the provisioning history cannot be read
+- **THEN** the engine SHALL still write a valid manifest of the captured packages
+- **AND** it SHALL omit the home-manager field rather than returning an error
+
+#### Scenario: Updating a manifest preserves an existing config reference
+
+- **WHEN** `capture` updates an existing manifest that declares a home-manager configuration, and the
+  provisioning history records no activated configuration
+- **THEN** the engine SHALL preserve the existing manifest's home-manager configuration reference
+
+### Requirement: Home-manager config content is out of scope for capture
+
+Capture SHALL NOT capture home-manager configuration *content* (the managed files or a generated
+configuration). It SHALL record only the configuration reference the engine activated. Capture of
+configuration content is explicitly out of scope.
+
+#### Scenario: No config content in the capture output
+
+- **WHEN** `capture` records a home-manager configuration
+- **THEN** the output SHALL contain only the configuration reference (the flake the engine activated)
+- **AND** it SHALL NOT contain captured home-manager file content or a generated home-manager
+  configuration

--- a/openspec/changes/nix-home-manager-capture/tasks.md
+++ b/openspec/changes/nix-home-manager-capture/tasks.md
@@ -1,0 +1,34 @@
+> TDD: write each test RED first, then implement to green. Hermetic + host-aware (inject
+> `listGenerationsFn` + a fake realizer via `withFakeRealizer`; key fixtures by `runtime.GOOS`).
+> Verify: `cd go-engine && go test ./...` (Linux) + `GOOS=windows go build ./...` + `go vet`; the
+> real-nix apply→capture→apply config round-trip smoke runs on the Linux dev box (local hm pin).
+
+## 1. Recover + emit the home-manager flake
+
+- [x] 1.1 RED tests (`capture_realizer_test.go`, inject `listGenerationsFn` + `withFakeRealizer`):
+      provisioning history whose newest config generation has a flake → manifest carries
+      `homeManager.flake`; a newer generation with `HomeManager=nil` over an older one with a flake →
+      the older flake is emitted (most-recent non-nil); no generation has a flake → no `homeManager`
+      key; `listGenerationsFn` error → no block AND command still succeeds with packages captured
+- [x] 1.2 `internal/commands/capture.go`: add `HomeManager *manifest.HomeManagerConfig`
+      (`json:"homeManager,omitempty"`) to `captureManifestOutput`
+- [x] 1.3 `internal/commands/capture_realizer.go`: add `var listGenerationsFn = provision.List`;
+      `recoverHomeManager(flags)` selecting the most-recent non-nil `HomeManager.Flake`; set
+      `outManifest.HomeManager`; best-effort (errors/empty omit the block)
+
+## 2. --update preservation
+
+- [x] 2.1 RED test: `--update` + `--manifest` with an existing `homeManager` block and no flake in
+      history → the existing block is preserved in the output
+- [x] 2.2 `recoverHomeManager`: when history has no flake, fall back to the existing manifest's
+      `HomeManager` (via `loadManifest`)
+
+## 3. Verification
+
+- [x] 3.1 `cd go-engine && go test ./...` green on Linux
+- [x] 3.2 `GOOS=windows go build ./...` + `go vet ./...` clean (winget + package capture untouched)
+- [x] 3.3 `npm run openspec:validate` (strict) + `npx openspec validate nix-home-manager-capture --strict`
+- [x] 3.4 Real-nix config round-trip smoke (isolated `ENDSTATE_ROOT`,
+      `ENDSTATE_HOME_MANAGER_PIN=/home/hugoa/projects/home-manager`): `apply` a tiny
+      `homeConfigurations` flake (`--enable-restore`) → `capture` → manifest carries
+      `homeManager.flake` → `apply` the captured manifest into fresh state re-activates the config


### PR DESCRIPTION
## Why

`apply`/`verify` work on the Nix realizer, package **capture** shipped (#79), and #81 added a home-manager **config apply** stage. But `capture` was package-only — it never recorded the activated config, so the *config* half of the snapshot → manifest → rebuild loop was open: you could apply a home-manager config but not snapshot one back.

## What

`runCaptureRealizer` now recovers the activated home-manager flake and emits it into the manifest as `homeManager.flake` (reusing `manifest.HomeManagerConfig`, so the output round-trips through #81's apply config stage).

**The flake comes from the engine, not the system.** home-manager doesn't persist the source flakeref in a live install (its generation records `hm-version` + a managed-file `manifest.json`, never the flake — confirmed against the home-manager source). But `apply` already records it in `provision.Generation.HomeManager{Flake}`. Capture reads `provision.List()` (newest-first) and takes the flake from the **most-recent generation whose `HomeManager` is non-nil** (a later package-only apply records `HomeManager=nil`, so "latest overall" would wrongly drop it).

- **`--update`**: with no flake in history, an existing manifest's `homeManager` block is preserved.
- **Best-effort**: a provisioning-history read error / empty history omits the field and never fails capture.
- **Realizer-only**; winget capture + package capture byte-identical. A `listGenerationsFn` seam keeps the read hermetic.

## Design decision (confirmed)

Direction A — engine-provisioned flake passthrough. Rejected raw-file snapshot (home-manager files are read-only store symlinks; can't re-apply through the flake stage; the imperative paradigm #81 declined for Nix) and hybrid (YAGNI). **Honest limitation (documented in spec):** only captures configs applied *through* Endstate; a pre-existing manual setup yields no flake until declared + applied once — the flakeref genuinely isn't recoverable otherwise.

## Verification

- ✅ 5 new hermetic, host-aware tests (`capture_realizer_test.go`, TDD: RED → GREEN) covering: flake emitted from history; most-recent-non-nil selection; no-history omits the field; `--update` preservation; history-read error omits + still captures packages.
- ✅ `go test ./...` green on Linux; `GOOS=windows go build ./...` + `go vet ./...` clean; gofmt clean; `npm run openspec:validate` strict (60/60).
- ✅ **Real-nix live round-trip** (fully sandboxed: temp `HOME`/`ENDSTATE_ROOT`, local clone as the hm pin via `git+file://` to sidestep a dirty-`path:`-flake narHash mismatch): real `endstate apply --enable-restore` activated a tiny `homeConfigurations` flake **and** recorded the generation → real `endstate capture` emitted `homeManager.flake` → real `endstate apply` of the captured manifest into a **fresh** provisioning root re-activated it (`success=true`). Your real `$HOME` was never touched.

New OpenSpec change `nix-home-manager-capture`. Archive post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)