### PR TITLE
feat(engine): home-manager config rollback (rollback --enable-restore)

### DIFF
--- a/go-engine/cmd/endstate/main.go
+++ b/go-engine/cmd/endstate/main.go
@@ -51,7 +51,7 @@ Per-command flags:
   --manifest <path>    Path to manifest file (apply, verify, plan, capture, restore)
                        Alias: --profile <path> (apply, verify, plan)
   --dry-run            Preview changes without applying them (apply, restore)
-  --enable-restore     Enable restore operations during apply (opt-in)
+  --enable-restore     Enable restore operations during apply, and home-manager config rollback (opt-in)
   --out <path>         Output file path (capture)
   --name <name>        Manifest name (capture)
   --profile <name>     Profile name for output (capture)
@@ -321,7 +321,7 @@ func commandUsage(cmd string) string {
 	case "report":
 		return "Usage: endstate report [--latest] [--last <n>] [--run-id <id>] [--json]\n\nRetrieve run history.\n"
 	case "rollback":
-		return "Usage: endstate rollback [--to <generation>] [--confirm] [--dry-run] [--json] [--events jsonl]\n\nRoll back the installed package set to a prior provisioning generation. Available only on backends that advertise native rollback (e.g. Nix on Linux/macOS). With --to, targets that engine generation number (see 'endstate generations'); without it, rolls back to the previous version. Requires --confirm; use --dry-run to preview the target without changing anything.\n"
+		return "Usage: endstate rollback [--to <generation>] [--enable-restore] [--confirm] [--dry-run] [--json] [--events jsonl]\n\nRoll back the installed package set to a prior provisioning generation. Available only on backends that advertise native rollback (e.g. Nix on Linux/macOS). With --to, targets that engine generation number (see 'endstate generations'); without it, rolls back to the previous version. With --enable-restore (and --to), ALSO reverts the home-manager configuration recorded in that generation (symmetric with 'apply --enable-restore'). Requires --confirm; use --dry-run to preview the target without changing anything.\n"
 	case "doctor":
 		return "Usage: endstate doctor [--json]\n\nRun system diagnostics.\n"
 	case "profile":
@@ -467,10 +467,11 @@ func dispatch(p parsedArgs) (interface{}, *envelope.Error) {
 
 	case "rollback":
 		return commands.RunRollback(commands.RollbackFlags{
-			To:      p.to,
-			Confirm: p.confirm,
-			DryRun:  p.dryRun,
-			Events:  p.events,
+			To:            p.to,
+			Confirm:       p.confirm,
+			DryRun:        p.dryRun,
+			EnableRestore: p.enableRestore,
+			Events:        p.events,
 		})
 
 	case "doctor":

--- a/go-engine/internal/commands/apply_realizer_test.go
+++ b/go-engine/internal/commands/apply_realizer_test.go
@@ -58,6 +58,22 @@ type fakeRealizer struct {
 	homeErr         error // scripted ActivateHome error
 	activateCalls   int
 	lastActivateArg string
+
+	// --- home-manager config rollback ---
+	homeRollbackGen     int   // scripted RollbackHome (new forward) generation
+	homeRollbackErr     error // scripted RollbackHome error
+	homeRollbackCalls   int
+	lastHomeRollbackArg int
+}
+
+// RollbackHome satisfies realizer.HomeRollbacker, recording the requested
+// home-manager generation and returning the scripted new generation/error. Its
+// presence makes *fakeRealizer a HomeRollbacker, so the config-rollback path is
+// exercised host-independently.
+func (f *fakeRealizer) RollbackHome(generation int) (int, error) {
+	f.homeRollbackCalls++
+	f.lastHomeRollbackArg = generation
+	return f.homeRollbackGen, f.homeRollbackErr
 }
 
 // ActivateHome satisfies realizer.HomeActivator, recording the requested flake

--- a/go-engine/internal/commands/rollback.go
+++ b/go-engine/internal/commands/rollback.go
@@ -4,6 +4,7 @@
 package commands
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
@@ -30,6 +31,11 @@ type RollbackFlags struct {
 	// DryRun previews the resolved target without changing any state and without
 	// requiring Confirm.
 	DryRun bool
+	// EnableRestore opts rollback into ALSO reverting the home-manager config
+	// recorded in the target generation (realizer backends only), symmetric with
+	// `apply --enable-restore`. Without it, rollback is package-only. Config
+	// rollback requires an explicit --to <generation>.
+	EnableRestore bool
 	// Events controls streaming event output. Accepted for parity; rollback does
 	// not stream a per-item sequence (it is a single whole-set operation).
 	Events string
@@ -51,6 +57,22 @@ type RollbackResult struct {
 	FailedRefs  []string `json:"failedRefs,omitempty"`  // refs whose uninstall failed
 	Partial     bool     `json:"partial,omitempty"`     // true when any targeted uninstall failed
 	Warning     string   `json:"warning,omitempty"`     // best-effort caveat (untracked dependencies)
+
+	// HomeManager carries the opt-in (--enable-restore) home-manager config
+	// rollback outcome; nil when no config stage ran.
+	HomeManager *RollbackHomeResult `json:"homeManager,omitempty"`
+}
+
+// RollbackHomeResult is the home-manager config-rollback portion of a rollback.
+// On --dry-run it reports the target (recorded) generation that would be
+// re-activated; on a real run it also reports the new (forward) generation.
+type RollbackHomeResult struct {
+	TargetGeneration int    `json:"targetGeneration"`          // recorded home-manager generation being reverted to
+	NewGeneration    int    `json:"newGeneration,omitempty"`   // new forward generation after re-activation (0 on dry-run)
+	Flake            string `json:"flake,omitempty"`           // the config that was/would be re-activated
+	Config           string `json:"config,omitempty"`          // the user's declared home.nix, when the recorded config was engine-generated
+	Reactivated      bool   `json:"reactivated"`               // true when the config was actually re-activated
+	ViaFallback      bool   `json:"viaFallback,omitempty"`     // true when re-activated from the recorded flake because the snapshot was unavailable
 }
 
 // RunRollback reverts the installed package set to a prior Provisioning
@@ -95,8 +117,10 @@ func runRealizerRollback(flags RollbackFlags, r realizer.Realizer) (interface{},
 	}
 
 	// Resolve the native target version from the engine generation number.
-	target := -1   // backend-native version; -1 == previous
-	targetGen := 0 // engine generation number; 0 == unspecified (previous)
+	target := -1                               // backend-native version; -1 == previous
+	targetGen := 0                             // engine generation number; 0 == unspecified (previous)
+	hasPackageTarget := true                   // false for a config-only target generation (no native anchor)
+	var targetGeneration *provision.Generation // the resolved generation (config rollback reads its HomeManager ref)
 	if to := strings.TrimSpace(flags.To); to != "" {
 		n, err := strconv.Atoi(to)
 		if err != nil || n <= 0 {
@@ -108,14 +132,48 @@ func runRealizerRollback(flags RollbackFlags, r realizer.Realizer) (interface{},
 		if gerr != nil {
 			return nil, gerr
 		}
-		native, nerr := strconv.Atoi(gen.Native)
-		if gen.Native == "" || nerr != nil {
-			return nil, envelope.NewError(envelope.ErrGenerationNotFound,
-				fmt.Sprintf("Generation %d has no native rollback anchor.", n)).
-				WithRemediation("Only generations committed by a native-rollback backend can be rolled back to.")
-		}
-		target = native
 		targetGen = n
+		targetGeneration = gen
+		// A config-only generation (a config apply that installed/pruned nothing)
+		// records no native anchor; that is not an error when --enable-restore will
+		// roll its config back. The "nothing to roll back" rejection is deferred
+		// until config eligibility is known.
+		if native, nerr := strconv.Atoi(gen.Native); gen.Native != "" && nerr == nil {
+			target = native
+		} else {
+			hasPackageTarget = false
+		}
+	}
+
+	// Config rollback eligibility, validated BEFORE any mutation (--enable-restore
+	// opts rollback into ALSO reverting the home-manager config recorded in the
+	// target generation; it is realizer-only and requires an explicit --to so there
+	// is a recorded config to revert to).
+	var homeRef *provision.HomeGenRef
+	if flags.EnableRestore {
+		if targetGeneration == nil {
+			return nil, envelope.NewError(envelope.ErrGenerationNotFound,
+				"Home-manager config rollback requires an explicit target generation.").
+				WithRemediation("Re-run with --to <generation> (see 'endstate generations'); bare rollback is package-only.")
+		}
+		homeRef = targetGeneration.HomeManager
+		if homeRef != nil {
+			if _, ok := r.(realizer.HomeRollbacker); !ok {
+				return nil, envelope.NewError(envelope.ErrRollbackUnsupported,
+					fmt.Sprintf("The %s backend does not support home-manager config rollback.", r.Name())).
+					WithRemediation("Config rollback requires a backend that can re-activate a home-manager configuration (e.g. Nix).")
+			}
+		}
+	}
+
+	// Nothing to roll back: a target generation with no native anchor AND no
+	// eligible config rollback. Preserves the package-only "no native anchor"
+	// rejection while letting a config-only generation be reverted under
+	// --enable-restore.
+	if !hasPackageTarget && homeRef == nil {
+		return nil, envelope.NewError(envelope.ErrGenerationNotFound,
+			fmt.Sprintf("Generation %d has no native rollback anchor.", targetGen)).
+			WithRemediation("Only generations committed by a native-rollback backend can be rolled back to.")
 	}
 
 	// Best-effort current native version for reporting.
@@ -124,19 +182,30 @@ func runRealizerRollback(flags RollbackFlags, r realizer.Realizer) (interface{},
 		fromNative = strconv.Itoa(cur.Generation)
 	}
 
-	toNative := "previous"
-	if target > 0 {
-		toNative = strconv.Itoa(target)
+	toNative := ""
+	if hasPackageTarget {
+		toNative = "previous"
+		if target > 0 {
+			toNative = strconv.Itoa(target)
+		}
 	}
 
 	if flags.DryRun {
-		return &RollbackResult{
+		res := &RollbackResult{
 			DryRun:           true,
 			Backend:          r.Name(),
 			TargetGeneration: targetGen,
 			FromNative:       fromNative,
 			ToNative:         toNative,
-		}, nil
+		}
+		if flags.EnableRestore && homeRef != nil {
+			res.HomeManager = &RollbackHomeResult{
+				TargetGeneration: homeRef.Generation,
+				Flake:            homeRef.Flake,
+				Config:           homeRef.Config,
+			}
+		}
+		return res, nil
 	}
 
 	if !flags.Confirm {
@@ -145,23 +214,116 @@ func runRealizerRollback(flags RollbackFlags, r realizer.Realizer) (interface{},
 			WithRemediation("Re-run with --confirm, or use --dry-run to preview the target.")
 	}
 
-	if err := rb.Rollback(target); err != nil {
-		return nil, rollbackError(err)
+	// Packages first (mirrors apply's package-then-config ordering). Skipped for a
+	// config-only target generation, which has no native package anchor.
+	if hasPackageTarget {
+		if err := rb.Rollback(target); err != nil {
+			return nil, rollbackError(err)
+		}
+	}
+
+	// Config (opt-in): re-activate the home-manager config recorded in the target
+	// generation. Mints a new forward home-manager generation (append-only).
+	var homeResult *RollbackHomeResult
+	var newHomeRef *provision.HomeGenRef
+	if flags.EnableRestore && homeRef != nil {
+		newGen, viaFallback, herr := rollbackHomeConfig(r, homeRef)
+		if herr != nil {
+			return nil, herr
+		}
+		newHomeRef = &provision.HomeGenRef{Flake: homeRef.Flake, Config: homeRef.Config, Generation: newGen}
+		homeResult = &RollbackHomeResult{
+			TargetGeneration: homeRef.Generation,
+			NewGeneration:    newGen,
+			Flake:            homeRef.Flake,
+			Config:           homeRef.Config,
+			Reactivated:      true,
+			ViaFallback:      viaFallback,
+		}
 	}
 
 	// Success: append a new Provisioning Generation snapshotting the now-active
-	// set so the append-only history keeps "newest == active" truthful.
+	// set (and any reverted config) so the append-only history keeps
+	// "newest == active" truthful. A config-only rollback records no native anchor
+	// (packages were untouched), so a later package rollback treats it correctly.
 	cur, _ := r.Current()
-	newGen := appendRollbackGeneration(buildRunID("rollback"), r.Name(), cur)
+	native := ""
+	if hasPackageTarget {
+		native = strconv.Itoa(cur.Generation)
+	}
+	newGen := appendRollbackGeneration(buildRunID("rollback"), r.Name(), cur, native, newHomeRef)
 
 	return &RollbackResult{
 		DryRun:           false,
 		Backend:          r.Name(),
 		TargetGeneration: targetGen,
 		FromNative:       fromNative,
-		ToNative:         strconv.Itoa(cur.Generation),
+		ToNative:         native,
 		NewGeneration:    newGen,
+		HomeManager:      homeResult,
 	}, nil
+}
+
+// rollbackHomeConfig re-activates the home-manager config recorded by the target
+// generation via the realizer's HomeRollbacker, returning the new (forward)
+// home-manager generation. When the recorded generation's snapshot is no longer
+// available it falls back to re-activating a directly-referenced flake (faithful
+// for a pinned flake); for an engine-generated wrapper (Config set) the state-dir
+// flake now holds the LATEST config, not the target's, so it refuses rather than
+// activate the wrong config (non-destructive). The caller has already confirmed r
+// is a HomeRollbacker. viaFallback reports whether the fallback path ran.
+func rollbackHomeConfig(r realizer.Realizer, homeRef *provision.HomeGenRef) (newGen int, viaFallback bool, eerr *envelope.Error) {
+	hr := r.(realizer.HomeRollbacker)
+	gen, herr := hr.RollbackHome(homeRef.Generation)
+	if herr == nil {
+		return gen, false, nil
+	}
+	if !errors.Is(herr, realizer.ErrHomeSnapshotMissing) {
+		return 0, false, homeRollbackError(herr)
+	}
+
+	// Snapshot garbage-collected. Fall back only when faithful.
+	if homeRef.Config != "" || homeRef.Flake == "" {
+		// Engine-generated wrapper (or nothing to fall back to): the state-dir flake
+		// holds the latest config, not the target's — refuse rather than mislead.
+		return 0, false, envelope.NewError(envelope.ErrRollbackFailed,
+			"The home-manager configuration snapshot for the target generation is unavailable (garbage-collected).").
+			WithRemediation("Re-apply the desired home.nix with 'endstate apply --enable-restore'.")
+	}
+	activator, ok := r.(realizer.HomeActivator)
+	if !ok {
+		return 0, false, envelope.NewError(envelope.ErrRollbackFailed,
+			"The home-manager configuration snapshot is unavailable and cannot be re-activated.").
+			WithRemediation("Re-apply the desired configuration with 'endstate apply --enable-restore'.")
+	}
+	gen, aerr := activator.ActivateHome(homeRef.Flake)
+	if aerr != nil {
+		return 0, false, homeRollbackError(aerr)
+	}
+	return gen, true, nil
+}
+
+// homeRollbackError maps a home-manager config-rollback failure to an envelope
+// error, mirroring rollbackError: systemic classes reuse the realizer envelope
+// error; otherwise the (already-classified) code is surfaced with raw backend
+// text confined to error.detail (the moat). A generic INSTALL_FAILED from the
+// fallback ActivateHome is remapped to ROLLBACK_FAILED so the error names the verb.
+func homeRollbackError(err error) *envelope.Error {
+	rerr, ok := err.(*realizer.Error)
+	if !ok {
+		return envelope.NewError(envelope.ErrRollbackFailed, "Home-manager configuration rollback failed.").
+			WithDetail(map[string]string{"raw": err.Error()})
+	}
+	if isSystemic(rerr.Code) {
+		return realizerEnvelopeError(rerr)
+	}
+	code := rerr.Code
+	if code == envelope.ErrInstallFailed {
+		code = envelope.ErrRollbackFailed
+	}
+	return envelope.NewError(code, "Home-manager configuration rollback failed.").
+		WithDetail(map[string]string{"subcode": rerr.Subcode, "stage": rerr.Stage, "raw": rerr.Raw}).
+		WithRemediation("Run 'endstate generations' to inspect available rollback targets.")
 }
 
 // nativeRollbackCapable reports whether r advertises native rollback. A backend
@@ -193,13 +355,17 @@ func findGeneration(n int) (*provision.Generation, *envelope.Error) {
 
 // appendRollbackGeneration writes a new Provisioning Generation snapshotting the
 // now-active package set after a successful rollback. AddedRefs is empty (nothing
-// was newly installed) and Rollback is true. It is best-effort: a write error
-// never fails the rollback, mirroring run-history persistence. Returns the
-// assigned generation number, or 0 on write failure.
+// was newly installed) and Rollback is true. When home is non-nil it also records
+// the home-manager config re-activated by the rollback (a flakeref + generation
+// number — still a provisioning fact, not config file contents), so the
+// append-only history's newest record reflects the active config too. It is
+// best-effort: a write error never fails the rollback, mirroring run-history
+// persistence. Returns the assigned generation number, or 0 on write failure.
 //
-// Separation of concerns: this records package facts only — it never touches the
-// config backup directory or the restore revert journal.
-func appendRollbackGeneration(runID, backend string, set realizer.Set) int {
+// Separation of concerns: this records package facts plus the engine-owned
+// home-manager config reference — it never touches the config backup directory or
+// the restore revert journal.
+func appendRollbackGeneration(runID, backend string, set realizer.Set, native string, home *provision.HomeGenRef) int {
 	items := make([]provision.ProvItem, 0, len(set.Elements))
 	for name, e := range set.Elements {
 		ref := e.AttrPath
@@ -209,13 +375,14 @@ func appendRollbackGeneration(runID, backend string, set realizer.Set) int {
 		items = append(items, provision.ProvItem{ID: name, Ref: ref, Status: "present"})
 	}
 	g := &provision.Generation{
-		RunID:     runID,
-		Timestamp: time.Now().UTC().Format(time.RFC3339),
-		Backend:   backend,
-		Items:     items,
-		AddedRefs: []string{},
-		Native:    strconv.Itoa(set.Generation),
-		Rollback:  true,
+		RunID:       runID,
+		Timestamp:   time.Now().UTC().Format(time.RFC3339),
+		Backend:     backend,
+		Items:       items,
+		AddedRefs:   []string{},
+		Native:      native,
+		Rollback:    true,
+		HomeManager: home,
 	}
 	if err := provision.Write(g); err != nil {
 		return 0

--- a/go-engine/internal/commands/rollback_test.go
+++ b/go-engine/internal/commands/rollback_test.go
@@ -621,3 +621,372 @@ func TestRollback_Driver_MissingBinary_WingetUnavailable(t *testing.T) {
 		}
 	})
 }
+
+// ---------------------------------------------------------------------------
+// Home-manager config rollback (--enable-restore), realizer (Nix) path
+// ---------------------------------------------------------------------------
+
+// pkgOnlyRollbacker advertises native PACKAGE rollback but does NOT implement
+// realizer.HomeRollbacker (nor HomeActivator) — used to verify config rollback is
+// refused on a backend that cannot re-activate a home-manager configuration.
+type pkgOnlyRollbacker struct {
+	rollbackCalls int
+	cur           realizer.Set
+}
+
+func (*pkgOnlyRollbacker) Name() string                              { return "nix" }
+func (p *pkgOnlyRollbacker) Current() (realizer.Set, error)          { return p.cur, nil }
+func (*pkgOnlyRollbacker) Plan([]realizer.Installable) (realizer.Diff, error) {
+	return realizer.Diff{}, nil
+}
+func (*pkgOnlyRollbacker) Realize([]realizer.Installable) (realizer.Result, error) {
+	return realizer.Result{}, nil
+}
+func (p *pkgOnlyRollbacker) Rollback(int) error                      { p.rollbackCalls++; return nil }
+func (*pkgOnlyRollbacker) Capabilities() provision.Capabilities {
+	return provision.Capabilities{NativeRollback: true}
+}
+
+// withRealizerOnly forces the realizer dispatch path with an arbitrary realizer.
+func withRealizerOnly(r realizer.Realizer, f func()) {
+	orig := newRealizerFn
+	newRealizerFn = func() (realizer.Realizer, error) { return r, nil }
+	defer func() { newRealizerFn = orig }()
+	f()
+}
+
+// seedNixHomeGen writes a nix Provisioning Generation (native anchor "4") with the
+// given home-manager ref (nil for a package-only generation).
+func seedNixHomeGen(t *testing.T, home *provision.HomeGenRef) {
+	t.Helper()
+	if err := provision.Write(&provision.Generation{
+		Backend:     "nix",
+		Native:      "4",
+		Items:       []provision.ProvItem{{ID: "jq", Ref: "nixpkgs#jq", Status: "installed"}},
+		AddedRefs:   []string{"nixpkgs#jq"},
+		HomeManager: home,
+	}); err != nil {
+		t.Fatalf("seed generation: %v", err)
+	}
+}
+
+// TestRollback_EnableRestore_RevertsConfigAndRecordsIt: `rollback --to N
+// --enable-restore` rolls back packages AND re-activates the config recorded in
+// generation N, then appends a rollback generation recording the new config gen.
+func TestRollback_EnableRestore_RevertsConfigAndRecordsIt(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedNixHomeGen(t, &provision.HomeGenRef{Flake: "/dot#me", Generation: 7})
+
+	fr := capableRealizer(setOf(4, "jq"))
+	fr.homeRollbackGen = 12
+	var result *RollbackResult
+	withFakeRealizer(fr, func() {
+		raw, env := RunRollback(RollbackFlags{To: "1", EnableRestore: true, Confirm: true})
+		if env != nil {
+			t.Fatalf("unexpected envelope error: %+v", env)
+		}
+		result = raw.(*RollbackResult)
+	})
+
+	if fr.rollbackCalls != 1 {
+		t.Errorf("package Rollback called %d times, want 1", fr.rollbackCalls)
+	}
+	if fr.homeRollbackCalls != 1 || fr.lastHomeRollbackArg != 7 {
+		t.Errorf("want RollbackHome(7) once, got calls=%d arg=%d", fr.homeRollbackCalls, fr.lastHomeRollbackArg)
+	}
+	if result.HomeManager == nil {
+		t.Fatal("result.HomeManager is nil, want config rollback recorded")
+	}
+	if result.HomeManager.TargetGeneration != 7 || result.HomeManager.NewGeneration != 12 || !result.HomeManager.Reactivated {
+		t.Errorf("HomeManager = %+v, want target=7 new=12 reactivated=true", result.HomeManager)
+	}
+	gens, _ := provision.List()
+	newest := gens[0]
+	if newest.HomeManager == nil || newest.HomeManager.Generation != 12 || newest.HomeManager.Flake != "/dot#me" {
+		t.Errorf("appended generation home ref = %+v, want {flake:/dot#me, generation:12}", newest.HomeManager)
+	}
+	if !newest.Rollback {
+		t.Error("appended generation should be marked rollback")
+	}
+}
+
+// TestRollback_NoEnableRestore_PackageOnly: without --enable-restore, a generation
+// with a recorded config still rolls back PACKAGES ONLY (backward-compatible).
+func TestRollback_NoEnableRestore_PackageOnly(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedNixHomeGen(t, &provision.HomeGenRef{Flake: "/dot#me", Generation: 7})
+
+	fr := capableRealizer(setOf(4, "jq"))
+	var result *RollbackResult
+	withFakeRealizer(fr, func() {
+		raw, env := RunRollback(RollbackFlags{To: "1", Confirm: true}) // no EnableRestore
+		if env != nil {
+			t.Fatalf("unexpected envelope error: %+v", env)
+		}
+		result = raw.(*RollbackResult)
+	})
+
+	if fr.rollbackCalls != 1 {
+		t.Errorf("package Rollback called %d times, want 1", fr.rollbackCalls)
+	}
+	if fr.homeRollbackCalls != 0 {
+		t.Errorf("RollbackHome called %d times without --enable-restore, want 0", fr.homeRollbackCalls)
+	}
+	if result.HomeManager != nil {
+		t.Errorf("HomeManager should be nil without --enable-restore, got %+v", result.HomeManager)
+	}
+}
+
+// TestRollback_EnableRestore_NoRecordedConfig_PackageOnly: --enable-restore on a
+// generation that recorded no config rolls back packages only (non-destructive
+// no-op for config), without error.
+func TestRollback_EnableRestore_NoRecordedConfig_PackageOnly(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedNixHomeGen(t, nil) // no home-manager ref
+
+	fr := capableRealizer(setOf(4, "jq"))
+	var result *RollbackResult
+	withFakeRealizer(fr, func() {
+		raw, env := RunRollback(RollbackFlags{To: "1", EnableRestore: true, Confirm: true})
+		if env != nil {
+			t.Fatalf("unexpected envelope error: %+v", env)
+		}
+		result = raw.(*RollbackResult)
+	})
+
+	if fr.rollbackCalls != 1 {
+		t.Errorf("package Rollback called %d times, want 1", fr.rollbackCalls)
+	}
+	if fr.homeRollbackCalls != 0 {
+		t.Errorf("RollbackHome called %d times for a config-less generation, want 0", fr.homeRollbackCalls)
+	}
+	if result.HomeManager != nil {
+		t.Errorf("HomeManager should be nil when the target recorded no config, got %+v", result.HomeManager)
+	}
+}
+
+// TestRollback_EnableRestore_NonHomeRollbacker_Unsupported: --enable-restore with a
+// recorded config but a backend that cannot re-activate config → ROLLBACK_UNSUPPORTED
+// with NOTHING mutated (validated before the package rollback).
+func TestRollback_EnableRestore_NonHomeRollbacker_Unsupported(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedNixHomeGen(t, &provision.HomeGenRef{Flake: "/dot#me", Generation: 7})
+
+	p := &pkgOnlyRollbacker{cur: setOf(4, "jq")}
+	withRealizerOnly(p, func() {
+		_, env := RunRollback(RollbackFlags{To: "1", EnableRestore: true, Confirm: true})
+		if env == nil || env.Code != envelope.ErrRollbackUnsupported {
+			t.Fatalf("want ROLLBACK_UNSUPPORTED, got %+v", env)
+		}
+	})
+	if p.rollbackCalls != 0 {
+		t.Errorf("package Rollback called %d times, want 0 (refuse before mutating)", p.rollbackCalls)
+	}
+	if gens, _ := provision.List(); len(gens) != 1 {
+		t.Errorf("no generation should be appended on refusal; want 1 (seed), got %d", len(gens))
+	}
+}
+
+// TestRollback_EnableRestore_RequiresTo: --enable-restore without --to is refused
+// (config rollback needs an explicit target generation), nothing mutated.
+func TestRollback_EnableRestore_RequiresTo(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	fr := capableRealizer(setOf(4, "jq"))
+	withFakeRealizer(fr, func() {
+		_, env := RunRollback(RollbackFlags{EnableRestore: true, Confirm: true}) // no To
+		if env == nil {
+			t.Fatal("expected refusal, got nil")
+		}
+		if !strings.Contains(env.Message, "--to") && !strings.Contains(strFromRemediation(env), "--to") {
+			t.Errorf("refusal should mention --to, got message=%q", env.Message)
+		}
+	})
+	if fr.rollbackCalls != 0 || fr.homeRollbackCalls != 0 {
+		t.Errorf("nothing should be mutated; got rollback=%d homeRollback=%d", fr.rollbackCalls, fr.homeRollbackCalls)
+	}
+}
+
+// TestRollback_EnableRestore_DryRun_PreviewsConfigNoMutation: --dry-run with
+// --enable-restore previews the config target and activates/rolls nothing.
+func TestRollback_EnableRestore_DryRun_PreviewsConfigNoMutation(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedNixHomeGen(t, &provision.HomeGenRef{Flake: "/dot#me", Generation: 7})
+
+	fr := capableRealizer(setOf(5, "jq"))
+	var result *RollbackResult
+	withFakeRealizer(fr, func() {
+		raw, env := RunRollback(RollbackFlags{To: "1", EnableRestore: true, DryRun: true}) // no confirm
+		if env != nil {
+			t.Fatalf("unexpected envelope error: %+v", env)
+		}
+		result = raw.(*RollbackResult)
+	})
+
+	if !result.DryRun {
+		t.Error("result.DryRun = false, want true")
+	}
+	if result.HomeManager == nil || result.HomeManager.TargetGeneration != 7 || result.HomeManager.Reactivated {
+		t.Errorf("dry-run HomeManager = %+v, want target=7 reactivated=false", result.HomeManager)
+	}
+	if fr.rollbackCalls != 0 || fr.homeRollbackCalls != 0 {
+		t.Errorf("dry-run must not mutate; got rollback=%d homeRollback=%d", fr.rollbackCalls, fr.homeRollbackCalls)
+	}
+	if gens, _ := provision.List(); len(gens) != 1 {
+		t.Errorf("dry-run must not append a generation; want 1 (seed), got %d", len(gens))
+	}
+}
+
+// TestRollback_EnableRestore_ConfigSystemicError_RawInDetailOnly: a systemic config
+// rollback failure surfaces its code with raw text confined to Detail.
+func TestRollback_EnableRestore_ConfigSystemicError_RawInDetailOnly(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedNixHomeGen(t, &provision.HomeGenRef{Flake: "/dot#me", Generation: 7})
+
+	raw := "error: cannot connect to socket at '/nix/var/nix/daemon-socket/socket'"
+	fr := capableRealizer(setOf(4, "jq"))
+	fr.homeRollbackErr = &realizer.Error{Code: envelope.ErrRealizerUnavailable, Subcode: "daemon", Stage: "spawn", Raw: raw}
+
+	var env *envelope.Error
+	withFakeRealizer(fr, func() {
+		_, env = RunRollback(RollbackFlags{To: "1", EnableRestore: true, Confirm: true})
+	})
+	if env == nil || env.Code != envelope.ErrRealizerUnavailable {
+		t.Fatalf("want REALIZER_UNAVAILABLE, got %+v", env)
+	}
+	if strings.Contains(env.Message, raw) {
+		t.Errorf("raw text leaked into Message: %q", env.Message)
+	}
+	dm, ok := env.Detail.(map[string]string)
+	if !ok || dm["raw"] != raw {
+		t.Errorf("raw text not confined to Detail: %+v", env.Detail)
+	}
+}
+
+// TestRollback_EnableRestore_ConfigFailed_RawInDetailOnly: a non-systemic config
+// rollback failure surfaces ROLLBACK_FAILED with raw confined to Detail.
+func TestRollback_EnableRestore_ConfigFailed_RawInDetailOnly(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedNixHomeGen(t, &provision.HomeGenRef{Flake: "/dot#me", Generation: 7})
+
+	raw := "error: activation script failed"
+	fr := capableRealizer(setOf(4, "jq"))
+	fr.homeRollbackErr = &realizer.Error{Code: envelope.ErrRollbackFailed, Stage: "rollback", Raw: raw}
+
+	var env *envelope.Error
+	withFakeRealizer(fr, func() {
+		_, env = RunRollback(RollbackFlags{To: "1", EnableRestore: true, Confirm: true})
+	})
+	if env == nil || env.Code != envelope.ErrRollbackFailed {
+		t.Fatalf("want ROLLBACK_FAILED, got %+v", env)
+	}
+	if strings.Contains(env.Message, raw) {
+		t.Errorf("raw text leaked into Message: %q", env.Message)
+	}
+	dm, ok := env.Detail.(map[string]string)
+	if !ok || dm["raw"] != raw {
+		t.Errorf("raw text not confined to Detail: %+v", env.Detail)
+	}
+}
+
+// TestRollback_EnableRestore_GcdSnapshot_DirectFlake_FallsBack: when the recorded
+// snapshot is gone and the generation recorded a DIRECT flake, the engine falls
+// back to re-activating that flake via ActivateHome.
+func TestRollback_EnableRestore_GcdSnapshot_DirectFlake_FallsBack(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedNixHomeGen(t, &provision.HomeGenRef{Flake: "/dot#me", Generation: 7}) // direct flake, no Config
+
+	fr := capableRealizer(setOf(4, "jq"))
+	fr.homeRollbackErr = realizer.ErrHomeSnapshotMissing
+	fr.homeGenNum = 20 // ActivateHome (fallback) returns the new gen
+	var result *RollbackResult
+	withFakeRealizer(fr, func() {
+		raw, env := RunRollback(RollbackFlags{To: "1", EnableRestore: true, Confirm: true})
+		if env != nil {
+			t.Fatalf("unexpected envelope error: %+v", env)
+		}
+		result = raw.(*RollbackResult)
+	})
+
+	if fr.activateCalls != 1 || fr.lastActivateArg != "/dot#me" {
+		t.Errorf("want ActivateHome(/dot#me) fallback once, got calls=%d arg=%q", fr.activateCalls, fr.lastActivateArg)
+	}
+	if result.HomeManager == nil || result.HomeManager.NewGeneration != 20 || !result.HomeManager.ViaFallback {
+		t.Errorf("HomeManager = %+v, want new=20 viaFallback=true", result.HomeManager)
+	}
+	gens, _ := provision.List()
+	if gens[0].HomeManager == nil || gens[0].HomeManager.Generation != 20 {
+		t.Errorf("appended home ref = %+v, want generation 20", gens[0].HomeManager)
+	}
+}
+
+// TestRollback_EnableRestore_GcdSnapshot_Wrapper_Refuses: when the recorded snapshot
+// is gone and the generation recorded an engine-generated wrapper (Config set), the
+// engine refuses (the state-dir flake holds the latest config, not gen N's) without
+// re-activating anything.
+func TestRollback_EnableRestore_GcdSnapshot_Wrapper_Refuses(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedNixHomeGen(t, &provision.HomeGenRef{Flake: "/state/home-manager/me#me", Config: "./home.nix", Generation: 7})
+
+	fr := capableRealizer(setOf(4, "jq"))
+	fr.homeRollbackErr = realizer.ErrHomeSnapshotMissing
+	var env *envelope.Error
+	withFakeRealizer(fr, func() {
+		_, env = RunRollback(RollbackFlags{To: "1", EnableRestore: true, Confirm: true})
+	})
+	if env == nil || env.Code != envelope.ErrRollbackFailed {
+		t.Fatalf("want ROLLBACK_FAILED, got %+v", env)
+	}
+	if fr.activateCalls != 0 {
+		t.Errorf("must NOT re-activate the (overwritten) wrapper flake; activateCalls=%d", fr.activateCalls)
+	}
+}
+
+// TestRollback_EnableRestore_ConfigOnlyGeneration_NoPackageRollback: a config-only
+// target generation (a config apply that installed/pruned nothing, so no native
+// anchor) is still revertable under --enable-restore: the config is re-activated
+// and the package rollback is skipped (there is no anchor), without error.
+func TestRollback_EnableRestore_ConfigOnlyGeneration_NoPackageRollback(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	if err := provision.Write(&provision.Generation{
+		Backend:     "nix",
+		Native:      "", // config-only apply: nothing installed/pruned, so no native anchor
+		HomeManager: &provision.HomeGenRef{Flake: "/dot#me", Generation: 7},
+	}); err != nil {
+		t.Fatalf("seed generation: %v", err)
+	}
+
+	fr := capableRealizer(setOf(0))
+	fr.homeRollbackGen = 12
+	var result *RollbackResult
+	withFakeRealizer(fr, func() {
+		raw, env := RunRollback(RollbackFlags{To: "1", EnableRestore: true, Confirm: true})
+		if env != nil {
+			t.Fatalf("unexpected envelope error: %+v", env)
+		}
+		result = raw.(*RollbackResult)
+	})
+
+	if fr.rollbackCalls != 0 {
+		t.Errorf("package Rollback called %d times for a config-only target, want 0", fr.rollbackCalls)
+	}
+	if fr.homeRollbackCalls != 1 || fr.lastHomeRollbackArg != 7 {
+		t.Errorf("want RollbackHome(7) once, got calls=%d arg=%d", fr.homeRollbackCalls, fr.lastHomeRollbackArg)
+	}
+	if result.HomeManager == nil || result.HomeManager.NewGeneration != 12 || !result.HomeManager.Reactivated {
+		t.Errorf("HomeManager = %+v, want new=12 reactivated=true", result.HomeManager)
+	}
+	// The appended config-only rollback generation records NO native anchor, so a
+	// later package rollback does not misinterpret it as having one.
+	gens, _ := provision.List()
+	if gens[0].Native != "" {
+		t.Errorf("config-only rollback generation Native = %q, want empty", gens[0].Native)
+	}
+}
+
+// strFromRemediation extracts an envelope error's remediation text for assertions.
+func strFromRemediation(e *envelope.Error) string {
+	if e == nil {
+		return ""
+	}
+	return e.Remediation
+}

--- a/go-engine/internal/realizer/nix/home_rollback.go
+++ b/go-engine/internal/realizer/nix/home_rollback.go
@@ -1,0 +1,64 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package nix
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+// compile-time assertion: the Nix backend implements realizer.HomeRollbacker, so
+// the rollback command can discover home-manager config-rollback support by
+// type-assertion.
+var _ realizer.HomeRollbacker = (*Backend)(nil)
+
+// RollbackHome reverts the home-manager configuration to a prior provisioning
+// generation by re-activating the home-manager generation that generation
+// recorded. home-manager has no arbitrary version pointer-move (`switch
+// --rollback` is one step only), so re-activation is done by running the target
+// generation's built `activate` script — which mints a NEW FORWARD home-manager
+// generation reproducing that config (confirmed empirically). This is append-only,
+// exactly like native package rollback: the newest generation is the active one,
+// and the user never references a backend-native generation number.
+//
+// `generation` is the home-manager generation number recorded in the Provisioning
+// Generation (HomeGenRef.Generation). RollbackHome resolves the
+// `home-manager-<generation>-link` snapshot under the home-manager profile dir and
+// runs its `activate` script. When that link no longer exists (the snapshot was
+// garbage-collected from the store) it returns realizer.ErrHomeSnapshotMissing so
+// the caller can fall back to re-activating the recorded configuration source.
+//
+// Failures are classified through the same anchor path as ActivateHome: spawn ->
+// REALIZER_UNAVAILABLE, permission -> PERMISSION_DENIED, daemon ->
+// REALIZER_UNAVAILABLE, and any other non-zero exit -> ROLLBACK_FAILED (classify's
+// INSTALL_FAILED fallback is remapped, since this is the rollback verb). The
+// `activate` script prints plain text (not nix internal-json), so classification
+// anchors against the raw stderr via parsePlainLog. Raw text is retained ONLY in
+// Error.Raw, destined for envelope error.detail (the moat).
+func (b *Backend) RollbackHome(generation int) (int, error) {
+	link := homeProfilePath() + "-" + strconv.Itoa(generation) + "-link"
+	store, err := os.Readlink(link)
+	if err != nil {
+		return 0, realizer.ErrHomeSnapshotMissing
+	}
+
+	activate := filepath.Join(store, "activate")
+	_, stderr, exit, runErr := b.execScript(activate)
+	if runErr != nil { // spawn failure (script missing/unrunnable)
+		return 0, classify(-1, parsePlainLog(stderr), false)
+	}
+	if exit != 0 {
+		rerr := classify(exit, parsePlainLog(stderr), false)
+		if rerr != nil && rerr.Code == envelope.ErrInstallFailed {
+			rerr.Code = envelope.ErrRollbackFailed
+			rerr.Stage = "rollback"
+		}
+		return 0, rerr
+	}
+	return b.homeGen(), nil
+}

--- a/go-engine/internal/realizer/nix/home_rollback_test.go
+++ b/go-engine/internal/realizer/nix/home_rollback_test.go
@@ -1,0 +1,150 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package nix
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+// captureScript returns a ScriptRunner that records the (single) script path it
+// was asked to run and replays the scripted stderr/exit/err.
+func captureScript(stderr []byte, exit int, runErr error) (ScriptRunner, *string) {
+	got := new(string)
+	r := func(path string, args ...string) ([]byte, []byte, int, error) {
+		*got = path
+		return nil, stderr, exit, runErr
+	}
+	return r, got
+}
+
+// setupHomeLink points XDG_STATE_HOME at a temp dir and creates a
+// home-manager-<gen>-link symlink in the home-manager profile dir, returning the
+// (arbitrary) store path it points at. The target need not exist — RollbackHome
+// only reads the link to locate the generation's `activate` script.
+func setupHomeLink(t *testing.T, gen int) string {
+	t.Helper()
+	state := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", state)
+	profiles := filepath.Join(state, "nix", "profiles")
+	if err := os.MkdirAll(profiles, 0o755); err != nil {
+		t.Fatalf("mkdir profiles: %v", err)
+	}
+	store := filepath.Join(t.TempDir(), "xxxx-home-manager-generation")
+	link := filepath.Join(profiles, "home-manager-"+strconv.Itoa(gen)+"-link")
+	if err := os.Symlink(store, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	return store
+}
+
+// TestRollbackHome_Success_RunsActivateAndReturnsNewGen: RollbackHome(M) resolves
+// the home-manager-<M>-link snapshot, runs its `activate` script, and returns the
+// new (forward) home-manager generation read via the homeGenFn seam.
+func TestRollbackHome_Success_RunsActivateAndReturnsNewGen(t *testing.T) {
+	store := setupHomeLink(t, 3)
+	run, gotPath := captureScript(nil, 0, nil)
+	b := &Backend{runScript: run, homeGenFn: func() int { return 9 }}
+
+	gen, err := b.RollbackHome(3)
+	if err != nil {
+		t.Fatalf("expected nil error on successful re-activation, got %v", err)
+	}
+	if gen != 9 {
+		t.Errorf("generation = %d, want 9 (the new forward gen from homeGenFn)", gen)
+	}
+	want := filepath.Join(store, "activate")
+	if *gotPath != want {
+		t.Errorf("ran script %q, want %q", *gotPath, want)
+	}
+}
+
+// TestRollbackHome_MissingSnapshot_DistinctErrorNoExec: when the
+// home-manager-<M>-link is absent (snapshot garbage-collected), RollbackHome
+// returns the distinguishable ErrHomeSnapshotMissing and runs nothing, so the
+// command layer can fall back.
+func TestRollbackHome_MissingSnapshot_DistinctErrorNoExec(t *testing.T) {
+	state := t.TempDir()
+	t.Setenv("XDG_STATE_HOME", state) // no profiles dir, no link
+	ran := false
+	b := &Backend{runScript: func(path string, args ...string) ([]byte, []byte, int, error) {
+		ran = true
+		return nil, nil, 0, nil
+	}}
+
+	_, err := b.RollbackHome(5)
+	if !errors.Is(err, realizer.ErrHomeSnapshotMissing) {
+		t.Fatalf("want ErrHomeSnapshotMissing, got %v", err)
+	}
+	if ran {
+		t.Error("activate must NOT run when the snapshot link is missing")
+	}
+}
+
+// TestRollbackHome_Failure_RemapsToRollbackFailed: a non-zero exit whose plain
+// stderr matches no systemic anchor classifies as ROLLBACK_FAILED (not
+// INSTALL_FAILED), with the raw text confined to Err.Raw (the moat).
+func TestRollbackHome_Failure_RemapsToRollbackFailed(t *testing.T) {
+	setupHomeLink(t, 2)
+	run, _ := captureScript([]byte("error: activation script failed midway"), 1, nil)
+	b := &Backend{runScript: run}
+
+	_, err := b.RollbackHome(2)
+	rerr := asRealizerErr(t, err)
+	if rerr.Code != envelope.ErrRollbackFailed {
+		t.Errorf("Code = %q, want ROLLBACK_FAILED", rerr.Code)
+	}
+	if !strings.Contains(rerr.Raw, "activation script failed") {
+		t.Errorf("raw text not retained in Err.Raw: %q", rerr.Raw)
+	}
+}
+
+// TestRollbackHome_Permission_Systemic: a permission anchor surfaces
+// PERMISSION_DENIED.
+func TestRollbackHome_Permission_Systemic(t *testing.T) {
+	setupHomeLink(t, 2)
+	run, _ := captureScript([]byte("error: opening file '/nix/store/.lock': Permission denied"), 1, nil)
+	b := &Backend{runScript: run}
+
+	_, err := b.RollbackHome(2)
+	rerr := asRealizerErr(t, err)
+	if rerr.Code != envelope.ErrPermissionDenied {
+		t.Errorf("Code = %q, want PERMISSION_DENIED", rerr.Code)
+	}
+}
+
+// TestRollbackHome_Daemon_Systemic: a daemon anchor surfaces REALIZER_UNAVAILABLE
+// (passed through classify, not remapped).
+func TestRollbackHome_Daemon_Systemic(t *testing.T) {
+	setupHomeLink(t, 2)
+	run, _ := captureScript([]byte("error: cannot connect to socket at '/nix/var/nix/daemon-socket/socket'"), 1, nil)
+	b := &Backend{runScript: run}
+
+	_, err := b.RollbackHome(2)
+	rerr := asRealizerErr(t, err)
+	if rerr.Code != envelope.ErrRealizerUnavailable {
+		t.Errorf("Code = %q, want REALIZER_UNAVAILABLE", rerr.Code)
+	}
+}
+
+// TestRollbackHome_Spawn_Unavailable: a spawn failure (runner returns a non-nil
+// error) surfaces REALIZER_UNAVAILABLE regardless of any text.
+func TestRollbackHome_Spawn_Unavailable(t *testing.T) {
+	setupHomeLink(t, 2)
+	run, _ := captureScript(nil, -1, errors.New("exec: activate not found"))
+	b := &Backend{runScript: run}
+
+	_, err := b.RollbackHome(2)
+	rerr := asRealizerErr(t, err)
+	if rerr.Code != envelope.ErrRealizerUnavailable {
+		t.Errorf("Code = %q, want REALIZER_UNAVAILABLE", rerr.Code)
+	}
+}

--- a/go-engine/internal/realizer/nix/nix.go
+++ b/go-engine/internal/realizer/nix/nix.go
@@ -28,6 +28,12 @@ import (
 // a nil error. It is an injection point so tests stay hermetic.
 type Runner func(args ...string) (stdout, stderr []byte, exitCode int, err error)
 
+// ScriptRunner executes a store-path script (e.g. a home-manager generation's
+// `activate`) and follows the same exit/err convention as Runner. It is a
+// SEPARATE seam from Runner because `activate` is a store-path executable, not a
+// `nix` subcommand, so it is invoked directly rather than through `nix`.
+type ScriptRunner func(path string, args ...string) (stdout, stderr []byte, exitCode int, err error)
+
 // Backend implements realizer.Realizer over the Nix CLI.
 type Backend struct {
 	// Profile is the Endstate-managed nix profile path.
@@ -42,6 +48,10 @@ type Backend struct {
 	HomePin string
 	// Run executes nix; defaults to the real exec runner.
 	Run Runner
+	// runScript executes a store-path script (a home-manager generation's
+	// `activate`) for RollbackHome; nil means the real exec runner. Tests inject a
+	// stub so the re-activation path is exercised hermetically.
+	runScript ScriptRunner
 	// genFn overrides generation reading; nil means read the profile symlink.
 	// Tests (in-package) set this to drive Realize's atomicity detection
 	// hermetically without a real generation switch.
@@ -160,6 +170,34 @@ func defaultRunner(args ...string) ([]byte, []byte, int, error) {
 	}
 	// Spawn failure (binary missing, not executable, etc.).
 	return out.Bytes(), errb.Bytes(), -1, runErr
+}
+
+// defaultScriptRunner runs a store-path script directly (e.g. a home-manager
+// generation's `activate`), inheriting the engine's environment, and follows the
+// same exit/err convention as defaultRunner.
+func defaultScriptRunner(path string, args ...string) ([]byte, []byte, int, error) {
+	cmd := exec.Command(path, args...)
+	var out, errb bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errb
+	runErr := cmd.Run()
+	if runErr == nil {
+		return out.Bytes(), errb.Bytes(), 0, nil
+	}
+	var exitErr *exec.ExitError
+	if errors.As(runErr, &exitErr) {
+		return out.Bytes(), errb.Bytes(), exitErr.ExitCode(), nil
+	}
+	return out.Bytes(), errb.Bytes(), -1, runErr
+}
+
+// execScript runs a store-path script via runScript when set (tests) else the
+// real exec runner.
+func (b *Backend) execScript(path string, args ...string) ([]byte, []byte, int, error) {
+	if b.runScript != nil {
+		return b.runScript(path, args...)
+	}
+	return defaultScriptRunner(path, args...)
 }
 
 // ResolveInstallable expands a manifest ref into a concrete nix installable. A

--- a/go-engine/internal/realizer/realizer.go
+++ b/go-engine/internal/realizer/realizer.go
@@ -11,7 +11,17 @@
 // generation result back into the existing per-item event stream.
 package realizer
 
-import "github.com/Artexis10/endstate/go-engine/internal/envelope"
+import (
+	"errors"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// ErrHomeSnapshotMissing is returned by HomeRollbacker.RollbackHome when the
+// target generation's built home-manager snapshot is no longer available (for
+// example, garbage-collected from the Nix store), so the caller can fall back to
+// re-activating the recorded configuration source instead of failing outright.
+var ErrHomeSnapshotMissing = errors.New("home-manager generation snapshot is unavailable")
 
 // Installable is one resolved package to realize: the manifest App.ID plus the
 // concrete reference passed to the backend (e.g. a pinned nixpkgs flake
@@ -112,4 +122,22 @@ type HomeActivator interface {
 	// flakeref and returns the resulting home-manager generation number. On
 	// failure it returns a classified *Error (raw backend text in Error.Raw only).
 	ActivateHome(flake string) (generation int, err error)
+}
+
+// HomeRollbacker is an OPTIONAL realizer capability: reverting the home-manager
+// configuration to a prior provisioning generation by re-activating the
+// home-manager generation that generation recorded. Like Pruner/HomeActivator it
+// is discovered by type-assertion on a Realizer, so only a backend that owns a
+// home-manager lifecycle (the Nix realizer) implements it. The backend has no
+// arbitrary version pointer-move, so re-activation mints a NEW forward
+// home-manager generation that reproduces the recorded config — append-only,
+// matching native package rollback ("newest == active").
+type HomeRollbacker interface {
+	// RollbackHome reverts the home-manager configuration by re-activating the
+	// snapshot of the given home-manager generation number and returns the
+	// resulting (new, forward) generation number. It returns ErrHomeSnapshotMissing
+	// when that snapshot is no longer available (so the caller can fall back to the
+	// recorded configuration source), or a classified *Error on activation failure
+	// (raw backend text in Error.Raw only).
+	RollbackHome(generation int) (newGen int, err error)
 }

--- a/openspec/changes/nix-home-manager-rollback/.openspec.yaml
+++ b/openspec/changes/nix-home-manager-rollback/.openspec.yaml
@@ -1,0 +1,10 @@
+id: nix-home-manager-rollback
+title: "Home-manager config rollback: revert the config to a prior Provisioning Generation"
+status: implementing
+spec: nix-home-manager-rollback
+created: "2026-06-02"
+author: Hugo Ander Kivi
+artifacts:
+  - proposal.md
+  - design.md
+  - tasks.md

--- a/openspec/changes/nix-home-manager-rollback/design.md
+++ b/openspec/changes/nix-home-manager-rollback/design.md
@@ -1,0 +1,105 @@
+## Context
+
+`nix-native-rollback` (#60) gave the `rollback` command its native package path: map an engine-owned
+Provisioning Generation number N → the recorded `Native` anchor → `nix profile rollback --to`, then append a
+rollback-marked generation. `nix-home-manager-config` (#81/#87) records, per apply, the activated
+home-manager configuration in `provision.HomeGenRef{Flake, Config, Generation}`. Config rollback was deferred
+from #81. This change reverts the **config** to a prior generation, parallel to the package path.
+
+## Empirical verdict (real-nix smoke, confirmed before this spec was finalized)
+
+home-manager has **no arbitrary pointer-move-back**. `home-manager switch --rollback` is `nix-env --rollback`
+— one step back only. To revert to an arbitrary generation M, you run that generation's `activate` script
+(`<store-path>/activate`). Confirmed in a sandbox (apply marker "A" → gen1, apply marker "B" → gen2, run
+gen1's `activate`): a **new forward** generation link (`home-manager-3-link`) appeared and became active, and
+the managed file reverted to "A". So re-activation is **append-only** ("newest == active"), exactly the model
+package rollback uses. The activate script runs directly (no flags, driver-version 0 default) with exit 0,
+emitting plain-text activation lines (`Activating installPackages` / `linkGeneration`) — classified by the
+existing `parsePlainLog` + `classify` path.
+
+## Decisions
+
+- **Coupled, opt-in via `--enable-restore`.** `rollback --to N` is package-only by default; with
+  `--enable-restore` it also reverts the home-manager config recorded in generation N. Symmetric with
+  `apply --enable-restore` (which gates the config *apply* stage). No new rollback-specific flag, no new
+  command.
+- **Re-activate the recorded generation's store-path snapshot (primary).** Resolve
+  `home-manager-<M>-link` (M = `genN.HomeManager.Generation`), read the store path, run `<store>/activate`.
+  The `-<M>-link` store path is the **immutable, faithful** snapshot of the config at gen N. (The
+  engine-generated wrapper-flake dir is regenerated/overwritten each apply, so rebuilding *from it* would be
+  unfaithful — this is the same reason #89 made capture prefer `Config` over the generated `Flake`.)
+- **Fallback when the snapshot link is gone (GC'd):**
+  - *Directly-referenced flake* (`genN.HomeManager.Config == ""`): re-activate `genN.HomeManager.Flake` via
+    the existing `ActivateHome` — a pinned flake rebuilds faithfully.
+  - *Engine-generated wrapper* (`Config != ""`): **refuse** with `ROLLBACK_FAILED` + remediation ("generation
+    N's home-manager snapshot was garbage-collected; re-apply with `endstate apply --enable-restore`"). The
+    state-dir wrapper now holds the *latest* config, not gen N's, so silently activating it would be wrong —
+    non-destructive default.
+- **New optional `realizer.HomeRollbacker`** — `RollbackHome(generation int) (newGen int, err error)` —
+  discovered by type-assertion like `Pruner`/`HomeActivator`. Keeps interfaces small; only Nix implements it.
+  A missing `-<M>-link` is surfaced distinctly so the command layer (which holds the recorded `HomeGenRef`)
+  can drive the fallback.
+- **Validate-before-mutate.** When `--enable-restore` is set and gen N recorded a config but the backend is
+  not a `HomeRollbacker`, refuse with `ROLLBACK_UNSUPPORTED` **before** touching packages — nothing mutates.
+- **Append one combined generation.** On success, append a single rollback-marked Provisioning Generation
+  recording the now-active package set **and** `HomeManager{Flake, Config (copied from gen N), Generation:
+  newHmGen}`, keeping `newest == active` truthful for config too.
+- **Separation of concerns.** Config rollback is home-manager *generation re-activation* (a realizer +
+  provisioning concern). It is distinct from config-*file* restore (`state/backups/` + the revert journal)
+  and `rollback.go` continues to **not** import `internal/restore` (the `TestRollbackStaysPackageOnly` guard
+  stays green). Raw backend text stays in `error.detail`.
+
+## Design
+
+### Realizer (`internal/realizer`)
+`HomeRollbacker { RollbackHome(generation int) (newGen int, err error) }`. Compile-time-asserted on the Nix
+`Backend`.
+
+### Nix backend (`internal/realizer/nix`)
+`RollbackHome(M)`:
+1. `link := homeProfilePath() + "-" + strconv.Itoa(M) + "-link"`. If it does not exist → return a
+   distinguishable error (the command falls back). 
+2. `store := readlink(link)`; run `runScript(filepath.Join(store, "activate"))` via a small injectable
+   exec seam (the `activate` script is a store-path executable, not a `nix` subcommand, so it is a separate
+   seam from the nix `Runner`; defaults to `exec.Command`).
+3. Classify via `parsePlainLog` + `classify` (exit<0 → REALIZER_UNAVAILABLE/spawn; non-zero → anchor table;
+   the `INSTALL_FAILED` fallback is **remapped to `ROLLBACK_FAILED`** so the error names the verb — exactly
+   as the package `Rollback` does). On success return `homeGen()` (the new forward generation).
+
+### Command (`internal/commands/rollback.go`)
+`RollbackFlags.EnableRestore bool`; `RollbackResult` gains a `HomeManager *RollbackHomeResult` sub-object
+(target hm generation M, new hm generation, flake/config, dry-run-aware). In `runRealizerRollback`, after
+resolving the package target and **before** any mutation:
+- `wantConfig := flags.EnableRestore`; load gen N; `home := genN.HomeManager`.
+- If `wantConfig && home != nil && r` is not a `HomeRollbacker` → `ROLLBACK_UNSUPPORTED` (nothing mutated).
+- `--dry-run` → report package target + (if `wantConfig && home != nil`) the config target M; activate nothing.
+- `--confirm` gate (existing).
+- `rb.Rollback(target)` (packages). Then if `wantConfig && home != nil`: `hr.RollbackHome(home.Generation)`;
+  on the distinct "snapshot missing" signal, fall back (direct flake → `ActivateHome(home.Flake)`; wrapper →
+  `ROLLBACK_FAILED` + remediation). A config failure after a package rollback surfaces the classified error
+  (mirrors apply's package-then-config ordering).
+- Append one combined rollback generation (extend `appendRollbackGeneration` to take an optional
+  `*provision.HomeGenRef`, set to `{Flake, Config from gen N, Generation: newHmGen}`).
+
+### CLI (`cmd/endstate/main.go`, protected — additive)
+Add `EnableRestore: p.enableRestore` to the rollback case (the parser field already exists and is used by
+apply); extend the `rollback` usage text to note that `--enable-restore` also reverts the recorded
+home-manager config.
+
+## Risks / Verification
+
+- **GC'd snapshot.** Handled: faithful fallback for a direct flake; honest refusal for the engine-generated
+  wrapper. Tested with the distinct missing-generation signal.
+- **Partial outcome** (package rollback succeeds, config rollback fails). Mirrors apply: the classified config
+  error is returned (raw in detail). Documented.
+- **Hermetic tests:** realizer `RollbackHome` (temp `XDG_STATE_HOME` + a `home-manager-<M>-link` symlink;
+  injected `runScript`; classification of eval/permission/daemon/spawn; missing-link → distinct error, no
+  exec). Command tests (extend `fakeRealizer` to a `HomeRollbacker`): coupled success records the new config;
+  no `--enable-restore` ⇒ no `RollbackHome`; no recorded config ⇒ package-only; non-`HomeRollbacker` + config
+  ⇒ `ROLLBACK_UNSUPPORTED`, nothing mutated; dry-run previews and does not call; config failure classification
+  with raw confined to detail; fallback (direct flake re-activates; wrapper refuses). `go test ./...` (Linux);
+  `GOOS=windows go build ./...` + `go vet`; openspec strict.
+- **Real-nix e2e smoke** (sandbox `$HOME` + `ENDSTATE_ROOT`, hm pin `git+file:///home/hugoa/projects/home-manager`):
+  apply config A (gen1) → apply config B (gen2) → `rollback --to 1 --enable-restore --confirm` → the managed
+  config reverts to A and a rollback-marked generation recording the home ref is appended. Real `$HOME`
+  untouched.

--- a/openspec/changes/nix-home-manager-rollback/proposal.md
+++ b/openspec/changes/nix-home-manager-rollback/proposal.md
@@ -1,0 +1,67 @@
+## Why
+
+The Nix config arc is complete except one gap: there is no way to roll the home-manager **config**
+back. Packages roll back natively (`nix-native-rollback` → `nix profile rollback`), and config can be
+applied (#81), wrapped from a `home.nix` (#87), and captured (#86/#89). But once a user applies config
+A and then config B, `rollback` reverts only the package set — the home-manager config stays at B. This
+change closes the loop: a Provisioning Generation N can be reverted to as a coherent whole — its package
+set **and** the home-manager config it recorded.
+
+Rollback of the config was explicitly deferred from #81; this is that deferred work, parallel to package
+rollback (#60 native `nix profile rollback --to`; #63 winget best-effort).
+
+## What Changes
+
+- **`rollback` gains an opt-in config stage**, gated by the existing `--enable-restore` flag — symmetric
+  with `apply --enable-restore`. `rollback --to N` stays **package-only by default**; with
+  `--enable-restore` it *also* re-activates the home-manager config recorded in generation N. One coherent
+  "rollback to N". If generation N recorded no config, the config is left unchanged (non-destructive).
+- **Re-activation mechanism (empirically confirmed):** home-manager has no arbitrary pointer-move-back
+  (`switch --rollback` is one step only). The engine resolves the recorded home-manager generation's
+  snapshot (`home-manager-<M>-link`) and runs its `activate` script, which mints a **new forward**
+  home-manager generation that reproduces the recorded config — exactly the append-only "newest == active"
+  model package rollback already uses.
+- **New optional realizer capability `HomeRollbacker`**, discovered by type-assertion exactly like
+  `Pruner` / `HomeActivator`; only the Nix backend implements it.
+- **Garbage-collected snapshot handling:** if the recorded generation's store snapshot is gone, the engine
+  falls back to re-activating a *directly-referenced* flake (faithful for a pinned flake), and otherwise
+  refuses without changing the config (the engine-generated wrapper directory is overwritten each apply, so
+  rebuilding from it would be unfaithful) — non-destructive default with a clear remediation.
+- The appended rollback Provisioning Generation records the now-active config, so `newest == active`
+  stays truthful for config as well as packages. Raw home-manager/Nix text stays confined to `error.detail`.
+
+## Capabilities
+
+### New Capabilities
+
+- `nix-home-manager-rollback`: `rollback --enable-restore` reverts the home-manager config recorded in the
+  target Provisioning Generation by re-activating that generation's recorded home-manager generation
+  (append-only forward generation), with a non-destructive fallback when the snapshot is unavailable, and
+  records the reverted config in the appended generation.
+
+### Modified Capabilities
+
+- None in spec terms. This extends the existing `rollback` command (`nix-native-rollback`) with an opt-in
+  config stage; the package rollback path, the winget best-effort path, and a bare (package-only) rollback
+  are unchanged.
+
+## Impact
+
+- `internal/realizer/realizer.go` — new optional `HomeRollbacker { RollbackHome(generation int) (newGen int, err error) }`.
+- `internal/realizer/nix/` — implement `RollbackHome` (resolve `home-manager-<M>-link` → run `<store>/activate`),
+  reusing `homeProfilePath`/`homeGen`/`parsePlainLog`/`classify`; a small script-exec seam (`activate` is a
+  store-path executable, not a `nix` subcommand).
+- `internal/commands/rollback.go` — `RollbackFlags.EnableRestore`; `RollbackResult` config sub-object; the
+  realizer path validates config eligibility before mutating, then reverts packages and (opt-in) config, and
+  records the reverted config. Stays **package/realizer-only** — never imports `internal/restore`.
+- `cmd/endstate/main.go` — **PROTECTED (additive)**: wire `EnableRestore` into the rollback command and update
+  the `rollback` usage text.
+
+## Non-Goals (deferred)
+
+- **Config-file restore rollback** (the `state/backups/` + revert-journal layer) — a separate concern;
+  this change is home-manager generation re-activation only, distinct from file restore.
+- **Best-effort config rollback on non-realizer backends** (winget has no home-manager). Config rollback is
+  realizer-only; package rollback on winget is unchanged.
+- **Rolling back to a *pre-config* state by removing the home-manager config** (un-applying home-manager).
+  We only re-activate a *recorded* config; a generation with no recorded config leaves the config unchanged.

--- a/openspec/changes/nix-home-manager-rollback/specs/nix-home-manager-rollback/spec.md
+++ b/openspec/changes/nix-home-manager-rollback/specs/nix-home-manager-rollback/spec.md
@@ -1,0 +1,128 @@
+## ADDED Requirements
+
+### Requirement: Rollback optionally reverts the recorded home-manager config
+
+The `rollback` command SHALL revert the home-manager configuration recorded in the target Provisioning
+Generation when, and only when, configuration changes are enabled by the same opt-in used by apply. Without
+that opt-in, `rollback` SHALL remain package-only and SHALL NOT change the home-manager configuration. When
+the target generation recorded no home-manager configuration, the configuration SHALL be left unchanged.
+
+#### Scenario: Config is reverted when configuration changes are enabled
+
+- **WHEN** `rollback --to <N>` runs on the realizer with configuration changes enabled and Provisioning
+  Generation N recorded a home-manager configuration
+- **THEN** the engine SHALL revert the home-manager configuration to the one recorded by generation N
+- **AND** it SHALL also perform the package rollback for generation N
+
+#### Scenario: Config is untouched by default
+
+- **WHEN** `rollback --to <N>` runs without configuration changes enabled
+- **THEN** the engine SHALL roll back the package set only
+- **AND** it SHALL NOT change the active home-manager configuration
+
+#### Scenario: A generation without a recorded config leaves config unchanged
+
+- **WHEN** `rollback --to <N>` runs with configuration changes enabled but generation N recorded no
+  home-manager configuration
+- **THEN** the engine SHALL leave the active home-manager configuration unchanged
+- **AND** it SHALL NOT fail on account of the absent configuration
+
+### Requirement: Config rollback re-activates the recorded generation append-only
+
+To revert the configuration, the engine SHALL re-activate the home-manager generation recorded in the target
+Provisioning Generation. Because the backend provides no arbitrary version pointer-move, re-activation SHALL
+produce a new home-manager generation that reproduces the recorded configuration (append-only: the newest
+generation is the active one). The user SHALL NOT be required to reference any backend-native generation
+number.
+
+#### Scenario: Re-activation reproduces the recorded configuration
+
+- **WHEN** the engine reverts the home-manager configuration to the one recorded by generation N
+- **THEN** the now-active home-manager configuration SHALL match the configuration recorded by generation N
+- **AND** a new home-manager generation SHALL become the active one
+- **AND** the user SHALL NOT have to reference any backend-native generation number
+
+### Requirement: An unavailable snapshot is handled non-destructively
+
+The engine SHALL handle an unavailable recorded snapshot non-destructively. When the target generation's
+recorded home-manager snapshot is no longer available (for example, garbage collected), the engine SHALL fall
+back to re-activating the recorded configuration source when it can do so faithfully, and SHALL otherwise
+refuse without changing the active configuration, reporting how to recover.
+
+#### Scenario: Directly-referenced flake falls back to re-activation
+
+- **WHEN** the recorded snapshot for generation N is unavailable and generation N recorded a directly
+  referenced home-manager flake
+- **THEN** the engine SHALL re-activate that recorded flake
+- **AND** the now-active configuration SHALL reflect generation N's configuration
+
+#### Scenario: A generated-config snapshot that is gone is refused
+
+- **WHEN** the recorded snapshot for generation N is unavailable and generation N recorded an
+  engine-generated configuration (not a directly referenced flake)
+- **THEN** the engine SHALL refuse with a stable error and SHALL NOT change the active home-manager configuration
+- **AND** it SHALL report how to recover the desired configuration
+
+### Requirement: Config rollback requires confirmation and supports preview
+
+Because reverting the configuration changes system state, the config rollback SHALL be governed by the same
+confirmation and preview behavior as package rollback: it SHALL require explicit confirmation, and a preview
+mode SHALL report the configuration target without activating anything.
+
+#### Scenario: Preview reports the config target without mutating
+
+- **WHEN** `rollback --to <N>` runs in preview mode with configuration changes enabled and generation N
+  recorded a home-manager configuration
+- **THEN** the engine SHALL report the home-manager configuration target it would re-activate
+- **AND** it SHALL NOT activate any home-manager configuration
+- **AND** it SHALL NOT require confirmation
+
+#### Scenario: Confirmed config rollback executes
+
+- **WHEN** `rollback --to <N>` runs with confirmation and configuration changes enabled and a valid recorded config
+- **THEN** the engine SHALL perform the config rollback
+
+### Requirement: A backend that cannot re-activate config is refused without mutation
+
+The engine SHALL refuse a config rollback the backend cannot perform, before mutating anything. When
+configuration changes are enabled and the target generation recorded a home-manager configuration, but the
+active package backend cannot re-activate a home-manager configuration, the engine SHALL refuse with a stable
+error before performing any rollback, and SHALL NOT modify the package set or the configuration.
+
+#### Scenario: Unsupported config rollback refuses up front
+
+- **WHEN** `rollback --to <N>` runs with configuration changes enabled, generation N recorded a home-manager
+  configuration, and the backend cannot re-activate it
+- **THEN** the engine SHALL refuse with a stable error
+- **AND** it SHALL NOT roll back the package set
+- **AND** it SHALL NOT change the active home-manager configuration
+
+### Requirement: The appended generation records the reverted config
+
+After a successful config rollback, the engine SHALL record the now-active home-manager configuration in the
+appended rollback Provisioning Generation, so the append-only history's newest record reflects the active
+configuration as well as the active package set.
+
+#### Scenario: The rollback generation records the now-active config
+
+- **WHEN** a config rollback completes successfully
+- **THEN** the appended rollback Provisioning Generation SHALL record the now-active home-manager
+  configuration, including the resulting home-manager generation
+- **AND** that generation SHALL be distinguishable as produced by a rollback
+
+### Requirement: Config rollback stays separate from file restore and confines diagnostics
+
+Config rollback SHALL be confined to home-manager generation re-activation: it SHALL NOT read or write the
+configuration-file backup directory or the restore revert journal. Any raw backend output produced during a
+config rollback SHALL be confined to the error detail channel and SHALL NOT appear in the user-facing message.
+
+#### Scenario: Raw backend text is confined to detail
+
+- **WHEN** a config rollback fails with backend diagnostic output
+- **THEN** the raw backend text SHALL appear only in the error detail
+- **AND** the user-facing message SHALL NOT contain the raw backend text
+
+#### Scenario: Config rollback does not touch the file-restore layer
+
+- **WHEN** a config rollback runs
+- **THEN** the engine SHALL NOT read or write the configuration-file backup directory or the restore revert journal

--- a/openspec/changes/nix-home-manager-rollback/tasks.md
+++ b/openspec/changes/nix-home-manager-rollback/tasks.md
@@ -1,0 +1,62 @@
+> TDD: write each test RED first, then implement to green. Hermetic — realizer tests inject a `runScript`
+> seam + a temp `XDG_STATE_HOME` with a `home-manager-<M>-link` symlink; command tests inject `fakeRealizer`
+> (extended to a `HomeRollbacker`) and override the realizer seam. Verify: `cd go-engine && go test ./...`
+> (Linux) + `GOOS=windows go build ./...` + `go vet`. A **real-nix smoke** (sandbox `$HOME`/`ENDSTATE_ROOT`)
+> proves apply A → apply B → `rollback --to 1 --enable-restore` reverts the config to A.
+>
+> Empirical verdict (confirmed before this spec): re-running an old hm generation's `activate` mints a NEW
+> FORWARD generation and reverts the config (append-only). See design.md.
+
+## 1. Realizer capability
+
+- [ ] 1.1 `internal/realizer/realizer.go`: add optional `HomeRollbacker { RollbackHome(generation int) (newGen int, err error) }`
+      with a doc-comment in the `Pruner` / `HomeActivator` style (type-asserted, optional).
+
+## 2. Nix backend RollbackHome
+
+- [ ] 2.1 `internal/realizer/nix/nix.go`: add an injectable script-exec seam to `Backend` (e.g.
+      `runScript func(path string, args ...string) (stdout, stderr []byte, exit int, err error)`), defaulting
+      to a real `exec.Command` runner; wire the default in `New()`.
+- [ ] 2.2 RED tests (`internal/realizer/nix/home_rollback_test.go`): `RollbackHome(M)` resolves
+      `<homeProfilePath>-<M>-link`, reads the store path, execs `<store>/activate`, and returns the new
+      generation (via the `homeGenFn` seam); a missing `-<M>-link` returns a *distinguishable* error and does
+      NOT exec; non-zero exit with eval/permission/daemon stderr classifies as ROLLBACK_FAILED / PERMISSION_DENIED
+      / REALIZER_UNAVAILABLE; a spawn error → REALIZER_UNAVAILABLE; raw text confined to `Err.Raw`.
+- [ ] 2.3 Implement `(*Backend).RollbackHome` (new `home_rollback.go` or in `home_manager.go`): reuse
+      `homeProfilePath`/`homeGen`/`parsePlainLog`/`classify`, remap the `INSTALL_FAILED` fallback to
+      `ROLLBACK_FAILED` (Stage "rollback") so the error names the verb (mirrors package `Rollback`); add
+      `var _ realizer.HomeRollbacker = (*Backend)(nil)`.
+
+## 3. Command-layer coupling (rollback.go)
+
+- [ ] 3.1 `internal/commands/rollback.go`: add `EnableRestore bool` to `RollbackFlags`; add a
+      `HomeManager *RollbackHomeResult` sub-object to `RollbackResult` (target hm gen, new hm gen, flake/config,
+      dry-run-aware).
+- [ ] 3.2 `appendRollbackGeneration` (apply_generation.go or local): accept an optional `*provision.HomeGenRef`
+      so the appended rollback generation records the now-active config.
+- [ ] 3.3 RED command tests + impl in `runRealizerRollback`: validate config eligibility BEFORE mutating
+      (type-assert `HomeRollbacker`; load gen N; read `HomeManager`); `--enable-restore` + config present +
+      non-`HomeRollbacker` → `ROLLBACK_UNSUPPORTED` (nothing mutated); `--dry-run` previews config target, no
+      call, no append; on confirm: package `Rollback` then `RollbackHome(home.Generation)`; fallback on the
+      missing-snapshot signal (direct flake → `ActivateHome(home.Flake)`; wrapper → `ROLLBACK_FAILED` +
+      remediation); append one combined generation recording `{Flake, Config from gen N, Generation: newHmGen}`.
+- [ ] 3.4 Tests: coupled success records `HomeManager.Generation == newHmGen` and rolls packages too; no
+      `--enable-restore` ⇒ no `RollbackHome` (backward-compat); gen N has no config ⇒ package-only success;
+      config failure systemic vs non-systemic classification with raw confined to detail.
+- [ ] 3.5 `TestRollbackStaysPackageOnly` stays green — `rollback.go` MUST NOT import `internal/restore`.
+
+## 4. CLI wiring (PROTECTED — additive)
+
+- [ ] 4.1 `cmd/endstate/main.go`: add `EnableRestore: p.enableRestore` to the `rollback` case; update the
+      `rollback` usage/help text to note `--enable-restore` also reverts the recorded home-manager config.
+
+## 5. Verification
+
+- [ ] 5.1 `cd go-engine && go test ./...` green on Linux.
+- [ ] 5.2 `GOOS=windows go build ./...` + `go vet ./...` clean (realizer/home-manager path is non-Windows;
+      winget/default rollback untouched).
+- [ ] 5.3 `npm run openspec:validate` (strict) passes.
+- [ ] 5.4 **Real-nix e2e smoke** (sandbox `$HOME` + isolated `ENDSTATE_ROOT`; hm pin
+      `git+file:///home/hugoa/projects/home-manager`): apply config A (marker) → apply config B → 
+      `rollback --to 1 --enable-restore --confirm` → assert the managed config reverts to A (B's marker gone)
+      and a rollback-marked Provisioning Generation recording the home ref was appended. Real `$HOME` untouched.


### PR DESCRIPTION
Closes the last gap in the Nix config arc: roll the home-manager **config** back to a prior Provisioning Generation, parallel to native package rollback (#60). Config rollback was explicitly deferred from #81 — this is that work.

## Behavior

`rollback --to N` stays **package-only by default**; with `--enable-restore` it **also** re-activates the home-manager config recorded in generation N — symmetric with `apply --enable-restore`. One coherent "rollback to N".

| invocation | target gen home ref | result |
|---|---|---|
| `--to N --confirm` | any | package-only (unchanged) |
| `--to N --enable-restore --confirm` | present | packages + config re-activated |
| `--to N --enable-restore --confirm` | absent | package-only (config no-op, non-destructive) |
| `--to N --enable-restore` (config-only gen, no native anchor) | present | config-only re-activation |
| `--enable-restore` + config present + backend not HomeRollbacker | — | `ROLLBACK_UNSUPPORTED`, nothing mutated |
| `--enable-restore` without `--to` | — | refused (config rollback needs a target) |

## Mechanism (empirically confirmed before the spec)

home-manager has **no arbitrary pointer-move-back** (`switch --rollback` is one step only). To revert to an arbitrary generation the engine runs that generation's recorded `activate` snapshot (`home-manager-<M>-link`), which mints a **new forward** generation reproducing the config — append-only, exactly the native package-rollback model ("newest == active"). A sandbox smoke confirmed re-activating an old generation mints a forward link and reverts the managed files.

The recorded store-path snapshot is the **faithful** source: the engine-generated wrapper-flake dir is overwritten each apply, so rebuilding from it would be unfaithful (same reason #89 made capture prefer `config` over the generated `flake`). When the snapshot was garbage-collected, the engine falls back to re-activating a *directly-referenced* flake, and **refuses** (non-destructive) for an engine-generated wrapper.

## Changes

- **`realizer.HomeRollbacker`** (`RollbackHome(generation int) (newGen int, err error)`), type-asserted like `Pruner`/`HomeActivator`; only Nix implements it. Nix `RollbackHome` runs the snapshot's `activate` via a store-path exec seam, reusing `parsePlainLog`/`classify` with the `INSTALL_FAILED → ROLLBACK_FAILED` verb remap; a GC'd snapshot returns the distinct `ErrHomeSnapshotMissing`.
- **`rollback` command**: `--enable-restore` opt-in; validate-before-mutate; supports config-only target generations (no native anchor); appends one combined rollback generation recording the reverted config. Stays package/realizer-only — no `internal/restore` import (`TestRollbackStaysPackageOnly` green).
- **CLI**: `--enable-restore` wired into `rollback` + usage text (protected area, additive).
- **OpenSpec**: new `nix-home-manager-rollback` spec (7 requirements).

## Verification

- `go test ./...` (Linux) green; `GOOS=windows go build ./...` + `go vet ./...` clean; `npm run openspec:validate` strict 61/61.
- 17 new hermetic tests (6 realizer + 11 command), all RED-first.
- **Real-nix e2e** (sandbox `$HOME`/`ENDSTATE_ROOT`, hm pin `git+file://…/home-manager`): apply config A (gen1) → apply config B (gen2) → `rollback --to 1 --enable-restore --confirm` → managed config **reverted to A** despite the wrapper dir holding B; a rollback-marked gen3 recording the home ref was appended. Real `$HOME` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)