### PR TITLE
fix(engine): capture the declared home-manager input, not the generated flake

### DIFF
--- a/go-engine/internal/commands/apply_realizer.go
+++ b/go-engine/internal/commands/apply_realizer.go
@@ -444,6 +444,11 @@ func runApplyRealizer(flags ApplyFlags, mf *manifest.Manifest, r realizer.Realiz
 					WithDetail(map[string]string{"subcode": rerr.Subcode, "stage": rerr.Stage, "raw": rerr.Raw})
 			}
 			homeRef = &provision.HomeGenRef{Flake: flake, Generation: hmGen}
+			if generated {
+				// flake is the engine-generated, machine-local wrapper; record the
+				// user's declared homeManager.config so capture can round-trip it.
+				homeRef.Config = mf.HomeManager.Config
+			}
 			homeResult = &ApplyHomeManager{Flake: flake, Generated: generated, Activated: true}
 			emitter.EmitItem(flake, driverName, "configured", "", fmt.Sprintf("Activated home-manager generation %d", hmGen), "home-manager")
 			emitter.EmitSummary("config", 1, 1, 0, 0)

--- a/go-engine/internal/commands/apply_realizer_test.go
+++ b/go-engine/internal/commands/apply_realizer_test.go
@@ -54,8 +54,8 @@ type fakeRealizer struct {
 	lastRemoveArgs []string
 
 	// --- home-manager activation (config stage) ---
-	homeGenNum      int    // scripted ActivateHome generation
-	homeErr         error  // scripted ActivateHome error
+	homeGenNum      int   // scripted ActivateHome generation
+	homeErr         error // scripted ActivateHome error
 	activateCalls   int
 	lastActivateArg string
 }
@@ -520,6 +520,49 @@ func TestRunApplyRealizer_HomeManager_ActivatesAndRecords(t *testing.T) {
 	hm := gens[0].HomeManager
 	if hm == nil || hm.Flake != "/home/me/dotfiles#hugo" || hm.Generation != 5 {
 		t.Fatalf("generation HomeManager = %+v, want flake=/home/me/dotfiles#hugo gen=5", hm)
+	}
+}
+
+// TestRunApplyRealizer_HomeManager_Config_RecordsDeclaredConfig: a homeManager.config
+// apply records the user's DECLARED config path in the generation (so capture can
+// round-trip it), alongside the engine-generated flake that was actually activated.
+func TestRunApplyRealizer_HomeManager_Config_RecordsDeclaredConfig(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	cfg := filepath.Join(t.TempDir(), "home.nix")
+	if err := os.WriteFile(cfg, []byte("{ home.stateVersion = \"24.05\"; }\n"), 0o644); err != nil {
+		t.Fatalf("write home.nix: %v", err)
+	}
+	app := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := nixManifest(app)
+	mf.HomeManager = &manifest.HomeManagerConfig{Config: cfg}
+
+	ins := realizer.Installable{ID: "ripgrep", Ref: hostRef(app)}
+	fr := &fakeRealizer{
+		planDiff: realizer.Diff{ToAdd: []realizer.Installable{ins}},
+		realizeResult: realizer.Result{
+			Advanced: true, FromGeneration: 1, ToGeneration: 2,
+			After: realizer.Set{Generation: 2, Elements: map[string]realizer.Element{"ripgrep": {Name: "ripgrep", AttrPath: "ripgrep"}}},
+		},
+		homeGenNum: 7,
+	}
+
+	flags := ApplyFlags{Manifest: "nix-test", EnableRestore: true}
+	if _, eerr := runApplyRealizer(flags, mf, fr, noopEmitter(), "run-hmcfg", nil, nil); eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+	gens, _ := provision.List()
+	if len(gens) != 1 {
+		t.Fatalf("want 1 generation, got %d", len(gens))
+	}
+	hm := gens[0].HomeManager
+	if hm == nil {
+		t.Fatalf("generation HomeManager is nil")
+	}
+	if hm.Config != cfg {
+		t.Errorf("HomeManager.Config = %q, want the declared config %q", hm.Config, cfg)
+	}
+	if hm.Flake == "" {
+		t.Error("HomeManager.Flake should record the generated (activated) flake, got empty")
 	}
 }
 

