### PR TITLE
feat(engine): capture nix package versions (store-path parsing)

### DIFF
--- a/go-engine/internal/commands/apply_realizer.go
+++ b/go-engine/internal/commands/apply_realizer.go
@@ -204,6 +204,10 @@ func runApplyRealizer(flags ApplyFlags, mf *manifest.Manifest, r realizer.Realiz
 		return nil, envelope.NewError(envelope.ErrInternalError, "Failed to plan the package set.")
 	}
 
+	// Read the current set once so we can extract installed versions for
+	// already-present packages (best-effort; ignored on error).
+	curSet, _ := r.Current()
+
 	present := map[string]bool{} // app.ID -> already present
 	for _, ins := range diff.Present {
 		present[ins.ID] = true
@@ -234,6 +238,10 @@ func runApplyRealizer(flags ApplyFlags, mf *manifest.Manifest, r realizer.Realiz
 			a := ApplyAction{ID: e.app.ID, Ref: stringPtr(ref), Driver: driverName, Name: e.name}
 			if present[e.app.ID] {
 				a.Status, a.Reason = "present", "already_installed"
+				// Best-effort: parse the installed version from the current set.
+				if el, ok := curSet.Elements[e.app.ID]; ok {
+					a.Version = nix.StorePathVersion(el.Name, el.StorePaths)
+				}
 				emitter.EmitItem(ref, driverName, "present", "already_installed", "Already installed", e.name)
 				presentCount++
 			} else {
@@ -339,6 +347,10 @@ func runApplyRealizer(flags ApplyFlags, mf *manifest.Manifest, r realizer.Realiz
 				emitter.EmitItem(ins.Ref, driverName, "installed", "", "Installed", names[ins.ID])
 				if i, ok := idx[ins.ID]; ok {
 					actions[i].Status, actions[i].Reason = "installed", ""
+					// Best-effort: parse the installed version from the post-realize set.
+					if el, ok := res.After.Elements[ins.ID]; ok {
+						actions[i].Version = nix.StorePathVersion(el.Name, el.StorePaths)
+					}
 				}
 				successCount++
 			}

--- a/go-engine/internal/commands/apply_realizer_test.go
+++ b/go-engine/internal/commands/apply_realizer_test.go
@@ -908,3 +908,176 @@ func TestRunApply_WingetPath_ConfigNeverGenerates(t *testing.T) {
 		t.Fatalf("winget path generated a home-manager flake dir (err=%v); it must never generate", err)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Version capture: store-path version → ProvItem.Version
+// ---------------------------------------------------------------------------
+
+// nixElementWithStorePath builds a realizer.Element whose store path encodes
+// the given version, so the parser can extract it.
+func nixElementWithStorePath(name, version string) realizer.Element {
+	return realizer.Element{
+		Name:     name,
+		AttrPath: "legacyPackages.x86_64-linux." + name,
+		// 32-char lowercase base32 hash + name + version.
+		StorePaths: []string{
+			"/nix/store/2rwsbbpn5p76jf35rv7cb9qlhpxnp83p-" + name + "-" + version,
+		},
+	}
+}
+
+// TestRunApplyRealizer_VersionCapture_PresentPackage: when one package is
+// present and another is installed, the generation records versions for both.
+func TestRunApplyRealizer_VersionCapture_PresentPackage(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	appPresent := nixApp("ripgrep", "nixpkgs#ripgrep")
+	appNew := nixApp("jq", "nixpkgs#jq")
+	mf := nixManifest(appPresent, appNew)
+
+	insPresent := realizer.Installable{ID: "ripgrep", Ref: hostRef(appPresent)}
+	insNew := realizer.Installable{ID: "jq", Ref: hostRef(appNew)}
+
+	currentElements := map[string]realizer.Element{
+		"ripgrep": nixElementWithStorePath("ripgrep", "14.1.0"),
+	}
+	afterElements := map[string]realizer.Element{
+		"ripgrep": nixElementWithStorePath("ripgrep", "14.1.0"),
+		"jq":      nixElementWithStorePath("jq", "1.8.1"),
+	}
+	fr := &fakeRealizer{
+		currentSet: realizer.Set{Generation: 1, Elements: currentElements},
+		planDiff: realizer.Diff{
+			Present: []realizer.Installable{insPresent},
+			ToAdd:   []realizer.Installable{insNew},
+		},
+		realizeResult: realizer.Result{
+			Advanced:       true,
+			FromGeneration: 1,
+			ToGeneration:   2,
+			After:          realizer.Set{Generation: 2, Elements: afterElements},
+		},
+	}
+
+	flags := ApplyFlags{Manifest: "nix-test", DryRun: false}
+	_, eerr := runApplyRealizer(flags, mf, fr, noopEmitter(), "run-ver1", nil, nil)
+	if eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+
+	gens, _ := provision.List()
+	if len(gens) != 1 {
+		t.Fatalf("want 1 generation, got %d", len(gens))
+	}
+	for _, item := range gens[0].Items {
+		switch item.ID {
+		case "ripgrep":
+			if item.Version != "14.1.0" {
+				t.Errorf("present ripgrep ProvItem.Version = %q, want 14.1.0", item.Version)
+			}
+		case "jq":
+			if item.Version != "1.8.1" {
+				t.Errorf("installed jq ProvItem.Version = %q, want 1.8.1", item.Version)
+			}
+		}
+	}
+}
+
+// TestRunApplyRealizer_VersionCapture_InstalledPackage: a newly-installed
+// package gets its store-path version recorded in the Provisioning Generation.
+func TestRunApplyRealizer_VersionCapture_InstalledPackage(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	app := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := nixManifest(app)
+
+	ins := realizer.Installable{ID: "ripgrep", Ref: hostRef(app)}
+	afterSet := realizer.Set{
+		Generation: 2,
+		Elements: map[string]realizer.Element{
+			"ripgrep": nixElementWithStorePath("ripgrep", "14.1.0"),
+		},
+	}
+	fr := &fakeRealizer{
+		currentSet: realizer.Set{Generation: 1, Elements: map[string]realizer.Element{}},
+		planDiff:   realizer.Diff{ToAdd: []realizer.Installable{ins}},
+		realizeResult: realizer.Result{
+			Advanced:       true,
+			FromGeneration: 1,
+			ToGeneration:   2,
+			After:          afterSet,
+		},
+	}
+
+	flags := ApplyFlags{Manifest: "nix-test", DryRun: false}
+	_, eerr := runApplyRealizer(flags, mf, fr, noopEmitter(), "run-ver2", nil, nil)
+	if eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+
+	gens, _ := provision.List()
+	if len(gens) != 1 {
+		t.Fatalf("want 1 generation, got %d", len(gens))
+	}
+	var item *provision.ProvItem
+	for i := range gens[0].Items {
+		if gens[0].Items[i].ID == "ripgrep" {
+			item = &gens[0].Items[i]
+			break
+		}
+	}
+	if item == nil {
+		t.Fatal("no ripgrep item in generation")
+	}
+	if item.Version != "14.1.0" {
+		t.Errorf("ProvItem.Version = %q, want 14.1.0", item.Version)
+	}
+}
+
+// TestRunApplyRealizer_VersionCapture_EmptyStorePaths: an element with no store
+// paths records an empty version, and the run does NOT fail.
+func TestRunApplyRealizer_VersionCapture_EmptyStorePaths(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	app := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := nixManifest(app)
+
+	ins := realizer.Installable{ID: "ripgrep", Ref: hostRef(app)}
+	afterSet := realizer.Set{
+		Generation: 2,
+		Elements: map[string]realizer.Element{
+			"ripgrep": {Name: "ripgrep", AttrPath: "legacyPackages.x86_64-linux.ripgrep", StorePaths: []string{}},
+		},
+	}
+	fr := &fakeRealizer{
+		currentSet: realizer.Set{Generation: 1, Elements: map[string]realizer.Element{}},
+		planDiff:   realizer.Diff{ToAdd: []realizer.Installable{ins}},
+		realizeResult: realizer.Result{
+			Advanced:       true,
+			FromGeneration: 1,
+			ToGeneration:   2,
+			After:          afterSet,
+		},
+	}
+
+	flags := ApplyFlags{Manifest: "nix-test", DryRun: false}
+	_, eerr := runApplyRealizer(flags, mf, fr, noopEmitter(), "run-ver3", nil, nil)
+	if eerr != nil {
+		t.Fatalf("empty store paths must not fail apply: %v", eerr)
+	}
+
+	gens, _ := provision.List()
+	if len(gens) != 1 {
+		t.Fatalf("want 1 generation, got %d", len(gens))
+	}
+	var item *provision.ProvItem
+	for i := range gens[0].Items {
+		if gens[0].Items[i].ID == "ripgrep" {
+			item = &gens[0].Items[i]
+			break
+		}
+	}
+	if item == nil {
+		t.Fatal("no ripgrep item in generation")
+	}
+	if item.Version != "" {
+		t.Errorf("ProvItem.Version = %q, want empty when no store paths", item.Version)
+	}
+}

--- a/go-engine/internal/commands/capture.go
+++ b/go-engine/internal/commands/capture.go
@@ -126,15 +126,17 @@ var loadModuleCatalogFn = func(repoRoot string) (map[string]*modules.Module, err
 // capturedApp is an internal representation of a captured application entry
 // before it is written to the output manifest.
 type capturedApp struct {
-	ID   string            `json:"id"`
-	Refs map[string]string `json:"refs"`
-	Name string            `json:"_name,omitempty"`
+	ID      string            `json:"id"`
+	Refs    map[string]string `json:"refs"`
+	Version string            `json:"version,omitempty"`
+	Name    string            `json:"_name,omitempty"`
 }
 
 // cleanApp is the sanitized version of capturedApp without underscore-prefixed fields.
 type cleanApp struct {
-	ID   string            `json:"id"`
-	Refs map[string]string `json:"refs"`
+	ID      string            `json:"id"`
+	Refs    map[string]string `json:"refs"`
+	Version string            `json:"version,omitempty"`
 }
 
 // captureManifestOutput is the manifest structure written to disk.

--- a/go-engine/internal/commands/capture_realizer.go
+++ b/go-engine/internal/commands/capture_realizer.go
@@ -17,6 +17,7 @@ import (
 	"github.com/Artexis10/endstate/go-engine/internal/manifest"
 	"github.com/Artexis10/endstate/go-engine/internal/provision"
 	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer/nix"
 )
 
 // listGenerationsFn reads the provisioning generations (newest-first). It
@@ -63,10 +64,12 @@ func runCaptureRealizer(flags CaptureFlags, r realizer.Realizer, emitter *events
 	for _, name := range names {
 		el := cur.Elements[name]
 		ref := el.Name // bare attr -> apply's ResolveInstallable expands against the pin
+		ver := nix.StorePathVersion(el.Name, el.StorePaths)
 		captured = append(captured, capturedApp{
-			ID:   name,
-			Refs: map[string]string{goos: ref},
-			Name: name,
+			ID:      name,
+			Refs:    map[string]string{goos: ref},
+			Name:    name,
+			Version: ver,
 		})
 		emitter.EmitItem(ref, driverName, "captured", "", fmt.Sprintf("Captured %s", name), name)
 	}
@@ -102,7 +105,7 @@ func runCaptureRealizer(flags CaptureFlags, r realizer.Realizer, emitter *events
 	if flags.Sanitize {
 		sorted := make([]cleanApp, len(captured))
 		for i, app := range captured {
-			sorted[i] = cleanApp{ID: app.ID, Refs: app.Refs}
+			sorted[i] = cleanApp{ID: app.ID, Refs: app.Refs, Version: app.Version}
 		}
 		sort.Slice(sorted, func(i, j int) bool { return sorted[i].ID < sorted[j].ID })
 		outputApps = sorted

--- a/go-engine/internal/commands/capture_realizer_test.go
+++ b/go-engine/internal/commands/capture_realizer_test.go
@@ -26,14 +26,17 @@ import (
 // bare attr (its map key, as `nix profile list` reports a nixpkgs install) while
 // AttrPath carries a realistic, system-qualified path that DIFFERS from Name —
 // so a test asserting the emitted ref equals Name proves we emit the portable
-// bare attr, not the arch-baked AttrPath.
+// bare attr, not the arch-baked AttrPath. The store path uses a valid 32-char
+// base32 hash and encodes version "1.0.0" so version-capture tests can assert
+// the parsed version.
 func nixSet(names ...string) realizer.Set {
 	els := map[string]realizer.Element{}
 	for _, n := range names {
 		els[n] = realizer.Element{
-			Name:       n,
-			AttrPath:   "legacyPackages.x86_64-linux." + n,
-			StorePaths: []string{"/nix/store/0000000000000000000000000000-" + n + "-1.0.0"},
+			Name:     n,
+			AttrPath: "legacyPackages.x86_64-linux." + n,
+			// 32-char base32 hash (all zeros is valid base32) + name + version.
+			StorePaths: []string{"/nix/store/00000000000000000000000000000000-" + n + "-1.0.0"},
 		}
 	}
 	return realizer.Set{Generation: 1, Elements: els}
@@ -156,8 +159,9 @@ func TestRunCaptureRealizer_EmitsBareAttrHostKeyedRefs(t *testing.T) {
 		if len(a.Refs) != 1 {
 			t.Errorf("app %q: expected exactly the host ref, got %+v", a.ID, a.Refs)
 		}
-		if a.Version != "" {
-			t.Errorf("app %q: version = %q, want empty (out of scope)", a.ID, a.Version)
+		// Version is now populated from the store path ("1.0.0" in the nixSet fixture).
+		if a.Version != "1.0.0" {
+			t.Errorf("app %q: version = %q, want 1.0.0 (parsed from store path)", a.ID, a.Version)
 		}
 	}
 }
@@ -501,5 +505,85 @@ func TestRunCaptureRealizer_FlakeDeclared_StillEmitsFlake(t *testing.T) {
 	}
 	if mf.HomeManager.Config != "" {
 		t.Errorf("flake apply must not emit a config, got config=%q", mf.HomeManager.Config)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Version capture (store-path parsing)
+// ---------------------------------------------------------------------------
+
+// nixSetWithVersion builds a realizer.Set where each element has a store path
+// encoding a specific version, for version-capture assertions.
+func nixSetWithVersion(name, version string) realizer.Set {
+	return realizer.Set{
+		Generation: 1,
+		Elements: map[string]realizer.Element{
+			name: {
+				Name:     name,
+				AttrPath: "legacyPackages.x86_64-linux." + name,
+				StorePaths: []string{
+					"/nix/store/2rwsbbpn5p76jf35rv7cb9qlhpxnp83p-" + name + "-" + version,
+				},
+			},
+		},
+	}
+}
+
+// nixSetNoStorePaths builds a realizer.Set where the element has no store paths,
+// simulating the case where store-path version parsing yields "".
+func nixSetNoStorePaths(name string) realizer.Set {
+	return realizer.Set{
+		Generation: 1,
+		Elements: map[string]realizer.Element{
+			name: {
+				Name:       name,
+				AttrPath:   "legacyPackages.x86_64-linux." + name,
+				StorePaths: []string{},
+			},
+		},
+	}
+}
+
+// Version is parsed from the store path and emitted into the captured manifest
+// App.Version field.
+func TestRunCaptureRealizer_Version_PopulatedFromStorePath(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "ver.jsonc")
+	fr := &fakeRealizer{currentSet: nixSetWithVersion("ripgrep", "14.1.0")}
+
+	_, eerr := runCaptureRealizer(CaptureFlags{Out: out}, fr, noopEmitter())
+	if eerr != nil {
+		t.Fatalf("runCaptureRealizer returned envelope error: %+v", eerr)
+	}
+
+	mf := readCapturedManifest(t, out)
+	if len(mf.Apps) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(mf.Apps))
+	}
+	if mf.Apps[0].Version != "14.1.0" {
+		t.Errorf("app version = %q, want 14.1.0", mf.Apps[0].Version)
+	}
+}
+
+// When the element has no store paths, the captured App.Version is empty and
+// the run does NOT fail.
+func TestRunCaptureRealizer_Version_EmptyWhenNoStorePaths(t *testing.T) {
+	out := filepath.Join(t.TempDir(), "nover.jsonc")
+	fr := &fakeRealizer{currentSet: nixSetNoStorePaths("ripgrep")}
+
+	raw, eerr := runCaptureRealizer(CaptureFlags{Out: out}, fr, noopEmitter())
+	if eerr != nil {
+		t.Fatalf("runCaptureRealizer returned envelope error: %+v", eerr)
+	}
+	res := raw.(*CaptureResult)
+	if res.Counts.Included != 1 {
+		t.Errorf("Counts.Included = %d, want 1", res.Counts.Included)
+	}
+
+	mf := readCapturedManifest(t, out)
+	if len(mf.Apps) != 1 {
+		t.Fatalf("expected 1 app, got %d", len(mf.Apps))
+	}
+	if mf.Apps[0].Version != "" {
+		t.Errorf("app version = %q, want empty when no store paths", mf.Apps[0].Version)
 	}
 }

--- a/go-engine/internal/realizer/nix/versions.go
+++ b/go-engine/internal/realizer/nix/versions.go
@@ -1,0 +1,166 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package nix
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// knownOutputSuffixes is the set of Nix output names that appear as trailing
+// dash-separated tokens in a store-path base name and are NOT part of the
+// version. A token that matches one of these terminates the version scan.
+var knownOutputSuffixes = map[string]bool{
+	"bin":     true,
+	"dev":     true,
+	"doc":     true,
+	"lib":     true,
+	"man":     true,
+	"etc":     true,
+	"info":    true,
+	"out":     true,
+	"small":   true,
+	"debug":   true,
+	"light":   true,
+	"full":    true,
+	"wrapped": true,
+	"static":  true,
+	"shared":  true,
+	"data":    true,
+	"locale":  true,
+}
+
+// StorePathVersion extracts the package version from an element's Nix store
+// paths. It prefers a store path whose base starts with the exact element name
+// (i.e. no output suffix appended to the name), falling back to the first
+// path that yields a non-empty version. Returns "" when no version can be
+// parsed; never returns an error or panics.
+//
+// Store-path format: /nix/store/<32-hex-hash>-<name>-<version>[-output]
+// Examples:
+//
+//	/nix/store/2rwsbbpn5p76jf35rv7cb9qlhpxnp83p-ripgrep-14.1.0
+//	/nix/store/0b4y5p2qadabfmjmr2zczbzjfvpjydrq-ripgrep-14.1.0-man
+func StorePathVersion(name string, storePaths []string) string {
+	if name == "" || len(storePaths) == 0 {
+		return ""
+	}
+
+	// Two-pass: first pass collects exact-name matches (path base starts with
+	// hash-name-version, no output suffix); second pass uses any path that
+	// yields a version as a fallback.
+	var fallback string
+	for _, sp := range storePaths {
+		ver := parseStorePathVersion(name, sp)
+		if ver == "" {
+			continue
+		}
+		// Check whether this is an exact-name path (no output suffix appended
+		// to name): the base, after stripping hash, starts with "<name>-<ver>"
+		// and the version scan consumed the entire remainder without a suffix.
+		if isExactNamePath(name, sp) {
+			return ver
+		}
+		if fallback == "" {
+			fallback = ver
+		}
+	}
+	return fallback
+}
+
+// isExactNamePath reports whether the store path is the "base" output for the
+// element — i.e. the base name after stripping the hash prefix starts exactly
+// with "<name>-" and the remainder after the version tokens contains no known
+// output suffix. This distinguishes "/nix/store/<h>-ripgrep-14.1.0" from
+// "/nix/store/<h>-ripgrep-14.1.0-bin".
+func isExactNamePath(name, storePath string) bool {
+	base := filepath.Base(storePath)
+	rest, ok := stripHashPrefix(base)
+	if !ok {
+		return false
+	}
+	prefix := name + "-"
+	if !strings.HasPrefix(rest, prefix) {
+		return false
+	}
+	afterName := rest[len(prefix):]
+	// Tokenize and check: the last token should NOT be a known output suffix.
+	tokens := strings.Split(afterName, "-")
+	if len(tokens) == 0 {
+		return false
+	}
+	last := tokens[len(tokens)-1]
+	return !knownOutputSuffixes[last]
+}
+
+// parseStorePathVersion extracts the version from a single store path, given
+// the element name. Returns "" when the path does not follow the expected
+// format or does not contain the given name prefix.
+func parseStorePathVersion(name, storePath string) string {
+	base := filepath.Base(storePath)
+
+	// Strip the 32-char lowercase hex hash and the following dash.
+	rest, ok := stripHashPrefix(base)
+	if !ok {
+		return ""
+	}
+
+	// Strip the element name and the following dash.
+	prefix := name + "-"
+	if !strings.HasPrefix(rest, prefix) {
+		return ""
+	}
+	versionPart := rest[len(prefix):]
+	if versionPart == "" {
+		return ""
+	}
+
+	return extractVersion(versionPart)
+}
+
+// stripHashPrefix strips the leading "<32-char-nix-base32>-" prefix from a
+// store-path base name. Nix store hashes are 32 lowercase base32 characters
+// ([0-9a-z]); they are NOT hex. Returns the remainder and true on success;
+// "", false when the prefix is absent or malformed.
+func stripHashPrefix(base string) (string, bool) {
+	const hashLen = 32
+	if len(base) < hashLen+1 {
+		return "", false
+	}
+	hash := base[:hashLen]
+	if base[hashLen] != '-' {
+		return "", false
+	}
+	for _, c := range hash {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z')) {
+			return "", false
+		}
+	}
+	return base[hashLen+1:], true
+}
+
+// extractVersion scans the token string (everything after "<hash>-<name>-")
+// and collects version tokens. A token that is a known output suffix
+// terminates the scan. A token that starts with a digit is always part of
+// the version. A token that does not start with a digit and is a known output
+// suffix terminates; otherwise it is included (handles pre-release labels like
+// "alpha", "beta", "rc1").
+func extractVersion(s string) string {
+	if s == "" {
+		return ""
+	}
+	tokens := strings.Split(s, "-")
+	var versionTokens []string
+	for _, tok := range tokens {
+		if tok == "" {
+			continue
+		}
+		if knownOutputSuffixes[tok] {
+			// Stop at a known output suffix.
+			break
+		}
+		versionTokens = append(versionTokens, tok)
+	}
+	return strings.Join(versionTokens, "-")
+}

--- a/go-engine/internal/realizer/nix/versions_test.go
+++ b/go-engine/internal/realizer/nix/versions_test.go
@@ -1,0 +1,184 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package nix
+
+import "testing"
+
+// TestStorePathVersion covers the realistic store-path shapes emitted by
+// `nix profile list --json`. The parser is pure (no I/O) and best-effort:
+// an unparseable path must return "" and never panic or error.
+
+// Simple case: single store path, version immediately after hash+name.
+func TestStorePathVersion_Simple(t *testing.T) {
+	got := StorePathVersion("ripgrep", []string{
+		"/nix/store/2rwsbbpn5p76jf35rv7cb9qlhpxnp83p-ripgrep-14.1.0",
+	})
+	if got != "14.1.0" {
+		t.Errorf("simple: got %q, want 14.1.0", got)
+	}
+}
+
+// Output suffix -bin: version is before the known suffix.
+func TestStorePathVersion_BinSuffix(t *testing.T) {
+	got := StorePathVersion("ripgrep", []string{
+		"/nix/store/abc1234567890abcdef1234567890abc-ripgrep-14.1.0-bin",
+	})
+	if got != "14.1.0" {
+		t.Errorf("bin suffix: got %q, want 14.1.0", got)
+	}
+}
+
+// Output suffix -man: version is before the known suffix.
+func TestStorePathVersion_ManSuffix(t *testing.T) {
+	got := StorePathVersion("ripgrep", []string{
+		"/nix/store/abc1234567890abcdef1234567890abc-ripgrep-14.1.0-man",
+	})
+	if got != "14.1.0" {
+		t.Errorf("man suffix: got %q, want 14.1.0", got)
+	}
+}
+
+// Output suffix -dev.
+func TestStorePathVersion_DevSuffix(t *testing.T) {
+	got := StorePathVersion("openssl", []string{
+		"/nix/store/abc1234567890abcdef1234567890abc-openssl-3.3.1-dev",
+	})
+	if got != "3.3.1" {
+		t.Errorf("dev suffix: got %q, want 3.3.1", got)
+	}
+}
+
+// Output suffix -doc.
+func TestStorePathVersion_DocSuffix(t *testing.T) {
+	got := StorePathVersion("openssl", []string{
+		"/nix/store/abc1234567890abcdef1234567890abc-openssl-3.3.1-doc",
+	})
+	if got != "3.3.1" {
+		t.Errorf("doc suffix: got %q, want 3.3.1", got)
+	}
+}
+
+// Multi-segment version with a non-output trailing segment (like git's windows cross-version).
+func TestStorePathVersion_MultiSegment(t *testing.T) {
+	// git has versions like "2.43.0" — just confirm parsing works on a longer version.
+	got := StorePathVersion("git", []string{
+		"/nix/store/abc1234567890abcdef1234567890abc-git-2.43.0",
+	})
+	if got != "2.43.0" {
+		t.Errorf("multi-segment: got %q, want 2.43.0", got)
+	}
+}
+
+// Date-based version: tokens are numeric, all treated as version parts.
+func TestStorePathVersion_DateVersion(t *testing.T) {
+	got := StorePathVersion("some-package", []string{
+		"/nix/store/abc1234567890abcdef1234567890abc-some-package-2025-04-01",
+	})
+	if got != "2025-04-01" {
+		t.Errorf("date version: got %q, want 2025-04-01", got)
+	}
+}
+
+// Multi-path: prefers the exact-name path (no output suffix) over a -bin path.
+func TestStorePathVersion_MultiPath_PrefersExactName(t *testing.T) {
+	got := StorePathVersion("ripgrep", []string{
+		"/nix/store/abc1234567890abcdef1234567890abc-ripgrep-14.1.0-bin",
+		"/nix/store/2rwsbbpn5p76jf35rv7cb9qlhpxnp83p-ripgrep-14.1.0",
+	})
+	if got != "14.1.0" {
+		t.Errorf("multi-path prefer base: got %q, want 14.1.0", got)
+	}
+}
+
+// Multi-path: when only a suffixed path exists, still extracts the version.
+func TestStorePathVersion_MultiPath_OnlySuffixed(t *testing.T) {
+	got := StorePathVersion("ripgrep", []string{
+		"/nix/store/abc1234567890abcdef1234567890abc-ripgrep-14.1.0-bin",
+		"/nix/store/def1234567890abcdef1234567890abc-ripgrep-14.1.0-man",
+	})
+	if got != "14.1.0" {
+		t.Errorf("multi-path only suffixed: got %q, want 14.1.0", got)
+	}
+}
+
+// Name mismatch: no path contains the element name — fallback to first parseable.
+func TestStorePathVersion_NameMismatch_Fallback(t *testing.T) {
+	// Element name "foo" but store path has "bar-1.2.3"; should fall back.
+	got := StorePathVersion("foo", []string{
+		"/nix/store/abc1234567890abcdef1234567890abc-bar-1.2.3",
+	})
+	// Fallback: strip hash, then find first version-like token after the first dash.
+	// Since name "foo" is not a prefix, the fallback path is taken.
+	// The parser should return "" since it can't strip the "foo-" prefix from "bar-1.2.3".
+	if got != "" {
+		t.Errorf("name mismatch: got %q, want empty (no match)", got)
+	}
+}
+
+// Unparseable: hash is not 32 hex chars.
+func TestStorePathVersion_InvalidHash_ReturnsEmpty(t *testing.T) {
+	got := StorePathVersion("ripgrep", []string{
+		"/nix/store/tooshort-ripgrep-14.1.0",
+	})
+	if got != "" {
+		t.Errorf("invalid hash: got %q, want empty", got)
+	}
+}
+
+// Empty store paths → empty version, no panic.
+func TestStorePathVersion_EmptyPaths_ReturnsEmpty(t *testing.T) {
+	got := StorePathVersion("ripgrep", []string{})
+	if got != "" {
+		t.Errorf("empty paths: got %q, want empty", got)
+	}
+}
+
+// Nil store paths → empty version, no panic.
+func TestStorePathVersion_NilPaths_ReturnsEmpty(t *testing.T) {
+	got := StorePathVersion("ripgrep", nil)
+	if got != "" {
+		t.Errorf("nil paths: got %q, want empty", got)
+	}
+}
+
+// Empty name → fallback parsing (name prefix can't match); should not panic.
+func TestStorePathVersion_EmptyName_ReturnsEmpty(t *testing.T) {
+	got := StorePathVersion("", []string{
+		"/nix/store/2rwsbbpn5p76jf35rv7cb9qlhpxnp83p-ripgrep-14.1.0",
+	})
+	// Empty name means we can't strip a name prefix; returns "".
+	if got != "" {
+		t.Errorf("empty name: got %q, want empty", got)
+	}
+}
+
+// jq: single version with no suffix.
+func TestStorePathVersion_Jq(t *testing.T) {
+	got := StorePathVersion("jq", []string{
+		"/nix/store/def1234567890abcdef1234567890abc-jq-1.8.1",
+	})
+	if got != "1.8.1" {
+		t.Errorf("jq: got %q, want 1.8.1", got)
+	}
+}
+
+// A version with a -lib suffix (common for libraries).
+func TestStorePathVersion_LibSuffix(t *testing.T) {
+	got := StorePathVersion("openssl", []string{
+		"/nix/store/abc1234567890abcdef1234567890abc-openssl-3.3.1-lib",
+	})
+	if got != "3.3.1" {
+		t.Errorf("lib suffix: got %q, want 3.3.1", got)
+	}
+}
+
+// Package with a hyphenated name: "fd-find" should still work.
+func TestStorePathVersion_HyphenatedName(t *testing.T) {
+	got := StorePathVersion("fd-find", []string{
+		"/nix/store/abc1234567890abcdef1234567890abc-fd-find-10.2.0",
+	})
+	if got != "10.2.0" {
+		t.Errorf("hyphenated name: got %q, want 10.2.0", got)
+	}
+}

--- a/openspec/changes/nix-package-version-capture/.openspec.yaml
+++ b/openspec/changes/nix-package-version-capture/.openspec.yaml
@@ -1,0 +1,10 @@
+id: nix-package-version-capture
+title: "Nix Package Version Capture: parse store-path versions and record them"
+status: implementing
+spec: nix-package-version-capture
+created: "2026-06-02"
+author: Hugo Ander Kivi
+artifacts:
+  - proposal.md
+  - design.md
+  - tasks.md

--- a/openspec/changes/nix-package-version-capture/design.md
+++ b/openspec/changes/nix-package-version-capture/design.md
@@ -1,0 +1,120 @@
+## Context
+
+The Nix realizer capture path (`runCaptureRealizer`) already emits each installed element as a
+`capturedApp{ID, Refs, Name}`. The `manifest.App` struct has a `Version string` field
+(`json:"version,omitempty"`) that the winget path uses for declared-version pinning and that
+capture can populate to enable round-trip version pinning on re-apply. The `provision.ProvItem`
+struct has `Version string` (best-effort, always `""` on the Nix path today).
+
+Every Nix profile element has `StorePaths []string` populated by `parseProfileList`. A real
+install yields paths like:
+
+```
+/nix/store/2rwsbbpn5p76jf35rv7cb9qlhpxnp83p-ripgrep-14.1.0
+/nix/store/0b4y5p2qadabfmjmr2zczbzjfvpjydrq-ripgrep-14.1.0-man
+```
+
+The version is always the token between `<name>-` and the end (or a known output suffix like
+`-bin`, `-man`, `-dev`, `-doc`, `-lib`, `-etc`, `-info`, `-out`). The hash prefix is always 32
+lowercase hex chars followed by `-`.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Parse the version from `StorePaths` without any additional CLI call.
+- Record parsed version in `ProvItem.Version` (Provisioning Generation) on the Nix apply path.
+- Emit parsed version into `manifest.App.Version` in the captured manifest so re-apply can pin it.
+- Best-effort: unparseable store path → empty string, never fails the run.
+
+**Non-Goals:**
+- No version pinning on the Nix apply path (Nix pins via its ref/flakeref, not per-app version).
+  `App.Version` on the Nix path is informational only — `apply_realizer.go` never reads it.
+- No winget capture changes; home-manager paths unchanged.
+- No new realizer interface methods (`StorePathVersion` is a pure package-level function).
+
+## Decisions
+
+- **Parser placement**: `internal/realizer/nix/versions.go` (package `nix`), a pure function
+  `StorePathVersion(name string, storePaths []string) string`. No interface change.
+- **Store path format**: strip the 32-char hex hash prefix + `-`, strip the element name + `-`,
+  take the leading version token (up to the next `-` that begins a known output suffix or until
+  end). Prefer the store path whose base starts with `<hash>-<name>-` (exact name match); fall
+  back to any path when no exact match.
+- **Output suffix handling**: known suffixes treated as non-version segment starts: `-bin`,
+  `-man`, `-dev`, `-doc`, `-lib`, `-etc`, `-info`, `-out`, `-small`, `-debug`, `-light`,
+  `-full`, `-wrapped`. A segment starting with a digit is part of the version.
+- **Apply path**: after `Realize` returns, re-read `Current()` (already done) and for each
+  element in the resulting set whose ID matches an action, call `StorePathVersion` and set
+  `action.Version`. Already-present actions get their version from `Current()` before the
+  install phase (they are in the set already).
+
+## Design
+
+### `internal/realizer/nix/versions.go`
+
+```go
+// StorePathVersion extracts the version from element store paths.
+// It prefers the path whose base starts with "<hash>-<name>-" (exact name
+// match), falling back to the first parseable path. Returns "" on parse miss.
+func StorePathVersion(name string, storePaths []string) string
+```
+
+Algorithm:
+1. For each store path, call `parseStorePathVersion(name, path)`.
+2. Return the first non-empty result from a path whose base starts with
+   `<32hex>-<name>-` (exact-name match), then first non-empty from any path.
+3. Return "" if no path yields a version.
+
+`parseStorePathVersion(name, path) string`:
+1. Base = `filepath.Base(path)`.
+2. Strip the 32-char lowercase hex hash + `-` prefix. If the base does not match
+   `[0-9a-f]{32}-<rest>`, return "".
+3. Strip the element name + `-` prefix from `rest`. If `rest` does not start with
+   `name + "-"`, return "" (not an exact-name path — caller handles fallback).
+4. `versionPart = rest[len(name)+1:]`. Take the leading version segment: scan
+   forward while the current `-`-delimited token starts with a digit or is part of
+   a version-looking token (e.g. `14`, `1.0.0`, `2025-04-01`). Stop when a token
+   is a known output suffix.
+5. Return the joined version tokens.
+
+### `capture_realizer.go`
+
+In the emit loop, after building `el = cur.Elements[name]`:
+
+```go
+version := nix.StorePathVersion(el.Name, el.StorePaths)
+captured = append(captured, capturedApp{
+    ID:      name,
+    Refs:    map[string]string{goos: ref},
+    Name:    name,
+    Version: version,
+})
+```
+
+`capturedApp` gains `Version string \`json:"version,omitempty"\``.
+`cleanApp` gains the same field so sanitized output also carries it.
+
+### `apply_realizer.go`
+
+After the present-check loop (Phase 1: Plan), for each `present` entry, look up the element in
+`cur` (read once via `r.Current()` before the loop, as already done for the plan diff) and set
+`action.Version = nix.StorePathVersion(e.ins.Ref_leaf, el.StorePaths)`.
+
+After Phase 2 (Realize succeeds), for each newly-installed entry, look up the element in
+`res.After` and set `action.Version`.
+
+This flows to `ProvItem.Version` via the existing `writeProvisioningGeneration`.
+
+## Risks / Verification
+
+- **Store-path name segment**: if the element `Name` differs from the store-path base name
+  segment (rare for nixpkgs packages), the exact-match fails and the fallback picks the first
+  parseable path. The version is still best-effort correct.
+- **Multi-version store paths**: an element can have multiple store paths (e.g. `ripgrep-14.1.0`
+  and `ripgrep-14.1.0-man`). The exact-match preference picks the base output path (no suffix),
+  which is the most stable.
+- **Date-versioned packages**: some packages use `YYYY-MM-DD` versions. The parser treats
+  `-`-separated numeric tokens as part of the version, so `2025-04-01` parses correctly.
+- **Real-nix smoke**: coordinator applies 2-3 packages → captures → asserts `App.Version`
+  non-empty and `ProvItem.Version` non-empty in the generation; confirms the store-path format
+  matches the parser assumptions.

--- a/openspec/changes/nix-package-version-capture/proposal.md
+++ b/openspec/changes/nix-package-version-capture/proposal.md
@@ -1,0 +1,52 @@
+## Why
+
+`capture` on the Nix realizer path (Linux/macOS) already reads the installed set and emits each
+element as a manifest app. It does NOT capture versions. On the winget path, `DetectBatch` populates
+`DetectResult.Version` from the `winget list` output → `ApplyAction.Version` → `ProvItem.Version`,
+and the captured manifest app can carry a `version` field so an `apply` can pin the exact version.
+
+The Nix store path already encodes the package version — every element's `StorePaths` contains
+paths of the form `/nix/store/<32-char-hash>-<name>-<version>[-output]`. This version is
+machine-readable without any additional Nix CLI calls.
+
+This change gives the Nix capture path version-capture parity with winget:
+- Parse the installed version from the element's `StorePaths` (pure, no CLI, best-effort).
+- Record it in `ProvItem.Version` when `apply` records the Provisioning Generation.
+- Emit it into the captured manifest's `App.Version` during `capture` so a re-apply can pin the
+  same version.
+
+## What Changes
+
+- **Pure store-path version parser** in `internal/realizer/nix/` (`versions.go`). Given an
+  element's `Name` and its `StorePaths`, returns the best-effort version string. Unparseable →
+  empty string (never fails capture).
+- **`capture_realizer.go`**: populate the captured app's `Version` field from the parsed store-path
+  version, matching the winget capture shape.
+- **`apply_realizer.go`**: populate `ApplyAction.Version` for installed and present packages using
+  the same parser on the post-apply `Current()` set, so `ProvItem.Version` is recorded in the
+  Provisioning Generation.
+- **Unit tests**: thorough parser tests with realistic store-path fixtures; capture command tests
+  asserting version is recorded in the manifest and generation.
+
+## Capabilities
+
+### New Capabilities
+
+- `nix-package-version-capture`: the Nix capture path parses the installed version from each
+  element's store path and records it in the captured manifest app AND in the Provisioning
+  Generation, giving version-capture parity with winget. Version is best-effort; an unparseable
+  store path never fails the run.
+
+### Modified Capabilities
+
+- None. The winget capture path, Windows behavior, and home-manager paths are unchanged.
+
+## Impact
+
+- `internal/realizer/nix/versions.go` — **new**: `StorePathVersion(name string, storePaths []string) string`.
+- `internal/realizer/nix/versions_test.go` — **new**: comprehensive unit tests.
+- `internal/commands/capture_realizer.go` — populate `Version` on each `capturedApp`.
+- `internal/commands/apply_realizer.go` — populate `ApplyAction.Version` from the post-realize set.
+- `internal/commands/capture_realizer_test.go` — update existing test + add version assertions.
+- `internal/commands/apply_realizer_test.go` — add version-in-generation assertion.
+- **Zero winget / Windows regression.** The parser is Nix-only; winget capture is unchanged.

--- a/openspec/changes/nix-package-version-capture/specs/nix-package-version-capture/spec.md
+++ b/openspec/changes/nix-package-version-capture/specs/nix-package-version-capture/spec.md
@@ -1,0 +1,79 @@
+# nix-package-version-capture Specification
+
+## Purpose
+
+Give the Nix realizer capture path version-capture parity with the winget backend: parse the
+installed version from each element's Nix store path and record it in the captured manifest app
+and in the Provisioning Generation.
+
+## ADDED Requirements
+
+### Requirement: The Nix realizer capture path records the installed package version
+
+When `capture` runs on a host with a Nix realizer, the engine SHALL parse the installed version
+from each element's store paths and record it in the captured manifest app's `version` field,
+so a re-apply of the captured manifest can pin the exact version. A store path that does not
+yield a parseable version SHALL result in an empty version field for that app, and the run SHALL
+NOT fail.
+
+#### Scenario: Captured manifest app carries the parsed store-path version
+
+- **WHEN** `capture` runs on a realizer host and an element's store paths encode a version
+- **THEN** the captured manifest app for that element SHALL have its `version` field set to the
+  parsed version string
+
+#### Scenario: Unparseable store path does not fail capture
+
+- **WHEN** `capture` runs on a realizer host and an element's store paths do not yield a
+  parseable version
+- **THEN** the engine SHALL record an empty version for that element
+- **AND** the run SHALL NOT fail because a version was unavailable
+
+### Requirement: The Nix realizer apply path records the installed version in the Provisioning Generation
+
+The engine SHALL include the installed version of each package in the Provisioning Generation
+when `apply` runs on the Nix realizer path, by parsing the version from each element's store
+paths — matching the version-capture behavior of the winget backend. A store path that does not
+yield a parseable version SHALL result in an empty version in the generation entry, and the run
+SHALL NOT fail.
+
+#### Scenario: Provisioning Generation records the installed version for new installs
+
+- **WHEN** `apply` runs on the Nix realizer path and a package is newly installed
+- **THEN** the Provisioning Generation entry for that package SHALL record the parsed store-path
+  version (or empty if unparseable)
+
+#### Scenario: Provisioning Generation records the installed version for present packages
+
+- **WHEN** `apply` runs on the Nix realizer path and a package is already present
+- **THEN** the Provisioning Generation entry for that package SHALL record the parsed store-path
+  version (or empty if unparseable)
+
+#### Scenario: Missing store paths do not fail apply
+
+- **WHEN** `apply` runs and an element has no store paths or an unparseable store path
+- **THEN** the engine SHALL record an empty version for that package
+- **AND** the run SHALL NOT fail because a version was unavailable
+
+### Requirement: Store-path version parsing is robust and best-effort
+
+The store-path version parser SHALL handle common Nix store path shapes without failing: simple
+versions, versions with output suffixes (`-bin`, `-man`, `-dev`, `-doc`, `-lib`), multi-segment
+versions, and date-based versions. When the parser cannot extract a version it SHALL return an
+empty string rather than raising an error.
+
+#### Scenario: Parser handles output suffixes
+
+- **WHEN** an element's store path encodes a version followed by a known output suffix
+  (e.g. `-14.1.0-bin`, `-14.1.0-man`)
+- **THEN** the parser SHALL return the version without the suffix
+
+#### Scenario: Parser prefers the exact-name store path
+
+- **WHEN** an element has multiple store paths and one matches the element name exactly
+- **THEN** the parser SHALL prefer that path over others when extracting the version
+
+#### Scenario: Parser returns empty on unparseable input
+
+- **WHEN** the store path does not follow the expected `<32hex>-<name>-<version>` format
+- **THEN** the parser SHALL return an empty string and SHALL NOT return an error

--- a/openspec/changes/nix-package-version-capture/tasks.md
+++ b/openspec/changes/nix-package-version-capture/tasks.md
@@ -1,0 +1,41 @@
+> TDD: write each test RED first, then implement to green. Hermetic + host-aware (inject a fake
+> realizer via the shared `newRealizerFn` seam; key capture fixtures by `runtime.GOOS`;
+> override BOTH `newRealizerFn` AND `newDriverFn` for command tests). Isolate state with
+> `t.Setenv("ENDSTATE_ROOT", t.TempDir())`.
+> Verify: `cd go-engine && go test ./...` (green) + `GOOS=windows go build ./... && go vet ./...`
+> (clean) + `npm run openspec:validate` (strict).
+
+## 1. Pure store-path version parser
+
+- [ ] 1.1 RED tests (`internal/realizer/nix/versions_test.go`): realistic fixtures covering
+      simple (`/nix/store/<hash>-ripgrep-14.1.0`), output suffix (`-14.1.0-bin`, `-14.1.0-man`),
+      multi-segment version (`2.43.0.windows.1`), date version (`2025-04-01`), multi-path
+      (prefers exact-name match), name mismatch (fallback), and unparseable (returns "")
+- [ ] 1.2 `internal/realizer/nix/versions.go`: implement `StorePathVersion(name string, storePaths []string) string`
+
+## 2. Capture: emit version into manifest App
+
+- [ ] 2.1 Update `capturedApp` struct: add `Version string \`json:"version,omitempty"\``
+- [ ] 2.2 Update `cleanApp` struct: add `Version string \`json:"version,omitempty"\``
+- [ ] 2.3 `capture_realizer.go`: populate `Version` from `nix.StorePathVersion(el.Name, el.StorePaths)`
+- [ ] 2.4 RED+green tests in `capture_realizer_test.go`: update `nixSet` helper to include
+      realistic store paths; assert captured manifest `App.Version` matches parsed store-path version;
+      assert empty-version element still produces a valid manifest entry (no error)
+
+## 3. Apply: record version in Provisioning Generation
+
+- [ ] 3.1 `apply_realizer.go`: for `present` entries, look up element in `cur` and set
+      `action.Version = nix.StorePathVersion(...)` before the install phase
+- [ ] 3.2 `apply_realizer.go`: for newly-`installed` entries, look up element in `res.After` and
+      set `action.Version`
+- [ ] 3.3 RED+green tests in `apply_realizer_test.go`: scripted `fakeRealizer` with elements
+      carrying `StorePaths`; assert `ProvItem.Version` non-empty after apply; assert empty
+      `StorePaths` → empty version (no error)
+
+## 4. Verification
+
+- [ ] 4.1 `cd go-engine && go test ./...` green
+- [ ] 4.2 `GOOS=windows go build ./... && go vet ./...` clean
+- [ ] 4.3 `npm run openspec:validate` (strict) passes
+- [ ] 4.4 (Coordinator, real-nix) apply 2-3 packages → capture → assert `App.Version` non-empty
+      and `ProvItem.Version` non-empty in the latest generation


### PR DESCRIPTION
Gives the **Nix** capture path the version parity Windows already has (#68): the installed version is parsed from the store path and recorded into `ProvItem.version` (and the captured manifest's `App.Version`).

Part of a 3-PR parallel batch — recommended merge order **B (verify) → C (this) → D (catalog capture)**. C and D both touch `capture_realizer.go`/`apply_realizer.go`, so whichever merges second needs a trivial rebase.

## What
- New pure parser `nix.StorePathVersion(name, storePaths)` — strips the 32-char **base32** hash prefix + the package name, takes the version token, and stops at a known Nix output suffix (`-bin`/`-man`/`-dev`/…). Best-effort: unparseable → `""` (never fails capture). 17 unit tests.
- `capture` populates `App.Version`; `apply` sets `ProvItem.Version` for present + installed packages (read once from `realizer.Current()`/`Realize` results). Realizer-only; winget + home-manager capture unchanged.
- OpenSpec change `nix-package-version-capture`.

## Empirical catch
The agent's first parser used a hex hash charset; real Nix hashes are 32-char **base32** (`[0-9a-z]`). Fixed before merge.

## Verification
- `go test ./...` green; `GOOS=windows go build ./...` + `go vet` clean; `npm run openspec:validate` 62/62.
- **Real-nix smoke:** `apply [jq, ripgrep]` → real store paths `jq-1.8.1-man` (output suffix correctly stripped → `1.8.1`) and `ripgrep-15.1.0` → `capture` recorded both versions in the manifest **and** the generation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)