### PR TITLE
feat(engine): verify home-manager config (presence + drift)

### DIFF
--- a/go-engine/internal/commands/apply_realizer_test.go
+++ b/go-engine/internal/commands/apply_realizer_test.go
@@ -64,6 +64,9 @@ type fakeRealizer struct {
 	homeRollbackErr     error // scripted RollbackHome error
 	homeRollbackCalls   int
 	lastHomeRollbackArg int
+
+	// --- home-manager generation reading (verify) ---
+	activeHomeGen int // scripted ActiveHomeGeneration return value
 }
 
 // RollbackHome satisfies realizer.HomeRollbacker, recording the requested
@@ -75,6 +78,12 @@ func (f *fakeRealizer) RollbackHome(generation int) (int, error) {
 	f.lastHomeRollbackArg = generation
 	return f.homeRollbackGen, f.homeRollbackErr
 }
+
+// ActiveHomeGeneration satisfies realizer.HomeGenerationReader, returning the
+// scripted activeHomeGen value. Its presence makes *fakeRealizer a
+// HomeGenerationReader, so the verify home-manager check is exercised
+// host-independently.
+func (f *fakeRealizer) ActiveHomeGeneration() int { return f.activeHomeGen }
 
 // ActivateHome satisfies realizer.HomeActivator, recording the requested flake
 // and returning the scripted generation/error. Its presence makes *fakeRealizer a

--- a/go-engine/internal/commands/verify_plan_realizer.go
+++ b/go-engine/internal/commands/verify_plan_realizer.go
@@ -6,7 +6,9 @@ package commands
 import (
 	"fmt"
 	"runtime"
+	"strconv"
 
+	"github.com/Artexis10/endstate/go-engine/internal/driver"
 	"github.com/Artexis10/endstate/go-engine/internal/envelope"
 	"github.com/Artexis10/endstate/go-engine/internal/events"
 	"github.com/Artexis10/endstate/go-engine/internal/manifest"
@@ -79,6 +81,21 @@ func runVerifyRealizer(flags VerifyFlags, mf *manifest.Manifest, r realizer.Real
 		}
 	}
 
+	// Home-manager config check: only when the manifest declares a homeManager
+	// block AND the realizer implements HomeGenerationReader. Realizers that do
+	// not implement the interface (e.g. stubs, non-Nix backends) skip silently.
+	if mf.HomeManager != nil {
+		if hgr, ok := r.(realizer.HomeGenerationReader); ok {
+			item := checkHomeManagerGeneration(hgr, emitter)
+			if item.Status == "pass" {
+				pass++
+			} else {
+				fail++
+			}
+			results = append(results, item)
+		}
+	}
+
 	total := pass + fail
 	emitter.EmitSummary("verify", total, pass, 0, fail)
 	return &VerifyResult{
@@ -86,6 +103,61 @@ func runVerifyRealizer(flags VerifyFlags, mf *manifest.Manifest, r realizer.Real
 		Summary:  VerifySummary{Total: total, Pass: pass, Fail: fail},
 		Results:  results,
 	}, nil
+}
+
+// checkHomeManagerGeneration reads the active home-manager generation via hgr
+// and compares it to the most-recently recorded generation in the provisioning
+// history. It returns a VerifyItem of type "home-manager" with:
+//   - status "pass" when active == recorded
+//   - status "fail", reason "config_drift" when active > 0 and active != recorded
+//   - status "fail", reason "missing" when active == 0
+//
+// It also emits a streaming item event via emitter. The listGenerationsFn seam
+// (shared with capture_realizer.go) is used so tests can inject a fake history.
+func checkHomeManagerGeneration(hgr realizer.HomeGenerationReader, emitter interface {
+	EmitItem(id, driver, status, reason, message, name string)
+}) VerifyItem {
+	item := VerifyItem{
+		Type: "home-manager",
+		ID:   "home-manager",
+	}
+
+	active := hgr.ActiveHomeGeneration()
+
+	// Find the most-recent provisioning generation that recorded a home-manager
+	// config (package-only applies record HomeManager=nil, so skip those).
+	// Mirrors recoverHomeManager in capture_realizer.go.
+	recorded := 0
+	if gens, err := listGenerationsFn(); err == nil {
+		for _, g := range gens {
+			if g.HomeManager != nil {
+				recorded = g.HomeManager.Generation
+				break
+			}
+		}
+	}
+
+	switch {
+	case active == 0:
+		item.Status = "fail"
+		item.Reason = driver.ReasonMissing
+		item.Message = "No active home-manager generation — home-manager config was never applied or has been removed"
+		emitter.EmitItem("home-manager", "nix", "failed", driver.ReasonMissing, item.Message, "home-manager")
+	case active != recorded:
+		item.Status = "fail"
+		item.Reason = driver.ReasonConfigDrift
+		item.Version = strconv.Itoa(active)
+		item.Expected = strconv.Itoa(recorded)
+		item.Message = fmt.Sprintf("home-manager generation %d is active, want %d (recorded)", active, recorded)
+		emitter.EmitItem("home-manager", "nix", "failed", driver.ReasonConfigDrift, item.Message, "home-manager")
+	default:
+		item.Status = "pass"
+		item.Version = strconv.Itoa(active)
+		item.Message = fmt.Sprintf("home-manager generation %d matches recorded", active)
+		emitter.EmitItem("home-manager", "nix", "present", "", item.Message, "home-manager")
+	}
+
+	return item
 }
 
 // runPlanRealizer is the plan (read-only preview) path for a realizer backend.