--- a/go-engine/internal/commands/capture_realizer.go
+++ b/go-engine/internal/commands/capture_realizer.go
@@ -209,7 +209,16 @@ func runCaptureRealizer(flags CaptureFlags, r realizer.Realizer, emitter *events
 func recoverHomeManager(flags CaptureFlags) *manifest.HomeManagerConfig {
 	if gens, err := listGenerationsFn(); err == nil {
 		for _, g := range gens {
-			if g.HomeManager != nil && g.HomeManager.Flake != "" {
+			if g.HomeManager == nil {
+				continue
+			}
+			// Prefer the user's declared config (a config apply records the
+			// machine-local generated flake in Flake but the portable home.nix in
+			// Config); fall back to a directly-declared flake.
+			if g.HomeManager.Config != "" {
+				return &manifest.HomeManagerConfig{Config: g.HomeManager.Config}
+			}
+			if g.HomeManager.Flake != "" {
 				return &manifest.HomeManagerConfig{Flake: g.HomeManager.Flake}
 			}
 		}

--- a/go-engine/internal/commands/capture_realizer_test.go
+++ b/go-engine/internal/commands/capture_realizer_test.go
@@ -50,7 +50,8 @@ type capturedManifestFile struct {
 		Version string            `json:"version"`
 	} `json:"apps"`
 	HomeManager *struct {
-		Flake string `json:"flake"`
+		Flake  string `json:"flake"`
+		Config string `json:"config"`
 	} `json:"homeManager"`
 }
 
@@ -74,6 +75,13 @@ func hmGen(flake string, genNum int) *provision.Generation {
 // pkgGen builds a package-only provisioning generation (no home-manager config).
 func pkgGen() *provision.Generation {
 	return &provision.Generation{}
+}
+
+// hmGenConfig builds a generation from a homeManager.config apply: it records the
+// user's declared config path AND the engine-generated (machine-local) flake the
+// engine actually activated.
+func hmGenConfig(config, generatedFlake string, genNum int) *provision.Generation {
+	return &provision.Generation{HomeManager: &provision.HomeGenRef{Config: config, Flake: generatedFlake, Generation: genNum}}
 }
 
 func readCapturedManifest(t *testing.T, path string) capturedManifestFile {
@@ -447,5 +455,51 @@ func TestRunCaptureRealizer_Update_PreservesExistingHomeManager(t *testing.T) {
 	mf := readCapturedManifest(t, out)
 	if mf.HomeManager == nil || mf.HomeManager.Flake != "github:me/dots#hugo" {
 		t.Fatalf("expected preserved homeManager github:me/dots#hugo, got %+v", mf.HomeManager)
+	}
+}
+
+// A config-declared apply records both the user's config path and the engine-
+// generated (machine-local) flake. Capture must emit the declared config path,
+// NOT the generated flake — otherwise the manifest can't round-trip elsewhere.
+func TestRunCaptureRealizer_EmitsConfigOverGeneratedFlake(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "hmcfg.jsonc")
+	fr := &fakeRealizer{currentSet: nixSet("ripgrep")}
+
+	gen := hmGenConfig("./home.nix", "/home/me/.local/state/endstate/state/home-manager/me#me", 4)
+	withFakeGenerations([]*provision.Generation{gen}, nil, func() {
+		if _, eerr := runCaptureRealizer(CaptureFlags{Out: out}, fr, noopEmitter()); eerr != nil {
+			t.Fatalf("runCaptureRealizer returned envelope error: %+v", eerr)
+		}
+	})
+
+	mf := readCapturedManifest(t, out)
+	if mf.HomeManager == nil {
+		t.Fatalf("expected homeManager block, got none")
+	}
+	if mf.HomeManager.Config != "./home.nix" {
+		t.Errorf("homeManager.config = %q, want ./home.nix", mf.HomeManager.Config)
+	}
+	if mf.HomeManager.Flake != "" {
+		t.Errorf("must NOT emit the generated flake for a config apply, got flake=%q", mf.HomeManager.Flake)
+	}
+}
+
+// A flake-declared apply still captures as homeManager.flake (no regression).
+func TestRunCaptureRealizer_FlakeDeclared_StillEmitsFlake(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "hmflake.jsonc")
+	fr := &fakeRealizer{currentSet: nixSet("ripgrep")}
+
+	withFakeGenerations([]*provision.Generation{hmGen("github:me/dots#hugo", 2)}, nil, func() {
+		if _, eerr := runCaptureRealizer(CaptureFlags{Out: out}, fr, noopEmitter()); eerr != nil {
+			t.Fatalf("runCaptureRealizer returned envelope error: %+v", eerr)
+		}
+	})
+
+	mf := readCapturedManifest(t, out)
+	if mf.HomeManager == nil || mf.HomeManager.Flake != "github:me/dots#hugo" {
+		t.Fatalf("expected homeManager.flake github:me/dots#hugo, got %+v", mf.HomeManager)
+	}
+	if mf.HomeManager.Config != "" {
+		t.Errorf("flake apply must not emit a config, got config=%q", mf.HomeManager.Config)
 	}
 }

--- a/go-engine/internal/provision/provision.go
+++ b/go-engine/internal/provision/provision.go
@@ -38,8 +38,8 @@ type Generation struct {
 	Backend       string     `json:"backend"` // "nix" | "winget"
 	Items         []ProvItem `json:"items"`
 	AddedRefs     []string   `json:"addedRefs"`
-	Native        string     `json:"native,omitempty"` // backend-native anchor (nix generation number); "" if none
-	Partial       bool       `json:"partial"`          // true when a non-atomic backend committed a partial set
+	Native        string     `json:"native,omitempty"`      // backend-native anchor (nix generation number); "" if none
+	Partial       bool       `json:"partial"`               // true when a non-atomic backend committed a partial set
 	Rollback      bool       `json:"rollback,omitempty"`    // true when this generation was produced by a rollback (AddedRefs is empty)
 	RemovedRefs   []string   `json:"removedRefs,omitempty"` // refs uninstalled by a best-effort (winget) rollback; empty for native/apply generations
 
@@ -54,7 +54,13 @@ type Generation struct {
 // flakeref applied and the resulting home-manager generation number. It is the
 // config analogue of the package Native anchor.
 type HomeGenRef struct {
-	Flake      string `json:"flake"`
+	Flake string `json:"flake"`
+	// Config is the user's originally-declared homeManager.config (a path to a
+	// home.nix) when the activated flake was engine-generated from it; empty for a
+	// directly-declared homeManager.flake. Flake records what was actually
+	// activated (the generated, machine-local flakeref in the config case);
+	// Config records what the user declared, so capture can round-trip it.
+	Config     string `json:"config,omitempty"`
 	Generation int    `json:"generation"`
 }
 

--- a/openspec/changes/nix-hm-capture-config-roundtrip/.openspec.yaml
+++ b/openspec/changes/nix-hm-capture-config-roundtrip/.openspec.yaml
@@ -1,0 +1,10 @@
+id: nix-hm-capture-config-roundtrip
+title: "Capture preserves the declared home-manager input (config round-trips)"
+status: implementing
+spec: nix-home-manager-capture
+created: "2026-06-02"
+author: Hugo Ander Kivi
+artifacts:
+  - proposal.md
+  - design.md
+  - tasks.md

--- a/openspec/changes/nix-hm-capture-config-roundtrip/design.md
+++ b/openspec/changes/nix-hm-capture-config-roundtrip/design.md
@@ -1,0 +1,83 @@
+## Context
+
+- #87 `resolveHomeFlake` (`apply_realizer.go`): a `homeManager.config` is wrapped by
+  `nix.GenerateHomeFlake(state.StateDir(), cfgPath)` into `state/home-manager/<user>/` and the
+  generated `<dir>#<user>` flakeref is returned (`generated=true`); a `homeManager.flake` is returned
+  verbatim (`generated=false`). Apply records `provision.HomeGenRef{Flake: <activated>, Generation}`.
+- #86 `recoverHomeManager` (`capture_realizer.go`): reads `provision.List()` (newest-first) and emits
+  `manifest.HomeManagerConfig{Flake: g.HomeManager.Flake}` from the most-recent generation whose
+  `HomeManager` is non-nil.
+- `manifest.HomeManagerConfig` (post-#87) = `{Flake, Config}`, mutually exclusive, both omitempty.
+
+The gap: for a `config` apply, `HomeGenRef.Flake` is the generated, machine-local, ephemeral path, so
+capture emits a non-portable `homeManager.flake`.
+
+## Goals / Non-Goals
+
+**Goals:** capture round-trips a `homeManager.config`-applied machine to its `home.nix`; preserve the
+`homeManager.flake` round-trip; no regression elsewhere.
+
+**Non-Goals:** capturing `home.nix` *content* (still out of scope — `config` is a path the user owns,
+captured as a pointer, same portability caveat as a local flake path); changing the apply wrapper or
+the generated-flake mechanism.
+
+## Decisions
+
+- **Record the declared input, keep the activated one for audit.** `HomeGenRef` gains `Config`. For a
+  config apply, record `Config = mf.HomeManager.Config` (the value as declared) AND `Flake = <generated
+  ref>` (what was actually activated — audit). For a flake apply, `Config` stays empty. This keeps the
+  generation an accurate activation record while letting capture recover the user's intent.
+- **Capture prefers `Config`.** `recoverHomeManager` emits `{Config}` when the selected generation has
+  one, else `{Flake}`. Mirrors `homeManager`'s flake/config mutual exclusivity.
+- **Record the declared value verbatim** (not the manifest-resolved absolute path), so capture
+  re-emits exactly what the user wrote — symmetric with how the flake case re-emits the user's flake.
+
+## Design
+
+`provision.HomeGenRef`:
+
+```go
+type HomeGenRef struct {
+    Flake      string `json:"flake"`
+    Config     string `json:"config,omitempty"` // original homeManager.config (config-derived applies)
+    Generation int    `json:"generation"`
+}
+```
+
+`apply_realizer.go` config stage (where `homeRef` is built):
+
+```go
+homeRef = &provision.HomeGenRef{Flake: flake, Generation: hmGen}
+if generated { // generated == true ⇒ flake came from mf.HomeManager.Config
+    homeRef.Config = mf.HomeManager.Config
+}
+```
+
+`capture_realizer.go` `recoverHomeManager`:
+
+```go
+for _, g := range gens { // newest-first
+    if g.HomeManager == nil {
+        continue
+    }
+    if g.HomeManager.Config != "" {
+        return &manifest.HomeManagerConfig{Config: g.HomeManager.Config}
+    }
+    if g.HomeManager.Flake != "" {
+        return &manifest.HomeManagerConfig{Flake: g.HomeManager.Flake}
+    }
+}
+```
+
+The `--update` fallback (preserve an existing manifest's `HomeManager`) is unchanged.
+
+## Risks / Verification
+
+- **Hermetic:** apply test (config path → `GenerateHomeFlake`, which is pure-fs, no nix) asserts the
+  generation records `Config`; capture tests (inject `listGenerationsFn`) assert `homeManager.config`
+  is emitted for a config generation and `homeManager.flake` for a flake generation.
+- **Real-nix smoke:** apply via `homeManager.config` (a tiny `home.nix`, sandboxed `$HOME`, local hm
+  pin) → capture → assert the manifest carries `homeManager.config` (not the `state/` flake path) →
+  apply the captured manifest re-activates.
+- **No regression:** flake-declared applies/captures unchanged; `go test ./...` + `GOOS=windows`
+  build/vet green.

--- a/openspec/changes/nix-hm-capture-config-roundtrip/proposal.md
+++ b/openspec/changes/nix-hm-capture-config-roundtrip/proposal.md
@@ -1,0 +1,50 @@
+## Why
+
+Two home-manager features landed together: **config capture** (#86 — capture emits the activated
+flake recovered from the Provisioning Generation) and the **config-file wrapper** (#87 — a manifest
+can declare `homeManager.config`, a path to a `home.nix`, which the engine wraps into a generated,
+pinned flake under `state/` and activates).
+
+They compose with a gap. When a machine is configured via `homeManager.config`, apply records the
+**engine-generated** flakeref (a machine-local `state/home-manager/<user>#<user>` path, regenerated
+each apply) in `provision.HomeGenRef.Flake`. Capture (#86) then emits that as `homeManager.flake` —
+which **does not round-trip**: the path is ephemeral and machine-local, so applying the captured
+manifest on another machine points at a flake that doesn't exist. The `homeManager.flake` case
+(#81) round-trips fine; only the new `config` case is affected.
+
+The fix: capture must emit the **originally declared** input — `homeManager.config` for a
+config-declared apply, `homeManager.flake` for a flake-declared one — not the engine's generated
+artifact.
+
+## What Changes
+
+- **Record the declared input.** `provision.HomeGenRef` gains a `Config` field. When apply activates a
+  `homeManager.config` (the generated-flake path), it records the user's original `config` value
+  alongside the activated `Flake` (kept for audit). A direct `homeManager.flake` apply records only
+  `Flake` (unchanged).
+- **Capture emits the declared input.** `recoverHomeManager` emits `homeManager.config` when the
+  most-recent config generation recorded a `Config`, else `homeManager.flake`. So a config-applied
+  machine round-trips to its `home.nix`, and a flake-applied machine round-trips to its flake.
+
+## Capabilities
+
+### New Capabilities
+
+- None.
+
+### Modified Capabilities
+
+- `nix-home-manager-capture`: capture now preserves the originally-declared home-manager input
+  (`config` or `flake`) rather than emitting an engine-generated flakeref for `config`-declared
+  applies — so both input forms round-trip through the apply config stage.
+
+## Impact
+
+- `internal/provision/provision.go` — add `Config string` (omitempty) to `HomeGenRef`.
+- `internal/commands/apply_realizer.go` — record `homeRef.Config = mf.HomeManager.Config` when the
+  config stage activated a generated (config-derived) flake.
+- `internal/commands/capture_realizer.go` — `recoverHomeManager` prefers a recorded `Config` over the
+  generated `Flake`.
+- Tests: `apply_realizer_test.go` (config-apply records `Config`), `capture_realizer_test.go`
+  (capture emits `homeManager.config`; flake case unchanged).
+- **Zero regression to the flake path** (#81/#86) and the winget/package paths. Realizer-only.

--- a/openspec/changes/nix-hm-capture-config-roundtrip/specs/nix-home-manager-capture/spec.md
+++ b/openspec/changes/nix-hm-capture-config-roundtrip/specs/nix-home-manager-capture/spec.md
@@ -1,0 +1,29 @@
+## ADDED Requirements
+
+### Requirement: Capture preserves the originally-declared home-manager input
+
+When capture records a home-manager configuration, it SHALL emit the input the user originally
+declared — a configuration-file reference when the configuration was applied from a user
+configuration file, or a flake reference when it was applied from a flake — rather than an
+engine-generated artifact. A configuration applied from a user configuration file SHALL NOT be
+captured as an engine-generated, machine-local flake reference, so that the captured manifest
+round-trips through the apply config stage on another machine.
+
+#### Scenario: Config-declared configuration is captured as a config reference
+
+- **WHEN** a home-manager configuration was applied from a user configuration file (a `home.nix` the
+  engine wrapped into a generated flake) and `capture` then runs
+- **THEN** the written manifest SHALL carry the user's declared configuration-file reference
+- **AND** it SHALL NOT carry the engine-generated, machine-local flake reference
+
+#### Scenario: Flake-declared configuration is captured as a flake reference
+
+- **WHEN** a home-manager configuration was applied directly from a flake and `capture` then runs
+- **THEN** the written manifest SHALL carry that flake reference (unchanged)
+
+#### Scenario: Captured config-declared manifest re-applies
+
+- **WHEN** a manifest captured from a config-declared machine is applied on a realizer host with
+  configuration enabled
+- **THEN** the engine SHALL re-activate the same home-manager configuration from the declared
+  configuration file

--- a/openspec/changes/nix-hm-capture-config-roundtrip/tasks.md
+++ b/openspec/changes/nix-hm-capture-config-roundtrip/tasks.md
@@ -1,0 +1,33 @@
+> TDD: RED first, then implement. Hermetic + host-aware (inject `listGenerationsFn`; `GenerateHomeFlake`
+> is pure-fs so the apply config path is hermetic). Verify: `cd go-engine && go test ./...` (Linux) +
+> `GOOS=windows go build ./...` + `go vet`; real-nix config round-trip smoke (sandboxed `$HOME`, local
+> hm pin via `git+file://`).
+
+## 1. Record the declared input
+
+- [x] 1.1 RED test (`apply_realizer_test.go`): a `homeManager.config` apply (`--enable-restore`,
+      fakeRealizer HomeActivator, a real temp `home.nix`) records `gens[0].HomeManager.Config` =
+      the declared config value (and `.Flake` = the generated ref); a `homeManager.flake` apply leaves
+      `Config` empty (existing test still passes)
+- [x] 1.2 `internal/provision/provision.go`: add `Config string` (`json:"config,omitempty"`) to
+      `HomeGenRef`
+- [x] 1.3 `internal/commands/apply_realizer.go`: when the config stage activated a `generated`
+      (config-derived) flake, set `homeRef.Config = mf.HomeManager.Config`
+
+## 2. Capture emits the declared input
+
+- [x] 2.1 RED tests (`capture_realizer_test.go`, inject `listGenerationsFn`): a generation with
+      `HomeManager.Config` set (and a generated `Flake`) → manifest carries `homeManager.config`
+      (NOT the generated flake); a generation with only `Flake` → `homeManager.flake` (unchanged)
+- [x] 2.2 `internal/commands/capture_realizer.go`: `recoverHomeManager` prefers a recorded `Config`
+      over `Flake`
+
+## 3. Verification
+
+- [x] 3.1 `cd go-engine && go test ./...` green on Linux
+- [x] 3.2 `GOOS=windows go build ./...` + `go vet ./...` clean
+- [x] 3.3 `npm run openspec:validate` (strict) + `npx openspec validate nix-hm-capture-config-roundtrip --strict`
+- [x] 3.4 Real-nix config round-trip smoke (sandboxed `$HOME`/`ENDSTATE_ROOT`, local hm pin via
+      `git+file://`): `apply` a manifest with `homeManager.config` (a tiny `home.nix`) → `capture` →
+      manifest carries `homeManager.config` (not a `state/` flake path) → `apply` the captured
+      manifest re-activates


### PR DESCRIPTION
Fixes the composition gap between **#86** (home-manager config capture) and **#87** (`homeManager.config` wrapper), now both on `main`.

## The gap
A `homeManager.config` apply (#87) wraps the user's `home.nix` into an **engine-generated flake under `state/`** and recorded *that* machine-local, regenerated-each-apply path in `provision.HomeGenRef.Flake`. Capture (#86) then emitted it as `homeManager.flake` — which **doesn't round-trip**: the path is ephemeral and machine-local, so applying the captured manifest on another machine points at a flake that doesn't exist. The `homeManager.flake` path (#81) round-trips fine; only the new `config` form was affected.

## The fix
Record the user's **declared** input, not the engine's artifact:
- `provision.HomeGenRef` gains a `Config` field.
- `apply_realizer.go`: when the config stage activated a *generated* (config-derived) flake, record `homeRef.Config = mf.HomeManager.Config`. `Flake` still records what was actually activated (audit).
- `capture_realizer.go`: `recoverHomeManager` prefers a recorded `Config` over `Flake` — so a config-applied machine round-trips to its `home.nix`, a flake-applied machine to its flake.

Realizer-only; flake path and winget/package capture unchanged.

## Verification
- ✅ 3 new hermetic tests (TDD RED→GREEN): apply records `Config`; capture emits `homeManager.config` over the generated flake; flake case unchanged. Existing #86/#87 home-manager tests still pass (no regression).
- ✅ `go test ./...` Linux; `GOOS=windows go build ./...` + `go vet`; gofmt clean; `npm run openspec:validate` strict (62/62).
- ✅ **Real-nix config round-trip** (sandboxed `$HOME`, local hm pin via `git+file://`): `apply` via `homeManager.config` → generation records both `config` (declared) and `flake` (generated) → `capture` emits `homeManager.config` (not the `state/` path) → `apply` the captured manifest into a fresh root re-activates (`success=true`). Real `$HOME` untouched.

New OpenSpec change `nix-hm-capture-config-roundtrip` (ADDS to `nix-home-manager-capture`). Archive post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)