### PR TITLE
feat(engine): home-manager catalog capture (machine → homeManager.settings)

### DIFF
--- a/go-engine/internal/commands/apply_realizer.go
+++ b/go-engine/internal/commands/apply_realizer.go
@@ -457,8 +457,10 @@ func runApplyRealizer(flags ApplyFlags, mf *manifest.Manifest, r realizer.Realiz
 			homeRef = &provision.HomeGenRef{Flake: flake, Generation: hmGen}
 			if generated {
 				// flake is the engine-generated, machine-local wrapper; record the
-				// user's declared homeManager.config so capture can round-trip it.
+				// user's declared input (config path OR catalog settings) so capture
+				// can round-trip it. Exactly one of Config/Settings is set.
 				homeRef.Config = mf.HomeManager.Config
+				homeRef.Settings = mf.HomeManager.Settings
 			}
 			homeResult = &ApplyHomeManager{Flake: flake, Generated: generated, Activated: true}
 			emitter.EmitItem(flake, driverName, "configured", "", fmt.Sprintf("Activated home-manager generation %d", hmGen), "home-manager")

--- a/go-engine/internal/commands/capture_realizer.go
+++ b/go-engine/internal/commands/capture_realizer.go
@@ -212,9 +212,13 @@ func recoverHomeManager(flags CaptureFlags) *manifest.HomeManagerConfig {
 			if g.HomeManager == nil {
 				continue
 			}
-			// Prefer the user's declared config (a config apply records the
-			// machine-local generated flake in Flake but the portable home.nix in
-			// Config); fall back to a directly-declared flake.
+			// Prefer the user's declared catalog settings, then the declared config
+			// path (a config/settings apply records the machine-local generated flake
+			// in Flake but the portable input in Settings/Config); fall back to a
+			// directly-declared flake.
+			if g.HomeManager.Settings != nil {
+				return &manifest.HomeManagerConfig{Settings: g.HomeManager.Settings}
+			}
 			if g.HomeManager.Config != "" {
 				return &manifest.HomeManagerConfig{Config: g.HomeManager.Config}
 			}

--- a/go-engine/internal/commands/capture_realizer_test.go
+++ b/go-engine/internal/commands/capture_realizer_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/manifest"
 	"github.com/Artexis10/endstate/go-engine/internal/provision"
 	"github.com/Artexis10/endstate/go-engine/internal/realizer"
 )
@@ -50,8 +51,9 @@ type capturedManifestFile struct {
 		Version string            `json:"version"`
 	} `json:"apps"`
 	HomeManager *struct {
-		Flake  string `json:"flake"`
-		Config string `json:"config"`
+		Flake    string          `json:"flake"`
+		Config   string          `json:"config"`
+		Settings json.RawMessage `json:"settings"`
 	} `json:"homeManager"`
 }
 