--- a/go-engine/internal/commands/verify_plan_realizer_test.go
+++ b/go-engine/internal/commands/verify_plan_realizer_test.go
@@ -4,9 +4,13 @@
 package commands
 
 import (
+	"fmt"
 	"runtime"
 	"testing"
 
+	"github.com/Artexis10/endstate/go-engine/internal/driver"
+	"github.com/Artexis10/endstate/go-engine/internal/manifest"
+	"github.com/Artexis10/endstate/go-engine/internal/provision"
 	"github.com/Artexis10/endstate/go-engine/internal/realizer"
 )
 
@@ -362,5 +366,287 @@ func TestRunPlanRealizer_ActionDriver(t *testing.T) {
 	}
 	if pr.Actions[0].Driver != "nix" {
 		t.Errorf("action Driver = %q, want nix", pr.Actions[0].Driver)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// home-manager verify tests (HomeGenerationReader seam)
+// ---------------------------------------------------------------------------
+
+// seedHMGeneration writes a Provisioning Generation recording a home-manager
+// config with the given generation number. The test must set ENDSTATE_ROOT.
+func seedHMGeneration(t *testing.T, hmGen int) {
+	t.Helper()
+	if err := provision.Write(&provision.Generation{
+		Backend: "nix",
+		HomeManager: &provision.HomeGenRef{
+			Flake:      "/dot#me",
+			Generation: hmGen,
+		},
+	}); err != nil {
+		t.Fatalf("seedHMGeneration: provision.Write: %v", err)
+	}
+}
+
+// hmManifest builds a Manifest with one nix app and a homeManager block.
+func hmManifest(app manifest.App) *manifest.Manifest {
+	mf := nixManifest(app)
+	mf.HomeManager = &manifest.HomeManagerConfig{Flake: "/dot#me"}
+	return mf
+}
+
+// TestRunVerifyRealizer_HomeManager_Pass: declared hm, active==recorded → one
+// home-manager item with status "pass"; counts in summary.
+func TestRunVerifyRealizer_HomeManager_Pass(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedHMGeneration(t, 5)
+
+	app := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := hmManifest(app)
+
+	fr := &fakeRealizer{
+		currentSet: realizer.Set{
+			Generation: 3,
+			Elements:   map[string]realizer.Element{"ripgrep": {Name: "ripgrep", AttrPath: "ripgrep"}},
+		},
+		activeHomeGen: 5, // matches recorded
+	}
+
+	flags := VerifyFlags{Manifest: "hm-pass"}
+	raw, eerr := runVerifyRealizer(flags, mf, fr, noopEmitter())
+	if eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+	vr := raw.(*VerifyResult)
+
+	// Find the home-manager item.
+	var hmItem *VerifyItem
+	for i := range vr.Results {
+		if vr.Results[i].Type == "home-manager" {
+			hmItem = &vr.Results[i]
+			break
+		}
+	}
+	if hmItem == nil {
+		t.Fatal("expected a home-manager result item, got none")
+	}
+	if hmItem.Status != "pass" {
+		t.Errorf("home-manager item Status = %q, want pass", hmItem.Status)
+	}
+	if hmItem.ID != "home-manager" {
+		t.Errorf("home-manager item ID = %q, want home-manager", hmItem.ID)
+	}
+	// The pass item must be counted.
+	if vr.Summary.Pass != 2 { // ripgrep + hm
+		t.Errorf("Summary.Pass = %d, want 2", vr.Summary.Pass)
+	}
+	if vr.Summary.Fail != 0 {
+		t.Errorf("Summary.Fail = %d, want 0", vr.Summary.Fail)
+	}
+}
+
+// TestRunVerifyRealizer_HomeManager_ConfigDrift: active != recorded → fail
+// config_drift, Version and Expected set to active/recorded gen numbers.
+func TestRunVerifyRealizer_HomeManager_ConfigDrift(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedHMGeneration(t, 5)
+
+	app := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := hmManifest(app)
+
+	fr := &fakeRealizer{
+		currentSet: realizer.Set{
+			Elements: map[string]realizer.Element{"ripgrep": {Name: "ripgrep", AttrPath: "ripgrep"}},
+		},
+		activeHomeGen: 7, // differs from recorded (5)
+	}
+
+	flags := VerifyFlags{Manifest: "hm-drift"}
+	raw, eerr := runVerifyRealizer(flags, mf, fr, noopEmitter())
+	if eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+	vr := raw.(*VerifyResult)
+
+	var hmItem *VerifyItem
+	for i := range vr.Results {
+		if vr.Results[i].Type == "home-manager" {
+			hmItem = &vr.Results[i]
+			break
+		}
+	}
+	if hmItem == nil {
+		t.Fatal("expected a home-manager result item, got none")
+	}
+	if hmItem.Status != "fail" {
+		t.Errorf("Status = %q, want fail", hmItem.Status)
+	}
+	if hmItem.Reason != driver.ReasonConfigDrift {
+		t.Errorf("Reason = %q, want config_drift", hmItem.Reason)
+	}
+	if hmItem.Version != fmt.Sprintf("%d", 7) {
+		t.Errorf("Version (active) = %q, want 7", hmItem.Version)
+	}
+	if hmItem.Expected != fmt.Sprintf("%d", 5) {
+		t.Errorf("Expected (recorded) = %q, want 5", hmItem.Expected)
+	}
+	if vr.Summary.Fail != 1 {
+		t.Errorf("Summary.Fail = %d, want 1 (hm drift)", vr.Summary.Fail)
+	}
+}
+
+// TestRunVerifyRealizer_HomeManager_Missing: active==0 → fail missing.
+func TestRunVerifyRealizer_HomeManager_Missing(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedHMGeneration(t, 5)
+
+	app := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := hmManifest(app)
+
+	fr := &fakeRealizer{
+		currentSet: realizer.Set{
+			Elements: map[string]realizer.Element{"ripgrep": {Name: "ripgrep", AttrPath: "ripgrep"}},
+		},
+		activeHomeGen: 0, // nothing active
+	}
+
+	flags := VerifyFlags{Manifest: "hm-missing"}
+	raw, eerr := runVerifyRealizer(flags, mf, fr, noopEmitter())
+	if eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+	vr := raw.(*VerifyResult)
+
+	var hmItem *VerifyItem
+	for i := range vr.Results {
+		if vr.Results[i].Type == "home-manager" {
+			hmItem = &vr.Results[i]
+			break
+		}
+	}
+	if hmItem == nil {
+		t.Fatal("expected a home-manager result item, got none")
+	}
+	if hmItem.Status != "fail" {
+		t.Errorf("Status = %q, want fail", hmItem.Status)
+	}
+	if hmItem.Reason != driver.ReasonMissing {
+		t.Errorf("Reason = %q, want missing", hmItem.Reason)
+	}
+}
+
+// TestRunVerifyRealizer_HomeManager_NoRecordedGen_Missing: no history at all,
+// active==0 → fail missing.
+func TestRunVerifyRealizer_HomeManager_NoRecordedGen_Missing(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	// No generations written — empty history.
+
+	app := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := hmManifest(app)
+
+	fr := &fakeRealizer{
+		currentSet:    realizer.Set{Elements: map[string]realizer.Element{}},
+		activeHomeGen: 0,
+	}
+
+	flags := VerifyFlags{Manifest: "hm-no-history"}
+	raw, eerr := runVerifyRealizer(flags, mf, fr, noopEmitter())
+	if eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+	vr := raw.(*VerifyResult)
+
+	var hmItem *VerifyItem
+	for i := range vr.Results {
+		if vr.Results[i].Type == "home-manager" {
+			hmItem = &vr.Results[i]
+			break
+		}
+	}
+	if hmItem == nil {
+		t.Fatal("expected a home-manager result item, got none")
+	}
+	if hmItem.Status != "fail" {
+		t.Errorf("Status = %q, want fail", hmItem.Status)
+	}
+	if hmItem.Reason != driver.ReasonMissing {
+		t.Errorf("Reason = %q, want missing", hmItem.Reason)
+	}
+}
+
+// TestRunVerifyRealizer_NoHomeManager_NoHmItem: manifest without homeManager →
+// no home-manager item, existing package verify unaffected.
+func TestRunVerifyRealizer_NoHomeManager_NoHmItem(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	app := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := nixManifest(app) // no HomeManager field
+
+	fr := &fakeRealizer{
+		currentSet: realizer.Set{
+			Elements: map[string]realizer.Element{"ripgrep": {Name: "ripgrep", AttrPath: "ripgrep"}},
+		},
+		activeHomeGen: 3,
+	}
+
+	flags := VerifyFlags{Manifest: "no-hm-field"}
+	raw, eerr := runVerifyRealizer(flags, mf, fr, noopEmitter())
+	if eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+	vr := raw.(*VerifyResult)
+
+	for _, item := range vr.Results {
+		if item.Type == "home-manager" {
+			t.Errorf("unexpected home-manager item in results when manifest has no homeManager block")
+		}
+	}
+	if vr.Summary.Total != 1 {
+		t.Errorf("Summary.Total = %d, want 1 (only ripgrep)", vr.Summary.Total)
+	}
+	if vr.Summary.Pass != 1 {
+		t.Errorf("Summary.Pass = %d, want 1", vr.Summary.Pass)
+	}
+}
+
+// minimalRealizer implements only realizer.Realizer — NOT HomeGenerationReader —
+// so the verify path must skip the hm check when using it.
+type minimalRealizer struct {
+	currentSet realizer.Set
+}
+
+func (m *minimalRealizer) Name() string                                           { return "minimal" }
+func (m *minimalRealizer) Current() (realizer.Set, error)                         { return m.currentSet, nil }
+func (m *minimalRealizer) Plan([]realizer.Installable) (realizer.Diff, error)     { return realizer.Diff{}, nil }
+func (m *minimalRealizer) Realize([]realizer.Installable) (realizer.Result, error) {
+	return realizer.Result{}, nil
+}
+
+// TestRunVerifyRealizer_NoHomeGenerationReader_Skips: realizer does not implement
+// HomeGenerationReader → no home-manager item even when manifest declares hm.
+func TestRunVerifyRealizer_NoHomeGenerationReader_Skips(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	seedHMGeneration(t, 5)
+
+	app := nixApp("ripgrep", "nixpkgs#ripgrep")
+	mf := hmManifest(app)
+
+	mr := &minimalRealizer{
+		currentSet: realizer.Set{
+			Elements: map[string]realizer.Element{"ripgrep": {Name: "ripgrep", AttrPath: "ripgrep"}},
+		},
+	}
+
+	flags := VerifyFlags{Manifest: "no-hgr"}
+	raw, eerr := runVerifyRealizer(flags, mf, mr, noopEmitter())
+	if eerr != nil {
+		t.Fatalf("unexpected envelope error: %v", eerr)
+	}
+	vr := raw.(*VerifyResult)
+
+	for _, item := range vr.Results {
+		if item.Type == "home-manager" {
+			t.Errorf("unexpected home-manager item: backend does not implement HomeGenerationReader")
+		}
 	}
 }

--- a/go-engine/internal/driver/driver.go
+++ b/go-engine/internal/driver/driver.go
@@ -37,6 +37,11 @@ const (
 	// differs from the one declared by the manifest (a verify failure distinct
 	// from "missing"). Only evaluated for apps that declare a version.
 	ReasonVersionDrift = "version_drift"
+	// ReasonConfigDrift means the active home-manager generation differs from the
+	// most-recently recorded one: the configuration has drifted from the declared
+	// state. Only evaluated on the realizer path when the manifest declares a
+	// home-manager input.
+	ReasonConfigDrift = "config_drift"
 )
 
 // InstallResult is returned by Driver.Install and carries the outcome of a

--- a/go-engine/internal/realizer/nix/home_manager.go
+++ b/go-engine/internal/realizer/nix/home_manager.go
@@ -16,6 +16,15 @@ import (
 // the apply path can discover home-manager config support by type-assertion.
 var _ realizer.HomeActivator = (*Backend)(nil)
 
+// compile-time assertion: the Nix backend implements realizer.HomeGenerationReader,
+// so the verify path can discover home-manager generation reading by type-assertion.
+var _ realizer.HomeGenerationReader = (*Backend)(nil)
+
+// ActiveHomeGeneration returns the active home-manager generation number by
+// delegating to homeGen(), which reads the profile symlink (or the injected
+// homeGenFn in tests). Returns 0 when no home-manager generation is active.
+func (b *Backend) ActiveHomeGeneration() int { return b.homeGen() }
+
 // ActivateHome activates a declared home-manager configuration as the realizer's
 // config stage of apply. The engine owns the invocation — it runs the
 // home-manager CLI via `nix run <HomePin> -- switch --flake <flake> -b

--- a/go-engine/internal/realizer/realizer.go
+++ b/go-engine/internal/realizer/realizer.go
@@ -124,6 +124,18 @@ type HomeActivator interface {
 	ActivateHome(flake string) (generation int, err error)
 }
 
+// HomeGenerationReader is an OPTIONAL realizer capability: reading the active
+// home-manager generation number from the system. Discovered by type-assertion
+// on a Realizer, like Pruner / HomeActivator / HomeRollbacker, so only a backend
+// that owns the home-manager profile (the Nix realizer) implements it; other
+// backends simply do not, and the verify home-manager check is silently skipped.
+type HomeGenerationReader interface {
+	// ActiveHomeGeneration returns the current active home-manager generation
+	// number, or 0 when no home-manager generation is active (profile symlink
+	// absent or unreadable).
+	ActiveHomeGeneration() int
+}
+
 // HomeRollbacker is an OPTIONAL realizer capability: reverting the home-manager
 // configuration to a prior provisioning generation by re-activating the
 // home-manager generation that generation recorded. Like Pruner/HomeActivator it

--- a/openspec/changes/nix-home-manager-verify/.openspec.yaml
+++ b/openspec/changes/nix-home-manager-verify/.openspec.yaml
@@ -1,0 +1,10 @@
+id: nix-home-manager-verify
+title: "Home-manager config verification: verify presence and drift against recorded generation"
+status: implementing
+spec: nix-home-manager-verify
+created: "2026-06-02"
+author: Hugo Ander Kivi
+artifacts:
+  - proposal.md
+  - design.md
+  - tasks.md

--- a/openspec/changes/nix-home-manager-verify/design.md
+++ b/openspec/changes/nix-home-manager-verify/design.md
@@ -1,0 +1,91 @@
+## Context
+
+`nix-home-manager-config` (#81/#87/#89) gave the engine the ability to apply and record a home-manager
+configuration. The `verify` command checks packages and manifest `verify` entries but has no awareness of
+home-manager config at all. A machine where the active home-manager generation diverges from the recorded one
+silently reports all-green — a false positive. This change closes the verification gap.
+
+## Decisions
+
+- **Realizer path only.** The home-manager check is inside `runVerifyRealizer`. The winget/driver path
+  (`RunVerify`'s else branch) is unchanged. The check fires only when `mf.HomeManager != nil`.
+- **Active generation via a new optional seam.** The nix backend already has `homeGen()` (private). Rather
+  than making it public or hardcoding it in the command layer, we introduce a new optional capability
+  interface `realizer.HomeGenerationReader { ActiveHomeGeneration() int }`, discovered by type-assertion
+  exactly like `Pruner`/`HomeActivator`/`HomeRollbacker`. The `*Backend` implements it. If the realizer
+  does not implement `HomeGenerationReader`, the check is silently skipped (the backend cannot read hm
+  state, so neither can we).
+- **Recorded generation: newest non-nil HomeManager.** `provision.List()` is newest-first; skip entries
+  with `HomeManager == nil` (package-only applies); the first match is the most-recently recorded config.
+  This is the identical pattern used by `recoverHomeManager` in `capture_realizer.go`.
+- **Three outcomes only.**
+  - `pass` — active == recorded (or recorded == 0 and active == 0, meaning "declared but nothing ever
+    applied" is... not actually checked here; see below).
+  - `fail config_drift` — active > 0 AND active != recorded.
+  - `fail missing` — active == 0 (home-manager was never applied or was torn down).
+  - Edge: no recorded generation at all AND active == 0 → `fail missing` (declared in manifest but never
+    applied). No recorded generation AND active > 0 → still `fail missing` (we treat "no history" as
+    unverifiable presence without a reference → missing; this is the conservative side).
+- **Reason constant.** Add `ReasonConfigDrift = "config_drift"` in `internal/driver/driver.go` alongside
+  the existing `ReasonVersionDrift`. The `"missing"` reason already exists as `driver.ReasonMissing`.
+- **VerifyItem shape.** `Type: "home-manager"`, `ID: "home-manager"` (stable, no ref). Active generation
+  number in `Version` (as a decimal string), expected in `Expected`. This reuses the existing
+  version-drift display path in consumers without schema changes.
+- **`listGenerationsFn` seam.** `runVerifyRealizer` calls `listGenerationsFn()` (the same package-level
+  var used by `capture_realizer.go`), which defaults to `provision.List` and is replaceable in tests.
+
+## Design
+
+### Realizer interface (`internal/realizer/realizer.go`)
+
+```go
+// HomeGenerationReader is an OPTIONAL realizer capability: reading the active
+// home-manager generation number. Discovered by type-assertion on a Realizer,
+// like Pruner / HomeActivator / HomeRollbacker. The Nix backend implements it;
+// other backends (winget driver path) do not, and the hm verify check is skipped.
+type HomeGenerationReader interface {
+    ActiveHomeGeneration() int
+}
+```
+
+### Nix backend (`internal/realizer/nix/home_manager.go`)
+
+```go
+var _ realizer.HomeGenerationReader = (*Backend)(nil)
+
+func (b *Backend) ActiveHomeGeneration() int { return b.homeGen() }
+```
+
+### Verify path (`internal/commands/verify_plan_realizer.go`)
+
+After the existing app loop and manifest verify entries, before the summary event:
+
+```go
+if mf.HomeManager != nil {
+    if hgr, ok := r.(realizer.HomeGenerationReader); ok {
+        item := checkHomeManagerGeneration(hgr, emitter)
+        if item.Status == "pass" { pass++ } else { fail++ }
+        results = append(results, item)
+    }
+}
+```
+
+`checkHomeManagerGeneration` reads the active generation, finds the recorded generation via
+`listGenerationsFn()`, and builds the `VerifyItem`.
+
+### Reason constant (`internal/driver/driver.go`)
+
+```go
+ReasonConfigDrift = "config_drift"
+```
+
+## Risks / Verification
+
+- **No recorded history:** treated as `missing` (conservative — never silently pass without evidence).
+- **Package-only applies between config applies:** `provision.List` newest-first; skip nil `HomeManager`
+  entries; first non-nil is the config still in effect. Same as `recoverHomeManager`. Correct.
+- **Windows CI cross-compile:** `ActiveHomeGeneration()` calls `homeGen()` which reads a symlink — pure
+  stdlib, no platform guard needed. `GOOS=windows go build ./...` stays clean.
+- **Hermetic tests:** `fakeRealizer` gains `activeHomeGen int` field + `ActiveHomeGeneration()` method;
+  provision generations seeded via `provision.Write` under `t.Setenv("ENDSTATE_ROOT", t.TempDir())`.
+  `listGenerationsFn` is the shared package var already used by the capture tests.

--- a/openspec/changes/nix-home-manager-verify/proposal.md
+++ b/openspec/changes/nix-home-manager-verify/proposal.md
@@ -1,0 +1,51 @@
+## Why
+
+The Nix config arc covers apply (activates home-manager config) and capture (records the declared config for
+round-trip). But `verify` completely ignores home-manager config even when the manifest declares a
+`homeManager` block and a config was previously applied. This means a machine whose home-manager generation
+has drifted (e.g. another tool ran `home-manager switch`, or the config was never applied) reports all-green
+from `verify` — a false positive. Close this gap: when the manifest declares a home-manager input, `verify`
+should assert that the active generation matches the recorded one.
+
+## What Changes
+
+- **`verify` gains a home-manager config check** on the realizer path only (winget/driver path unchanged).
+  The check is evaluated only when `mf.HomeManager != nil`.
+- **Semantics: presence + drift-vs-recorded.** The check reads the active home-manager generation number
+  (from the `$XDG_STATE_HOME/nix/profiles/home-manager` symlink) and the recorded generation number (most
+  recent Provisioning Generation whose `HomeManager` is non-nil). If active == recorded → `pass`. If
+  active != recorded and active > 0 → `fail config_drift`. If active == 0 (nothing active) → `fail missing`.
+- **Seam (hermetically testable).** A new optional realizer capability `HomeGenerationReader` (discovered by
+  type-assertion, exactly like `Pruner`/`HomeActivator`/`HomeRollbacker`) lets the Nix backend expose the
+  active generation number. The verify path type-asserts it; a backend without it skips the hm check. The
+  Nix `Backend` implements it wrapping the existing `homeGen()` function. `fakeRealizer` gains a scriptable
+  field.
+- **One VerifyItem** of type `"home-manager"`, id `"home-manager"`, with status `pass`/`fail`, reason
+  (`config_drift` or `missing`), a human message, and the active/expected generation numbers exposed via
+  the existing `Version`/`Expected` fields.
+- **Summary counts** include the home-manager item.
+
+## Capabilities
+
+### New Capabilities
+
+- `nix-home-manager-verify`: when the manifest declares a `homeManager` block, `verify` on the Nix realizer
+  checks the active home-manager generation against the most-recently recorded one and reports
+  `pass` / `fail config_drift` / `fail missing`.
+
+## Impact
+
+- `internal/realizer/realizer.go` — new optional `HomeGenerationReader { ActiveHomeGeneration() int }`.
+- `internal/realizer/nix/home_manager.go` — implement `ActiveHomeGeneration()` on `*Backend` wrapping
+  `homeGen()`; compile-time assertion `var _ realizer.HomeGenerationReader = (*Backend)(nil)`.
+- `internal/commands/verify_plan_realizer.go` — add the hm check in `runVerifyRealizer`.
+- `internal/commands/verify_plan_realizer_test.go` — new hermetic test cases.
+- `internal/commands/apply_realizer_test.go` — extend `fakeRealizer` with `ActiveHomeGeneration`.
+- `openspec/specs/nix-home-manager-verify/spec.md` — new spec.
+
+## Non-Goals
+
+- No change to the winget/driver verify path.
+- No change to `apply` or `capture` behavior.
+- No automatic remediation (the check is read-only; `verify` is always read-only).
+- No per-file config drift check (this is generation-level only).

--- a/openspec/changes/nix-home-manager-verify/specs/nix-home-manager-verify/spec.md
+++ b/openspec/changes/nix-home-manager-verify/specs/nix-home-manager-verify/spec.md
@@ -1,0 +1,78 @@
+## ADDED Requirements
+
+### Requirement: verify checks home-manager config when declared
+
+The `verify` command on a realizer backend SHALL check the home-manager configuration when, and only when,
+the manifest declares a home-manager input. MUST produce exactly one `home-manager` item in the results
+with status `pass` when the active generation matches the recorded one, `fail` with reason `config_drift`
+when the generations diverge, or `fail` with reason `missing` when no home-manager generation is active.
+
+#### Scenario: Active generation matches recorded — pass
+
+- **WHEN** `verify` runs on the Nix realizer and the manifest declares a home-manager input
+- **AND** the active home-manager generation number equals the most-recently recorded generation number
+- **THEN** the engine SHALL emit one result item with type `home-manager`, id `home-manager`, status `pass`
+- **AND** that item SHALL be counted in the pass total
+
+#### Scenario: Active generation differs from recorded — config_drift
+
+- **WHEN** `verify` runs on the Nix realizer and the manifest declares a home-manager input
+- **AND** the active home-manager generation number is greater than zero but differs from the recorded one
+- **THEN** the engine SHALL emit one result item with type `home-manager`, id `home-manager`, status `fail`
+- **AND** the reason SHALL be `config_drift`
+- **AND** the item SHALL surface the active generation and the expected (recorded) generation
+- **AND** that item SHALL be counted in the fail total
+
+#### Scenario: No active generation — missing
+
+- **WHEN** `verify` runs on the Nix realizer and the manifest declares a home-manager input
+- **AND** the active home-manager generation number is zero (no generation is active)
+- **THEN** the engine SHALL emit one result item with type `home-manager`, id `home-manager`, status `fail`
+- **AND** the reason SHALL be `missing`
+- **AND** that item SHALL be counted in the fail total
+
+#### Scenario: No provisioning history — missing
+
+- **WHEN** `verify` runs on the Nix realizer and the manifest declares a home-manager input
+- **AND** there is no Provisioning Generation that recorded a home-manager configuration
+- **AND** the active home-manager generation number is zero
+- **THEN** the engine SHALL emit one result item with status `fail` and reason `missing`
+
+### Requirement: verify skips home-manager check when manifest does not declare it
+
+The engine SHALL NOT emit a home-manager result item when the manifest does not declare a home-manager
+input. MUST leave existing package and manifest-verify behavior completely unchanged.
+
+#### Scenario: No homeManager field — no hm item
+
+- **WHEN** `verify` runs on the Nix realizer and the manifest declares no `homeManager` block
+- **THEN** the engine SHALL NOT emit any result item with type `home-manager`
+- **AND** all other verify items SHALL be unaffected
+
+### Requirement: verify skips home-manager check when the backend cannot read hm state
+
+The home-manager generation check SHALL be gated on the realizer implementing the `HomeGenerationReader`
+capability. MUST be skipped when the realizer does not implement it, so non-Nix or stub backends are not
+broken.
+
+#### Scenario: Backend without HomeGenerationReader — check skipped
+
+- **WHEN** `verify` runs on a realizer that does not implement `HomeGenerationReader`
+- **AND** the manifest declares a home-manager input
+- **THEN** the engine SHALL NOT emit any result item with type `home-manager`
+
+### Requirement: home-manager verify is realizer-path-only and read-only
+
+The home-manager generation check SHALL run only on the realizer path (Nix) and SHALL NOT modify any
+system state. MUST not affect the driver (winget) verify path.
+
+#### Scenario: Driver path is unchanged
+
+- **WHEN** `verify` runs through the driver (winget) path
+- **THEN** the engine SHALL NOT check or emit any home-manager result item
+- **AND** the driver verify behavior SHALL be unchanged
+
+#### Scenario: verify does not mutate state
+
+- **WHEN** `verify` runs and checks the home-manager generation
+- **THEN** the engine SHALL NOT modify the active home-manager configuration or any provisioning state

--- a/openspec/changes/nix-home-manager-verify/tasks.md
+++ b/openspec/changes/nix-home-manager-verify/tasks.md
@@ -1,0 +1,51 @@
+> TDD: write each test RED first (compile failure = valid RED), then implement to green. All tests
+> hermetic — no real nix. Override both `newRealizerFn` AND `newDriverFn` in command-level tests.
+> Seed generations with `provision.Write` under `t.Setenv("ENDSTATE_ROOT", t.TempDir())`.
+
+## 1. OpenSpec change and spec
+
+- [x] 1.1 `openspec/changes/nix-home-manager-verify/`: `.openspec.yaml`, `proposal.md`, `design.md`, `tasks.md`
+- [x] 1.2 `openspec/specs/nix-home-manager-verify/spec.md`: `## ADDED Requirements` with `### Requirement:`
+      blocks each containing `#### Scenario:` with WHEN/THEN/AND bullets.
+
+## 2. Reason constant
+
+- [ ] 2.1 `internal/driver/driver.go`: add `ReasonConfigDrift = "config_drift"` alongside `ReasonVersionDrift`.
+
+## 3. Realizer capability interface
+
+- [ ] 3.1 `internal/realizer/realizer.go`: add optional `HomeGenerationReader { ActiveHomeGeneration() int }`
+      with a doc-comment in the `Pruner` / `HomeActivator` / `HomeRollbacker` style.
+
+## 4. Nix backend implementation
+
+- [ ] 4.1 RED: compile assertion `var _ realizer.HomeGenerationReader = (*Backend)(nil)` in
+      `internal/realizer/nix/home_manager.go` — fails until method is added.
+- [ ] 4.2 Implement `(*Backend).ActiveHomeGeneration() int { return b.homeGen() }`.
+
+## 5. Extend fakeRealizer
+
+- [ ] 5.1 `internal/commands/apply_realizer_test.go`: add `activeHomeGen int` field and
+      `ActiveHomeGeneration() int` method to `fakeRealizer` (returns `f.activeHomeGen`).
+
+## 6. TDD: command-layer tests (RED then GREEN)
+
+- [ ] 6.1 RED: `TestRunVerifyRealizer_HomeManager_Pass` — declared hm, active==recorded → single
+      `home-manager` item with status `pass`; total summary counts include it.
+- [ ] 6.2 RED: `TestRunVerifyRealizer_HomeManager_ConfigDrift` — active != recorded → `fail`,
+      reason `config_drift`; `Version` and `Expected` set.
+- [ ] 6.3 RED: `TestRunVerifyRealizer_HomeManager_Missing` — active==0 → `fail`, reason `missing`.
+- [ ] 6.4 RED: `TestRunVerifyRealizer_HomeManager_NoRecordedGen_Missing` — no history at all, active==0
+      → `fail missing`.
+- [ ] 6.5 RED: `TestRunVerifyRealizer_NoHomeManager_NoHmItem` — manifest with no `homeManager` field →
+      no `home-manager` item in results; existing package verify unaffected.
+- [ ] 6.6 RED: `TestRunVerifyRealizer_NoHomeGenerationReader_Skips` — realizer does NOT implement
+      `HomeGenerationReader` → no `home-manager` item emitted even when manifest declares hm.
+- [ ] 6.7 Implement `checkHomeManagerGeneration` helper and hm check in `runVerifyRealizer`.
+
+## 7. Verification
+
+- [ ] 7.1 `cd go-engine && go test ./internal/commands/... ./internal/realizer/...` green.
+- [ ] 7.2 `cd go-engine && go test ./...` green.
+- [ ] 7.3 `GOOS=windows go build ./... && go vet ./...` clean.
+- [ ] 7.4 `npm run openspec:validate` (strict) passes.

--- a/openspec/specs/nix-home-manager-verify/spec.md
+++ b/openspec/specs/nix-home-manager-verify/spec.md
@@ -1,0 +1,86 @@
+# nix-home-manager-verify Specification
+
+## Purpose
+
+Defines the behavior of the `verify` command when the manifest declares a home-manager configuration.
+`verify` MUST check both that a home-manager generation is active and that it matches the most-recently
+recorded one, reporting a distinct `config_drift` or `missing` failure when they diverge.
+
+## Requirements
+
+### Requirement: verify checks home-manager config when declared
+
+The `verify` command on a realizer backend SHALL check the home-manager configuration when, and only when,
+the manifest declares a home-manager input. MUST produce exactly one `home-manager` item in the results with
+status `pass` when the active generation matches the recorded one, `fail` with reason `config_drift` when
+the generations diverge, or `fail` with reason `missing` when no home-manager generation is active.
+
+#### Scenario: Active generation matches recorded — pass
+
+- **WHEN** `verify` runs on the Nix realizer and the manifest declares a home-manager input
+- **AND** the active home-manager generation number equals the most-recently recorded generation number
+- **THEN** the engine SHALL emit one result item with type `home-manager`, id `home-manager`, status `pass`
+- **AND** that item SHALL be counted in the pass total
+
+#### Scenario: Active generation differs from recorded — config_drift
+
+- **WHEN** `verify` runs on the Nix realizer and the manifest declares a home-manager input
+- **AND** the active home-manager generation number is greater than zero but differs from the recorded one
+- **THEN** the engine SHALL emit one result item with type `home-manager`, id `home-manager`, status `fail`
+- **AND** the reason SHALL be `config_drift`
+- **AND** the item SHALL surface the active generation and the expected (recorded) generation
+- **AND** that item SHALL be counted in the fail total
+
+#### Scenario: No active generation — missing
+
+- **WHEN** `verify` runs on the Nix realizer and the manifest declares a home-manager input
+- **AND** the active home-manager generation number is zero (no generation is active)
+- **THEN** the engine SHALL emit one result item with type `home-manager`, id `home-manager`, status `fail`
+- **AND** the reason SHALL be `missing`
+- **AND** that item SHALL be counted in the fail total
+
+#### Scenario: No provisioning history — missing
+
+- **WHEN** `verify` runs on the Nix realizer and the manifest declares a home-manager input
+- **AND** there is no Provisioning Generation that recorded a home-manager configuration
+- **AND** the active home-manager generation number is zero
+- **THEN** the engine SHALL emit one result item with status `fail` and reason `missing`
+
+### Requirement: verify skips home-manager check when manifest does not declare it
+
+The engine SHALL NOT emit a home-manager result item when the manifest does not declare a home-manager
+input. MUST leave existing package and manifest-verify behavior completely unchanged.
+
+#### Scenario: No homeManager field — no hm item
+
+- **WHEN** `verify` runs on the Nix realizer and the manifest declares no `homeManager` block
+- **THEN** the engine SHALL NOT emit any result item with type `home-manager`
+- **AND** all other verify items SHALL be unaffected
+
+### Requirement: verify skips home-manager check when the backend cannot read hm state
+
+The home-manager generation check SHALL be gated on the realizer implementing the `HomeGenerationReader`
+capability. MUST be skipped when the realizer does not implement it, so non-Nix or stub backends are not
+broken.
+
+#### Scenario: Backend without HomeGenerationReader — check skipped
+
+- **WHEN** `verify` runs on a realizer that does not implement `HomeGenerationReader`
+- **AND** the manifest declares a home-manager input
+- **THEN** the engine SHALL NOT emit any result item with type `home-manager`
+
+### Requirement: home-manager verify is realizer-path-only and read-only
+
+The home-manager generation check SHALL run only on the realizer path (Nix) and SHALL NOT modify any
+system state. MUST not affect the driver (winget) verify path.
+
+#### Scenario: Driver path is unchanged
+
+- **WHEN** `verify` runs through the driver (winget) path
+- **THEN** the engine SHALL NOT check or emit any home-manager result item
+- **AND** the driver verify behavior SHALL be unchanged
+
+#### Scenario: verify does not mutate state
+
+- **WHEN** `verify` runs and checks the home-manager generation
+- **THEN** the engine SHALL NOT modify the active home-manager configuration or any provisioning state


### PR DESCRIPTION
Closes the **verification-first** gap for home-manager config: `verify` checked packages + manifest verify entries but completely ignored the home-manager config that `apply --enable-restore` activates and records. Now it checks it.

Part of a 3-PR parallel batch — recommended merge order **B (this) → C (version capture) → D (catalog capture)**. B is the most independent; it only overlaps the others in the shared `fakeRealizer` test double.

## What
When the manifest declares a home-manager input, the realizer `verify` path checks **presence + drift vs recorded**:
- reads the active home-manager generation (off the nix profile symlink),
- compares to the generation Endstate last recorded (`provision.List()`, most-recent non-nil `HomeManager`),
- **pass** when they match; **fail `config_drift`** when the active gen differs (out-of-band change); **fail `missing`** when nothing is active.
- New optional `realizer.HomeGenerationReader` interface (type-asserted like `Pruner`/`HomeActivator`/`HomeRollbacker`); the Nix backend implements it; other backends skip the check. New `driver.ReasonConfigDrift`. Per-item failures don't flip envelope `success` (existing verify contract). Realizer-only.
- OpenSpec change `nix-home-manager-verify`.

## Verification
- `go test ./...` green; `GOOS=windows go build ./...` + `go vet` clean; `npm run openspec:validate` 63/63.
- **Real-nix smoke:** apply hm config → `verify` = **pass** ("generation 1 matches recorded"); switch a *different* config out-of-band (→ `home-manager-2-link`) → `verify` = **fail `config_drift`** ("generation 2 is active, want 1 (recorded)"); package-only manifest → **0** home-manager items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)