@@ -82,6 +84,13 @@ func pkgGen() *provision.Generation {
 // engine actually activated.
 func hmGenConfig(config, generatedFlake string, genNum int) *provision.Generation {
 	return &provision.Generation{HomeManager: &provision.HomeGenRef{Config: config, Flake: generatedFlake, Generation: genNum}}
+}
+
+// hmGenSettings builds a generation from a homeManager.settings (catalog) apply:
+// it records the user's declared catalog settings AND the engine-compiled
+// (machine-local) flake the engine actually activated.
+func hmGenSettings(settings *manifest.HomeManagerSettings, generatedFlake string, genNum int) *provision.Generation {
+	return &provision.Generation{HomeManager: &provision.HomeGenRef{Settings: settings, Flake: generatedFlake, Generation: genNum}}
 }
 
 func readCapturedManifest(t *testing.T, path string) capturedManifestFile {

--- a/go-engine/internal/provision/provision.go
+++ b/go-engine/internal/provision/provision.go
@@ -13,6 +13,8 @@
 // enforces the import constraint.
 package provision
 
+import "github.com/Artexis10/endstate/go-engine/internal/manifest"
+
 // SchemaVersion is the schema version of the Generation record. It is owned by
 // the provisioning layer and is independent of the manifest and envelope schema
 // versions, so the record format can migrate on its own cadence.
@@ -60,8 +62,14 @@ type HomeGenRef struct {
 	// directly-declared homeManager.flake. Flake records what was actually
 	// activated (the generated, machine-local flakeref in the config case);
 	// Config records what the user declared, so capture can round-trip it.
-	Config     string `json:"config,omitempty"`
-	Generation int    `json:"generation"`
+	Config string `json:"config,omitempty"`
+	// Settings is the user's declared homeManager.settings catalog when the
+	// activated flake was engine-compiled from it (the catalog tier); nil for a
+	// flake- or config-declared home-manager input. Like Config, it records what
+	// the user declared so capture can round-trip a settings-applied machine back
+	// to its catalog. In practice exactly one of Config/Settings is set.
+	Settings   *manifest.HomeManagerSettings `json:"settings,omitempty"`
+	Generation int                           `json:"generation"`
 }
 
 // Capabilities describes what a package backend can do. It is discovered at

--- a/go-engine/internal/provision/provision_test.go
+++ b/go-engine/internal/provision/provision_test.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/manifest"
 )
 
 func TestWriteTo_AssignsMonotonicNumbersAndDefaultsSchema(t *testing.T) {
@@ -137,6 +139,56 @@ func TestDir_ResolvesUnderStateDirNeverHardcoded(t *testing.T) {
 
 // TestPackageStaysInstallOnly enforces the separation-of-concerns invariant in
 // code: the provision package must never import the config/restore layer.
+// TestWriteTo_RecordsHomeManagerSettings verifies that HomeGenRef.Settings
+// (the user's declared homeManager.settings catalog) round-trips through
+// write/read so capture can recover it for the captured manifest.
+func TestWriteTo_RecordsHomeManagerSettings(t *testing.T) {
+	dir := t.TempDir()
+	settings := &manifest.HomeManagerSettings{
+		Git: &manifest.GitSettings{UserName: "Hugo", UserEmail: "h@example.com"},
+	}
+	g := &Generation{
+		RunID:   "apply-settings",
+		Backend: "nix",
+		HomeManager: &HomeGenRef{
+			Flake:    "/tmp/endstate/state/home-manager/flake#me",
+			Settings: settings,
+			Generation: 3,
+		},
+	}
+	if err := WriteTo(dir, g); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	gens, err := ListFrom(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(gens) != 1 {
+		t.Fatalf("len = %d, want 1", len(gens))
+	}
+	hm := gens[0].HomeManager
+	if hm == nil {
+		t.Fatal("HomeManager = nil after round-trip, want non-nil")
+	}
+	if hm.Settings == nil {
+		t.Fatal("HomeManager.Settings = nil after round-trip, want non-nil")
+	}
+	if hm.Settings.Git == nil || hm.Settings.Git.UserName != "Hugo" {
+		t.Errorf("HomeManager.Settings.Git.UserName = %q, want Hugo", func() string {
+			if hm.Settings.Git != nil {
+				return hm.Settings.Git.UserName
+			}
+			return "<nil>"
+		}())
+	}
+	if hm.Settings.Git.UserEmail != "h@example.com" {
+		t.Errorf("HomeManager.Settings.Git.UserEmail = %q, want h@example.com", hm.Settings.Git.UserEmail)
+	}
+	if hm.Generation != 3 {
+		t.Errorf("HomeManager.Generation = %d, want 3", hm.Generation)
+	}
+}
+
 func TestPackageStaysInstallOnly(t *testing.T) {
 	fset := token.NewFileSet()
 	files, err := filepath.Glob("*.go")

--- a/openspec/changes/nix-home-manager-catalog-capture/.openspec.yaml
+++ b/openspec/changes/nix-home-manager-catalog-capture/.openspec.yaml
@@ -1,0 +1,10 @@
+id: nix-home-manager-catalog-capture
+title: "Capture records the engine-provisioned home-manager catalog settings"
+status: implementing
+spec: nix-home-manager-catalog-capture
+created: "2026-06-02"
+author: Hugo Ander Kivi
+artifacts:
+  - proposal.md
+  - design.md
+  - tasks.md

--- a/openspec/changes/nix-home-manager-catalog-capture/design.md
+++ b/openspec/changes/nix-home-manager-catalog-capture/design.md
@@ -1,0 +1,128 @@
+## Context
+
+- `provision.HomeGenRef` (`internal/provision/provision.go`) records what the engine activated:
+  `Flake` (always: the activated ref), `Config` (PR #89: the user's declared `home.nix` path when
+  the flake was engine-generated from it), `Generation` (the resulting hm generation number).
+- `recoverHomeManager` (`internal/commands/capture_realizer.go`) iterates `provision.List()`
+  newest-first and currently prefers Config over Flake (PR #89). Settings adds a third tier.
+- `manifest.HomeManagerSettings` (`internal/manifest/types.go`, PR #91) is the declarative catalog
+  struct. It is a stdlib-only leaf — verified: `go list -deps ./internal/manifest/` shows zero
+  endstate imports. Therefore `provision → manifest` is cycle-free and we can store
+  `*manifest.HomeManagerSettings` directly (no serialized form needed).
+- The existing guard test (`TestPackageStaysInstallOnly`) checks for `internal/restore` imports
+  only; adding `internal/manifest` does not trigger it.
+
+## Goals / Non-Goals
+
+**Goals:**
+- `capture` emits `homeManager.settings` for a settings-applied machine so it round-trips through
+  the #91 apply settings stage.
+- Zero regression on flake, config, package, and Windows paths.
+- Hermetic tests; no live Nix invocations.
+
+**Non-Goals:**
+- No live-system settings recovery — not possible; only provisioning history.
+- No new manifest schema — reuse `manifest.HomeManagerSettings`.
+- No `--enable-restore` gate on capture — capture is read-only.
+- No capture of settings applied outside Endstate (documented limitation).
+
+## Decisions
+
+- **Direction: record-on-apply, read-back-on-capture** — mirrors PR #89's Config fix exactly.
+  `apply` records the declared settings into `HomeGenRef.Settings`; `capture` reads it back.
+  Rejected live-system synthesis (not possible: hm generation has no source settings).
+- **`provision → manifest` import is safe** — manifest is a stdlib-only leaf (confirmed above).
+  Use `*manifest.HomeManagerSettings` directly; no serialized form.
+- **Preference order: Settings > Config > Flake** — Settings is the most-specific input
+  (user never wrote Nix); Config is next (user wrote a home.nix); Flake is the fallback
+  (user wrote the full flake). The most-recent non-nil generation with any of these set wins.
+- **Best-effort** — history error / absent Settings falls through the chain; never fails capture.
+
+## Design
+
+### 1. `provision.HomeGenRef` — add `Settings` field
+
+```go
+// Settings holds the user's declared homeManager.settings catalog when the
+// activated config was compiled from it. Empty for config or flake inputs.
+// Recorded alongside Flake (which carries the generated, machine-local ref)
+// so capture can round-trip the portable settings declaration.
+Settings *manifest.HomeManagerSettings `json:"settings,omitempty"`
+```
+
+`internal/provision/provision.go` gains an import of
+`github.com/Artexis10/endstate/go-engine/internal/manifest`.
+
+### 2. `apply_realizer.go` — record settings in the config stage
+
+In the settings branch of `resolveHomeFlake` / `runApplyRealizer`, after building `homeRef`:
+
+```go
+homeRef = &provision.HomeGenRef{Flake: flake, Generation: hmGen}
+if generated {
+    homeRef.Config = mf.HomeManager.Config
+}
+// NEW: record declared settings so capture can round-trip them.
+if mf.HomeManager.Settings != nil {
+    homeRef.Settings = mf.HomeManager.Settings
+}
+```
+
+(The `generated` flag is true for both Config and Settings branches; both set `homeRef.Config` for
+the config path. For Settings, `mf.HomeManager.Config` is empty, so Settings is the right record.)
+
+Actually the cleanest form: replace the existing `generated` block with explicit branch checks:
+
+```go
+homeRef = &provision.HomeGenRef{Flake: flake, Generation: hmGen}
+switch {
+case mf.HomeManager.Settings != nil:
+    homeRef.Settings = mf.HomeManager.Settings
+case mf.HomeManager.Config != "":
+    homeRef.Config = mf.HomeManager.Config
+}
+```
+
+### 3. `capture_realizer.go` — `recoverHomeManager` prefers Settings > Config > Flake
+
+```go
+func recoverHomeManager(flags CaptureFlags) *manifest.HomeManagerConfig {
+    if gens, err := listGenerationsFn(); err == nil {
+        for _, g := range gens {
+            if g.HomeManager == nil {
+                continue
+            }
+            if g.HomeManager.Settings != nil {
+                return &manifest.HomeManagerConfig{Settings: g.HomeManager.Settings}
+            }
+            if g.HomeManager.Config != "" {
+                return &manifest.HomeManagerConfig{Config: g.HomeManager.Config}
+            }
+            if g.HomeManager.Flake != "" {
+                return &manifest.HomeManagerConfig{Flake: g.HomeManager.Flake}
+            }
+        }
+    }
+    // --update: preserve existing manifest's homeManager when history has none
+    if flags.Update && flags.Manifest != "" {
+        if mf, loadErr := loadManifest(flags.Manifest); loadErr == nil && mf.HomeManager != nil {
+            return mf.HomeManager
+        }
+    }
+    return nil
+}
+```
+
+## Risks / Verification
+
+- **Hermetic tests** — inject `listGenerationsFn` (existing seam): settings generation → emitted as
+  settings; settings > config > flake precedence per most-recent non-nil generation; no settings in
+  history → falls through to config/flake; history error → omitted + no failure.
+- **Provision round-trip test** — `TestWriteTo_RecordsHomeManagerSettings`: write a generation with
+  `HomeGenRef.Settings`, read it back, assert the struct matches.
+- **Guard test** — `TestPackageStaysInstallOnly` checks for `internal/restore` only; adding
+  `internal/manifest` does not trigger it. Run to confirm.
+- **`GOOS=windows` build/vet** — Settings path is Nix-only; Windows path never reaches it.
+- **Real-nix round-trip smoke** (Linux dev box): apply a manifest with `homeManager.settings`
+  (`--enable-restore`) → provision generation records Settings → `capture` → manifest carries
+  `homeManager.settings` → apply the captured manifest re-activates the same settings config.

--- a/openspec/changes/nix-home-manager-catalog-capture/proposal.md
+++ b/openspec/changes/nix-home-manager-catalog-capture/proposal.md
@@ -1,0 +1,59 @@
+## Why
+
+PR #91 added `homeManager.settings` — the user declares configuration in Endstate's own catalog
+format and the engine compiles a `home.nix`, wraps it into a generated flake, and activates it.
+This closes the **apply** direction for catalog-declared config. However, `capture` does not yet
+record catalog settings: it only recovers a `homeManager.config` path (from PR #89) or a
+`homeManager.flake` ref — neither is the right output for a settings-applied machine.
+
+The gap: when a user applied via `homeManager.settings`, ran `capture`, and took the captured
+manifest to a new machine, the manifest would have *no* `homeManager` block at all (because no
+`Config` and no portable `Flake` was recorded). The catalog apply↔capture loop is open.
+
+This change closes it: `capture` recovers the user's declared `homeManager.settings` from the
+engine's provisioning history and emits it into the captured manifest, so a captured manifest
+round-trips through the #91 apply settings stage.
+
+**The settings are recovered from the engine, not the system.** Home-manager does not persist the
+originating catalog declaration in a live install. However, Endstate's `apply` already records what
+it activated: the provisioning generation carries `HomeGenRef`. Capture reads that history.
+
+## What Changes
+
+- **Extend `provision.HomeGenRef` with a `Settings` field.** When a settings-applied configuration
+  is activated, the engine records the user's declared `*manifest.HomeManagerSettings` in
+  `HomeGenRef.Settings`. This is the only automatable source for round-trip capture.
+- **Record `Settings` in `apply`.** The settings branch of `resolveHomeFlake` /
+  `runApplyRealizer` records `homeRef.Settings = mf.HomeManager.Settings` when the catalog path
+  activates. Flake and Config continue to be recorded as before (audit trail unchanged).
+- **Emit `settings` in `capture`.** `recoverHomeManager` gains a third preference:
+  Settings > Config > Flake. When the most-recent activated generation has Settings set, the
+  captured manifest carries `homeManager: { settings: ... }` — a valid manifest the #91 apply
+  settings path consumes unchanged.
+- **Best-effort and non-destructive.** Exactly like the Config preference added by #89, a history
+  read error or absent Settings simply falls through to Config, then Flake, then nil. Capture never
+  fails because of this.
+
+## Capabilities
+
+### New Capabilities
+
+- `nix-home-manager-catalog-capture`: `capture` records the user's declared `homeManager.settings`
+  (from the engine's provisioning history) and emits it into the manifest, so a settings-applied
+  machine round-trips through the #91 apply catalog stage. Only settings applied through Endstate
+  are captured; a manual home-manager setup yields nothing until declared + applied once.
+
+### Modified Capabilities
+
+- None. Additive extension of the existing capture→apply loop.
+
+## Impact
+
+- `internal/provision/provision.go` — `HomeGenRef` gains `Settings *manifest.HomeManagerSettings`.
+  Import of `internal/manifest` is safe: `manifest` is a stdlib-only leaf with no endstate deps
+  (verified by `go list -deps`); the existing guard test checks only `internal/restore`.
+- `internal/commands/apply_realizer.go` — settings branch records `homeRef.Settings`.
+- `internal/commands/capture_realizer.go` — `recoverHomeManager` prefers Settings > Config > Flake.
+- `internal/commands/capture_realizer_test.go` — new hermetic tests for the settings preference.
+- `internal/provision/provision_test.go` — new round-trip test for `HomeGenRef.Settings`.
+- Zero winget / Windows / package-capture regression.

--- a/openspec/changes/nix-home-manager-catalog-capture/specs/nix-home-manager-catalog-capture/spec.md
+++ b/openspec/changes/nix-home-manager-catalog-capture/specs/nix-home-manager-catalog-capture/spec.md
@@ -1,0 +1,69 @@
+## ADDED Requirements
+
+### Requirement: Capture records the engine-provisioned home-manager catalog settings
+
+The engine SHALL record, in a captured manifest, the `homeManager.settings` catalog the user
+declared when the engine compiled and activated it, so that applying the captured manifest
+re-activates the same catalog configuration. The settings SHALL be recovered from the engine's
+provisioning history (the generation recorded on apply), not from the live system.
+
+#### Scenario: Captured manifest carries the declared settings
+
+- **WHEN** `capture` runs on a realizer host and the engine's provisioning history records an
+  activated home-manager configuration compiled from a declared catalog
+- **THEN** the written manifest SHALL include the `homeManager.settings` block from that history
+- **AND** applying the captured manifest SHALL re-activate the same home-manager configuration
+  through the catalog stage
+
+#### Scenario: Settings take precedence over config and flake in capture
+
+- **WHEN** the provisioning history contains a generation that activated a settings-compiled
+  configuration
+- **THEN** `capture` SHALL emit `homeManager.settings` rather than `homeManager.config` or
+  `homeManager.flake`
+
+#### Scenario: No recorded settings falls through to config and flake
+
+- **WHEN** the provisioning history records no settings but does record a config or flake
+- **THEN** `capture` SHALL emit the config or flake as before, without change
+
+#### Scenario: Capture then apply re-activates the same settings configuration
+
+- **WHEN** a manifest produced by `capture` (carrying `homeManager.settings`) is applied on a
+  realizer host with configuration enabled
+- **THEN** the engine SHALL re-activate the same home-manager configuration from the catalog
+
+### Requirement: Settings capture is best-effort and non-destructive
+
+Recovering the home-manager catalog settings for capture SHALL NOT fail the capture command. If
+the provisioning history cannot be read or records no settings, capture SHALL still produce a
+valid package manifest and omit the home-manager field.
+
+#### Scenario: Provisioning history unreadable — settings omitted, capture succeeds
+
+- **WHEN** `capture` runs and the provisioning history cannot be read
+- **THEN** the engine SHALL still write a valid manifest of the captured packages
+- **AND** it SHALL omit the home-manager field rather than returning an error
+
+#### Scenario: No settings in history — config or flake preserved
+
+- **WHEN** `capture` runs and the provisioning history records a config or flake but no settings
+- **THEN** the engine SHALL emit the config or flake in the captured manifest unchanged
+
+### Requirement: Apply records the declared settings in the provisioning generation
+
+The engine SHALL record the declared `homeManager.settings` in the Provisioning Generation after
+activating a home-manager configuration compiled from them, so that capture can round-trip them.
+
+#### Scenario: Generation records the declared settings on a settings apply
+
+- **WHEN** `apply` activates a home-manager configuration compiled from `homeManager.settings`
+- **THEN** the engine SHALL write a Provisioning Generation whose `HomeManager.Settings` equals
+  the declared catalog settings
+
+#### Scenario: Config and flake generation records are unchanged
+
+- **WHEN** `apply` activates a home-manager configuration from a `homeManager.config` or
+  `homeManager.flake`
+- **THEN** the Provisioning Generation SHALL record `Config` or `Flake` as before
+- **AND** `Settings` SHALL be absent from those generations

--- a/openspec/changes/nix-home-manager-catalog-capture/tasks.md
+++ b/openspec/changes/nix-home-manager-catalog-capture/tasks.md
@@ -1,0 +1,35 @@
+> TDD: write each test RED first, then implement to green. Hermetic (inject `listGenerationsFn` +
+> seeded `provision.Write`; no live Nix calls). Verify: `cd go-engine && go test ./...` (Linux) +
+> `GOOS=windows go build ./...` + `go vet`; real-nix apply→capture→apply settings round-trip smoke.
+
+## 1. Extend `provision.HomeGenRef` with `Settings`
+
+- [ ] 1.1 RED test (`provision_test.go`): write a generation with `HomeGenRef.Settings` set → read
+      back → `Settings` matches; confirm `TestPackageStaysInstallOnly` still passes with the new
+      `manifest` import.
+- [ ] 1.2 `internal/provision/provision.go`: add `Settings *manifest.HomeManagerSettings` to
+      `HomeGenRef`; add import of `internal/manifest`.
+
+## 2. Record `Settings` in `apply`
+
+- [ ] 2.1 RED test (`apply_realizer_catalog_test.go`): after a settings apply, the provisioning
+      generation's `HomeManager.Settings` equals the declared settings struct.
+- [ ] 2.2 `internal/commands/apply_realizer.go`: in the config stage, after building `homeRef`,
+      set `homeRef.Settings = mf.HomeManager.Settings` when the settings branch activated.
+
+## 3. Emit `settings` in `capture`
+
+- [ ] 3.1 RED tests (`capture_realizer_test.go`): a generation with Settings → manifest carries
+      `homeManager.settings`; Settings > Config > Flake precedence; no Settings in history →
+      falls through to Config/Flake; history error → omitted + still succeeds.
+- [ ] 3.2 `internal/commands/capture_realizer.go`: extend `recoverHomeManager` to prefer Settings
+      over Config over Flake.
+
+## 4. Verification
+
+- [ ] 4.1 `cd go-engine && go test ./...` green on Linux
+- [ ] 4.2 `GOOS=windows go build ./...` + `go vet ./...` clean
+- [ ] 4.3 `npm run openspec:validate` (strict) + `npx openspec validate nix-home-manager-catalog-capture --strict`
+- [ ] 4.4 Real-nix round-trip smoke: apply a manifest with `homeManager.settings`
+      (`--enable-restore`) → `capture` → manifest carries `homeManager.settings` → apply the
+      captured manifest re-activates the settings config.


### PR DESCRIPTION
Closes the capture↔apply loop for the **catalog tier** (#91): a machine provisioned via `homeManager.settings` now captures back to `homeManager.settings`, mirroring the flake/config round-trip (#86/#89).

Part of a 3-PR parallel batch — recommended merge order **B (verify) → C (version capture) → D (this)**. D and C both touch `capture_realizer.go`/`apply_realizer.go`; this one is meant to land last (rebase on C).

## What
The declared catalog settings aren't recoverable from a live home-manager install (same as the flakeref), so the engine **records them on apply and reads them back on capture** — the #89 record-on-apply / read-back-on-capture pattern:
- `provision.HomeGenRef` gains a `Settings` field. `internal/provision` imports `internal/manifest` (cycle-free — manifest is a pure leaf; the install-only guard test forbids only `internal/restore`).
- `apply` records `homeRef.Settings` for a settings-compiled config (alongside `Config` for the wrapper case; exactly one is set).
- capture's `recoverHomeManager` prefers **Settings > Config > Flake**.

Best-effort (history read error → omit; never fails capture). Realizer-only. Known limitation: only captures settings applied through Endstate.

## Verification
- `go test ./...` green; `GOOS=windows go build ./...` + `go vet` clean; `npm run openspec:validate` 62/62.
- **Real-nix round-trip smoke:** `apply homeManager.settings{git}` → managed gitconfig reflects it → `capture` emitted exactly `homeManager.settings.git{userName,userEmail}` with **no machine-local flake leaked** → re-applying the captured manifest activated cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)