### PR TITLE
feat(engine): broaden home-manager curated catalog (fzf, zoxide, bat, tmux, ssh)

### DIFF
--- a/go-engine/internal/manifest/home_settings_test.go
+++ b/go-engine/internal/manifest/home_settings_test.go
@@ -90,6 +90,79 @@ func TestLoadManifest_HomeManagerSettings_RejectsUnknownCuratedKey(t *testing.T)
 	}
 }
 
+// TestLoadManifest_HomeManagerSettings_BroadenedCurated verifies the broadened
+// curated catalog concepts (fzf, zoxide, bat, tmux, ssh) round-trip through JSONC
+// load with their typed fields retained.
+func TestLoadManifest_HomeManagerSettings_BroadenedCurated(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "m.jsonc")
+	content := `{
+  "version": 1,
+  "name": "hm-broaden",
+  "apps": [],
+  "homeManager": {
+    "settings": {
+      "fzf": { "enable": true },
+      "zoxide": { "enable": true },
+      "bat": { "enable": true, "config": { "theme": "TwoDark" } },
+      "tmux": { "enable": true, "extraConfig": "set -g mouse on" },
+      "ssh": { "enable": true, "extraConfig": "Host *\n  ServerAliveInterval 60" }
+    }
+  }
+}`
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := LoadManifest(p)
+	if err != nil {
+		t.Fatalf("unexpected error loading broadened catalog: %v", err)
+	}
+	if m.HomeManager == nil || m.HomeManager.Settings == nil {
+		t.Fatal("HomeManager.Settings = nil, want non-nil")
+	}
+	s := m.HomeManager.Settings
+	if s.Fzf == nil || !s.Fzf.Enable {
+		t.Errorf("fzf = %+v, want enable=true", s.Fzf)
+	}
+	if s.Zoxide == nil || !s.Zoxide.Enable {
+		t.Errorf("zoxide = %+v, want enable=true", s.Zoxide)
+	}
+	if s.Bat == nil || !s.Bat.Enable || s.Bat.Config["theme"] != "TwoDark" {
+		t.Errorf("bat = %+v, want enable=true + theme=TwoDark", s.Bat)
+	}
+	if s.Tmux == nil || !s.Tmux.Enable || s.Tmux.ExtraConfig != "set -g mouse on" {
+		t.Errorf("tmux = %+v, want enable=true + extraConfig", s.Tmux)
+	}
+	if s.SSH == nil || !s.SSH.Enable || !strings.Contains(s.SSH.ExtraConfig, "ServerAliveInterval") {
+		t.Errorf("ssh = %+v, want enable=true + extraConfig", s.SSH)
+	}
+}
+
+// TestLoadManifest_HomeManagerSettings_RejectsUnknownBroadenedKey verifies a typo'd
+// sub-key on a broadened curated concept (e.g. bat.confgi) fails to load rather than
+// being silently dropped.
+func TestLoadManifest_HomeManagerSettings_RejectsUnknownBroadenedKey(t *testing.T) {
+	cases := map[string]string{
+		"bat-typo":  `"bat": { "confgi": { "theme": "x" } }`,
+		"tmux-typo": `"tmux": { "extraConfigg": "x" }`,
+		"ssh-typo":  `"ssh": { "extarConfig": "x" }`,
+		"fzf-typo":  `"fzf": { "enabel": true }`,
+	}
+	for name, block := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			p := filepath.Join(dir, "m.jsonc")
+			content := `{ "version": 1, "name": "typo", "apps": [], "homeManager": { "settings": { ` + block + ` } } }`
+			if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := LoadManifest(p); err == nil {
+				t.Fatalf("%s: expected an error for an unknown sub-key, got nil", name)
+			}
+		})
+	}
+}
+
 // TestLoadManifest_HomeManagerInputsMutuallyExclusive verifies settings / config /
 // flake are mutually exclusive — any pair fails to load with a clear error.
 func TestLoadManifest_HomeManagerInputsMutuallyExclusive(t *testing.T) {

--- a/go-engine/internal/manifest/types.go
+++ b/go-engine/internal/manifest/types.go
@@ -70,6 +70,11 @@ type HomeManagerSettings struct {
 	Shell    *ShellSettings    `json:"shell,omitempty"`
 	Direnv   *ProgramToggle    `json:"direnv,omitempty"`
 	Starship *ProgramToggle    `json:"starship,omitempty"`
+	Fzf      *ProgramToggle    `json:"fzf,omitempty"`
+	Zoxide   *ProgramToggle    `json:"zoxide,omitempty"`
+	Bat      *BatSettings      `json:"bat,omitempty"`
+	Tmux     *TmuxSettings     `json:"tmux,omitempty"`
+	SSH      *SSHSettings      `json:"ssh,omitempty"`
 	Programs map[string]any    `json:"programs,omitempty"` // raw home-manager passthrough
 	Files    map[string]string `json:"files,omitempty"`    // target path -> source path (relative to manifest)
 }
@@ -105,9 +110,34 @@ type ShellSettings struct {
 	SessionVariables map[string]string `json:"sessionVariables,omitempty"`
 }
 
-// ProgramToggle is a curated enable flag for a single home-manager program.
+// ProgramToggle is a curated enable flag for a single home-manager program
+// (mapped to programs.<name>.enable — e.g. direnv, starship, fzf, zoxide).
 type ProgramToggle struct {
 	Enable bool `json:"enable,omitempty"`
+}
+
+// BatSettings are the curated bat concepts mapped to home-manager's
+// programs.bat.enable plus programs.bat.config (a stable key→value attrset of
+// bat config entries forwarded verbatim).
+type BatSettings struct {
+	Enable bool              `json:"enable,omitempty"`
+	Config map[string]string `json:"config,omitempty"`
+}
+
+// TmuxSettings are the curated tmux concepts mapped to programs.tmux.enable plus
+// programs.tmux.extraConfig — the raw tmux.conf string, which is the stable surface
+// that insulates the user from home-manager tmux option renames.
+type TmuxSettings struct {
+	Enable      bool   `json:"enable,omitempty"`
+	ExtraConfig string `json:"extraConfig,omitempty"`
+}
+
+// SSHSettings are the curated ssh concepts mapped to programs.ssh.enable plus
+// programs.ssh.extraConfig — the raw ssh config string, the stable surface that
+// insulates the user from home-manager ssh option renames.
+type SSHSettings struct {
+	Enable      bool   `json:"enable,omitempty"`
+	ExtraConfig string `json:"extraConfig,omitempty"`
 }
 
 // App represents a single application entry in the manifest. The Refs map

--- a/go-engine/internal/realizer/nix/home_catalog.go
+++ b/go-engine/internal/realizer/nix/home_catalog.go
@@ -22,6 +22,11 @@ var curatedPrograms = map[string]bool{
 	"git":      true,
 	"direnv":   true,
 	"starship": true,
+	"fzf":      true,
+	"zoxide":   true,
+	"bat":      true,
+	"tmux":     true,
+	"ssh":      true,
 }
 
 // GenerateHomeFlakeFromSettings compiles a declarative catalog (settings) into a
@@ -91,6 +96,39 @@ func CompileHomeNix(s *manifest.HomeManagerSettings, manifestDir string) ([]byte
 	}
 	if s.Starship != nil {
 		stmts = append(stmts, "programs.starship.enable = "+nixValue(s.Starship.Enable)+";")
+	}
+	if s.Fzf != nil {
+		stmts = append(stmts, "programs.fzf.enable = "+nixValue(s.Fzf.Enable)+";")
+	}
+	if s.Zoxide != nil {
+		stmts = append(stmts, "programs.zoxide.enable = "+nixValue(s.Zoxide.Enable)+";")
+	}
+
+	// bat → enable + the STABLE programs.bat.config attrset (key→value forwarded
+	// verbatim, sorted for determinism).
+	if s.Bat != nil {
+		stmts = append(stmts, "programs.bat.enable = "+nixValue(s.Bat.Enable)+";")
+		if len(s.Bat.Config) > 0 {
+			stmts = append(stmts, "programs.bat.config = "+nixValue(stringMapToAny(s.Bat.Config))+";")
+		}
+	}
+
+	// tmux → enable + the STABLE programs.tmux.extraConfig (raw tmux.conf string —
+	// insulates the user from home-manager tmux option renames).
+	if s.Tmux != nil {
+		stmts = append(stmts, "programs.tmux.enable = "+nixValue(s.Tmux.Enable)+";")
+		if s.Tmux.ExtraConfig != "" {
+			stmts = append(stmts, "programs.tmux.extraConfig = "+nixValue(s.Tmux.ExtraConfig)+";")
+		}
+	}
+
+	// ssh → enable + the STABLE programs.ssh.extraConfig (raw ssh config string —
+	// insulates the user from home-manager ssh option renames).
+	if s.SSH != nil {
+		stmts = append(stmts, "programs.ssh.enable = "+nixValue(s.SSH.Enable)+";")
+		if s.SSH.ExtraConfig != "" {
+			stmts = append(stmts, "programs.ssh.extraConfig = "+nixValue(s.SSH.ExtraConfig)+";")
+		}
 	}
 
 	// raw programs passthrough, verbatim, sorted for determinism.

--- a/go-engine/internal/realizer/nix/home_catalog_test.go
+++ b/go-engine/internal/realizer/nix/home_catalog_test.go
@@ -56,7 +56,7 @@ func TestCompileHomeNix_CuratedAndRaw(t *testing.T) {
 		Git:      &manifest.GitSettings{UserName: "Hugo", UserEmail: "h@x.com", DefaultBranch: "main"},
 		Shell:    &manifest.ShellSettings{Aliases: map[string]string{"ll": "ls -la"}, SessionVariables: map[string]string{"EDITOR": "nvim"}},
 		Direnv:   &manifest.ProgramToggle{Enable: true},
-		Programs: map[string]any{"bat": map[string]any{"enable": true}},
+		Programs: map[string]any{"htop": map[string]any{"enable": true}}, // non-curated raw passthrough
 	}
 	home, staged, err := CompileHomeNix(s, t.TempDir())
 	if err != nil {
@@ -76,7 +76,7 @@ func TestCompileHomeNix_CuratedAndRaw(t *testing.T) {
 		"home.sessionVariables",
 		`"EDITOR" = "nvim";`,
 		"programs.direnv.enable = true;",
-		"programs.bat = ", // raw passthrough, verbatim program name
+		"programs.htop = ", // raw passthrough, verbatim program name
 		`"enable" = true`,
 	} {
 		if !strings.Contains(out, w) {
@@ -89,10 +89,76 @@ func TestCompileHomeNix_CuratedAndRaw(t *testing.T) {
 	}
 }
 
+// TestCompileHomeNix_BroadenedCurated: the broadened curated concepts (fzf, zoxide,
+// bat, tmux, ssh) render the expected stable home-manager statements.
+func TestCompileHomeNix_BroadenedCurated(t *testing.T) {
+	s := &manifest.HomeManagerSettings{
+		Fzf:    &manifest.ProgramToggle{Enable: true},
+		Zoxide: &manifest.ProgramToggle{Enable: true},
+		Bat:    &manifest.BatSettings{Enable: true, Config: map[string]string{"theme": "TwoDark", "italic-text": "always"}},
+		Tmux:   &manifest.TmuxSettings{Enable: true, ExtraConfig: "set -g mouse on"},
+		SSH:    &manifest.SSHSettings{Enable: true, ExtraConfig: "Host *\n  ServerAliveInterval 60"},
+	}
+	home, _, err := CompileHomeNix(s, t.TempDir())
+	if err != nil {
+		t.Fatalf("CompileHomeNix: %v", err)
+	}
+	out := string(home)
+	for _, w := range []string{
+		"programs.fzf.enable = true;",
+		"programs.zoxide.enable = true;",
+		"programs.bat.enable = true;",
+		"programs.bat.config = ",
+		`"theme" = "TwoDark"`,
+		`"italic-text" = "always"`,
+		"programs.tmux.enable = true;",
+		`programs.tmux.extraConfig = "set -g mouse on";`,
+		"programs.ssh.enable = true;",
+		`programs.ssh.extraConfig = "Host *\n  ServerAliveInterval 60";`,
+	} {
+		if !strings.Contains(out, w) {
+			t.Errorf("compiled home.nix missing %q\n---\n%s", w, out)
+		}
+	}
+}
+
+// TestCompileHomeNix_BroadenedToggleDisabled: a broadened toggle with enable=false
+// still renders an explicit statement (so the user can pin "off").
+func TestCompileHomeNix_BroadenedToggleDisabled(t *testing.T) {
+	s := &manifest.HomeManagerSettings{Fzf: &manifest.ProgramToggle{Enable: false}}
+	home, _, err := CompileHomeNix(s, t.TempDir())
+	if err != nil {
+		t.Fatalf("CompileHomeNix: %v", err)
+	}
+	if !strings.Contains(string(home), "programs.fzf.enable = false;") {
+		t.Errorf("compiled home.nix missing explicit fzf disable:\n%s", home)
+	}
+}
+
+// TestCompileHomeNix_BroadenedRawOverlapErrors: a raw programs key colliding with a
+// broadened curated concept (e.g. raw programs.fzf + curated fzf) is a clear error.
+func TestCompileHomeNix_BroadenedRawOverlapErrors(t *testing.T) {
+	for _, name := range []string{"fzf", "zoxide", "bat", "tmux", "ssh"} {
+		t.Run(name, func(t *testing.T) {
+			s := &manifest.HomeManagerSettings{
+				Fzf:      &manifest.ProgramToggle{Enable: true},
+				Zoxide:   &manifest.ProgramToggle{Enable: true},
+				Bat:      &manifest.BatSettings{Enable: true},
+				Tmux:     &manifest.TmuxSettings{Enable: true},
+				SSH:      &manifest.SSHSettings{Enable: true},
+				Programs: map[string]any{name: map[string]any{"enable": true}},
+			}
+			if _, _, err := CompileHomeNix(s, t.TempDir()); err == nil {
+				t.Fatalf("expected an error for raw programs.%s overlapping curated %s, got nil", name, name)
+			}
+		})
+	}
+}
+
 // TestCompileHomeNix_Deterministic: identical settings → identical output.
 func TestCompileHomeNix_Deterministic(t *testing.T) {
 	s := &manifest.HomeManagerSettings{
-		Programs: map[string]any{"bat": map[string]any{"enable": true}, "fzf": map[string]any{"enable": true}},
+		Programs: map[string]any{"htop": map[string]any{"enable": true}, "lsd": map[string]any{"enable": true}},
 	}
 	d := t.TempDir()
 	a, _, err := CompileHomeNix(s, d)

--- a/manifests/examples/hm-settings-assets/starship.toml
+++ b/manifests/examples/hm-settings-assets/starship.toml
@@ -1,0 +1,7 @@
+# Minimal starship prompt config staged by the home-manager catalog example.
+# Placed at ~/.config/starship.toml via homeManager.settings.files.
+add_newline = false
+
+[character]
+success_symbol = "[➜](bold green)"
+error_symbol = "[➜](bold red)"

--- a/manifests/examples/home-manager-settings.jsonc
+++ b/manifests/examples/home-manager-settings.jsonc
@@ -1,0 +1,58 @@
+{
+  // Endstate-native home-manager catalog (homeManager.settings): declare your
+  // config in Endstate's own format — the engine compiles the home.nix, wraps it
+  // in a generated flake, and activates it. Apply with:
+  //   endstate apply --manifest manifests/examples/home-manager-settings.jsonc --enable-restore
+  // (the config stage is opt-in via --enable-restore; the winget path ignores it.)
+  "version": 1,
+  "name": "home-manager-settings",
+  "apps": [],
+
+  "homeManager": {
+    "settings": {
+      // Curated concepts — each maps to a STABLE home-manager option, so the
+      // declaration keeps working across home-manager option renames.
+      "git": {
+        "userName": "Ada Lovelace",
+        "userEmail": "ada@example.com",
+        "defaultBranch": "main"
+      },
+      "shell": {
+        "aliases": { "ll": "ls -la", "gs": "git status" },
+        "sessionVariables": { "EDITOR": "nvim" }
+      },
+      "direnv": { "enable": true },
+      "starship": { "enable": true },
+
+      // Broadened curated concepts.
+      "fzf": { "enable": true },
+      "zoxide": { "enable": true },
+      "bat": {
+        "enable": true,
+        "config": { "theme": "TwoDark", "italic-text": "always" }
+      },
+      "tmux": {
+        "enable": true,
+        // Raw tmux.conf — the stable surface (programs.tmux.extraConfig).
+        "extraConfig": "set -g mouse on\nset -g history-limit 50000"
+      },
+      "ssh": {
+        "enable": true,
+        // Raw ssh config — the stable surface (programs.ssh.extraConfig).
+        "extraConfig": "Host *\n  ServerAliveInterval 60\n  ServerAliveCountMax 3"
+      },
+
+      // Raw home-manager passthrough — forwarded verbatim. Use this for any
+      // program NOT in the curated set above (a curated name here would conflict).
+      "programs": {
+        "htop": { "enable": true, "settings": { "show_program_path": false } }
+      },
+
+      // Arbitrary files placed via home-manager (source resolved relative to this
+      // manifest). Target path → source path.
+      "files": {
+        "~/.config/starship.toml": "./hm-settings-assets/starship.toml"
+      }
+    }
+  }
+}

--- a/openspec/changes/nix-home-manager-catalog-broaden/.openspec.yaml
+++ b/openspec/changes/nix-home-manager-catalog-broaden/.openspec.yaml
@@ -1,0 +1,10 @@
+id: nix-home-manager-catalog-broaden
+title: "Broaden the curated home-manager catalog (fzf, zoxide, bat, tmux, ssh)"
+status: implementing
+spec: nix-home-manager-catalog
+created: "2026-06-03"
+author: Hugo Ander Kivi
+artifacts:
+  - proposal.md
+  - design.md
+  - tasks.md

--- a/openspec/changes/nix-home-manager-catalog-broaden/design.md
+++ b/openspec/changes/nix-home-manager-catalog-broaden/design.md
@@ -1,0 +1,135 @@
+## Context
+
+- `manifest.HomeManagerSettings` (`internal/manifest/types.go`, PR #91) is the declarative catalog
+  struct: typed curated fields (`Git`, `Shell`, `Direnv`, `Starship`) + a permissive `Programs` raw
+  passthrough + a `Files` map. Its custom `UnmarshalJSON` decodes with `DisallowUnknownFields`, so any
+  unknown sub-key WITHIN a typed curated concept fails to load. `Programs`/`Files` are maps and stay
+  permissive (maps have no "unknown fields").
+- `CompileHomeNix` (`internal/realizer/nix/home_catalog.go`) renders the `home.nix`: curated concepts
+  become fixed `programs.*`/`home.*` statements, the raw `programs` block is forwarded verbatim
+  (`nixValue`), and `files` are staged + placed via `home.file`. Output is deterministic (sorted keys).
+- `curatedPrograms` lists each curated concept that owns a `programs.<name>` entry. A raw `programs`
+  key matching one is rejected (`programs.<name> conflicts with the curated "<name>" concept`), because
+  the curated concept already emits that `programs.<name>` and Nix would reject a double definition.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add five curated concepts (`fzf`, `zoxide`, `bat`, `tmux`, `ssh`), each mapped to a STABLE
+  home-manager surface, so the catalog covers a common developer shell without dropping to the raw
+  passthrough.
+- Preserve unknown-sub-key rejection, the raw-overlap conflict, and deterministic rendering.
+- Hermetic tests only; no live Nix invocations.
+
+**Non-Goals:**
+- No change to the four existing curated concepts, the raw passthrough, or the files map.
+- No capture-side change (a settings-applied machine already round-trips: capture records the whole
+  `HomeManagerSettings`, which now simply carries more fields).
+- No exhaustive home-manager option surface — only the stable, rename-insulated keys below.
+
+## Decisions
+
+- **Prefer stable surfaces, mirroring git → `programs.git.extraConfig`.** Curated concepts exist to
+  insulate the declaration from home-manager option renames. `extraConfig`/`config`/`enable` are the
+  long-lived, rarely-renamed surfaces of these modules; per-feature typed options (e.g.
+  `programs.tmux.keyMode`) churn and would defeat the purpose. So `tmux`/`ssh` expose the raw config
+  string, `bat` exposes the config attrset, and `fzf`/`zoxide` expose only `enable`.
+- **Reuse `ProgramToggle` for `fzf`/`zoxide`** — they are pure enable flags, identical to
+  `direnv`/`starship`. `bat`/`tmux`/`ssh` get small typed structs (`BatSettings`, `TmuxSettings`,
+  `SSHSettings`) because they carry a second field; typed structs are what trigger the unknown-sub-key
+  rejection.
+- **Register all five in `curatedPrograms`** — each owns a `programs.<name>` entry, so a raw
+  `programs.<name>` must conflict (reuse the existing error). Without this a user could double-define
+  `programs.fzf` and get an opaque Nix error.
+- **`enable` is rendered explicitly even when false** — like the existing direnv/starship toggles —
+  so a user can pin a program OFF; the second field (config/extraConfig) is omitted when empty.
+
+## Design
+
+### Curated mapping table
+
+| Endstate concept     | Stable home-manager option(s)                     | Typed struct      | Why stable |
+|----------------------|---------------------------------------------------|-------------------|------------|
+| `fzf.enable`         | `programs.fzf.enable`                              | `ProgramToggle`   | `enable` is the module's permanent on/off surface (like direnv/starship). |
+| `zoxide.enable`      | `programs.zoxide.enable`                           | `ProgramToggle`   | Same — pure enable toggle. |
+| `bat.enable`         | `programs.bat.enable`                              | `BatSettings`     | `enable` + the `config` attrset are bat's documented long-lived surface; `config` keys are bat's own config names, forwarded verbatim. |
+| `bat.config`         | `programs.bat.config` (`key→value` attrset)       | `BatSettings`     | |
+| `tmux.enable`        | `programs.tmux.enable`                             | `TmuxSettings`    | `extraConfig` is a raw `tmux.conf` string — tmux's own stable config language; insulates from home-manager per-option renames. |
+| `tmux.extraConfig`   | `programs.tmux.extraConfig` (raw `tmux.conf`)     | `TmuxSettings`    | |
+| `ssh.enable`         | `programs.ssh.enable`                              | `SSHSettings`     | `extraConfig` is a raw ssh-config string — ssh's own stable config language; same insulation rationale. |
+| `ssh.extraConfig`    | `programs.ssh.extraConfig` (raw ssh config)       | `SSHSettings`     | |
+
+### Schema (`internal/manifest/types.go`)
+
+```go
+type HomeManagerSettings struct {
+    Git      *GitSettings   `json:"git,omitempty"`
+    Shell    *ShellSettings `json:"shell,omitempty"`
+    Direnv   *ProgramToggle `json:"direnv,omitempty"`
+    Starship *ProgramToggle `json:"starship,omitempty"`
+    Fzf      *ProgramToggle `json:"fzf,omitempty"`     // NEW
+    Zoxide   *ProgramToggle `json:"zoxide,omitempty"`  // NEW
+    Bat      *BatSettings   `json:"bat,omitempty"`     // NEW
+    Tmux     *TmuxSettings  `json:"tmux,omitempty"`    // NEW
+    SSH      *SSHSettings   `json:"ssh,omitempty"`     // NEW
+    Programs map[string]any    `json:"programs,omitempty"`
+    Files    map[string]string `json:"files,omitempty"`
+}
+
+type BatSettings struct {
+    Enable bool              `json:"enable,omitempty"`
+    Config map[string]string `json:"config,omitempty"`
+}
+type TmuxSettings struct {
+    Enable      bool   `json:"enable,omitempty"`
+    ExtraConfig string `json:"extraConfig,omitempty"`
+}
+type SSHSettings struct {
+    Enable      bool   `json:"enable,omitempty"`
+    ExtraConfig string `json:"extraConfig,omitempty"`
+}
+```
+
+### Rendering (`internal/realizer/nix/home_catalog.go`)
+
+`curatedPrograms` gains `fzf`, `zoxide`, `bat`, `tmux`, `ssh`. `CompileHomeNix` appends, after the
+direnv/starship blocks:
+
+```go
+if s.Fzf != nil    { stmts = append(stmts, "programs.fzf.enable = "+nixValue(s.Fzf.Enable)+";") }
+if s.Zoxide != nil { stmts = append(stmts, "programs.zoxide.enable = "+nixValue(s.Zoxide.Enable)+";") }
+if s.Bat != nil {
+    stmts = append(stmts, "programs.bat.enable = "+nixValue(s.Bat.Enable)+";")
+    if len(s.Bat.Config) > 0 {
+        stmts = append(stmts, "programs.bat.config = "+nixValue(stringMapToAny(s.Bat.Config))+";")
+    }
+}
+if s.Tmux != nil {
+    stmts = append(stmts, "programs.tmux.enable = "+nixValue(s.Tmux.Enable)+";")
+    if s.Tmux.ExtraConfig != "" {
+        stmts = append(stmts, "programs.tmux.extraConfig = "+nixValue(s.Tmux.ExtraConfig)+";")
+    }
+}
+if s.SSH != nil {
+    stmts = append(stmts, "programs.ssh.enable = "+nixValue(s.SSH.Enable)+";")
+    if s.SSH.ExtraConfig != "" {
+        stmts = append(stmts, "programs.ssh.extraConfig = "+nixValue(s.SSH.ExtraConfig)+";")
+    }
+}
+```
+
+`nixValue` already escapes newlines/quotes/`${`, so the raw `extraConfig` strings render as correct,
+single-line Nix string literals.
+
+## Risks / Verification
+
+- **Two pre-existing tests used `bat`/`fzf` as raw-passthrough placeholders.** Now that those names
+  are curated, a raw `programs.bat` is a conflict — correct behavior. The tests switch to a non-curated
+  name (`htop`/`lsd`), preserving their intent (raw passthrough of an arbitrary program).
+- **Hermetic tests** — render each new concept; explicit-false toggle; raw-overlap conflict for all
+  five; unknown-sub-key rejection (`bat.confgi`, `tmux.extraConfigg`, `ssh.extarConfig`, `fzf.enabel`);
+  determinism unchanged.
+- **`GOOS=windows` build + `go vet`** — the catalog path is Nix-only; Windows never reaches it.
+- **Real-nix smoke** (Linux dev box): apply a manifest declaring 2-3 new concepts with
+  `--enable-restore`, then assert the activated home-manager config exposes them (e.g. `bat config`,
+  `~/.tmux.conf`, `~/.ssh/config`).

--- a/openspec/changes/nix-home-manager-catalog-broaden/proposal.md
+++ b/openspec/changes/nix-home-manager-catalog-broaden/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+PR #91 introduced `homeManager.settings` — the user declares configuration in Endstate's own catalog
+format and the engine compiles a `home.nix`, wraps it in a generated flake, and activates it. The
+curated set shipped with four concepts (`git`, `shell`, `direnv`, `starship`) plus a raw `programs`
+passthrough and a `files` map. Each curated concept is the value of the catalog: it maps to a **stable**
+home-manager option, so the declaration keeps working across home-manager option renames — the raw
+passthrough does not buy that insulation.
+
+The curated set is too small to cover a common developer shell. A user who wants `fzf`, `zoxide`, `bat`,
+`tmux`, or `ssh` today must drop to the raw `programs` passthrough, losing the rename-insulation the
+curated layer exists to provide. Broadening the curated set is the next step of the catalog arc.
+
+## What Changes
+
+- **Add five curated concepts**, each mapped to a stable home-manager surface:
+  - `fzf` → `programs.fzf.enable` (a `ProgramToggle`, exactly like `direnv`/`starship`).
+  - `zoxide` → `programs.zoxide.enable` (a `ProgramToggle`).
+  - `bat` → `programs.bat.enable` + `programs.bat.config` (a `key→value` attrset forwarded verbatim).
+  - `tmux` → `programs.tmux.enable` + `programs.tmux.extraConfig` (the raw `tmux.conf` string — the
+    stable surface that dodges tmux option-rename churn).
+  - `ssh` → `programs.ssh.enable` + `programs.ssh.extraConfig` (the raw ssh-config string — the stable
+    surface).
+- **Each concept is a typed field** on `HomeManagerSettings`, so the existing unknown-field rejection
+  (`UnmarshalJSON` + `DisallowUnknownFields`) catches a mistyped sub-key (e.g. `bat.confgi`) at load —
+  a silent drop would mean a setting that mysteriously never applies.
+- **Each concept that owns a `programs.<name>` entry is registered in `curatedPrograms`**, so a raw
+  `programs.<name>` passthrough that targets the same name conflicts loudly (the existing conflict
+  error), rather than producing a Nix double-definition.
+- **Deterministic rendering preserved** — the new concepts render fixed statements; the `bat.config`
+  attrset is sorted; identical settings still yield identical `home.nix`.
+- **Example manifest** under `manifests/examples/home-manager-settings.jsonc` showing curated concepts
+  (including the new ones) + a raw `programs` block + a `files` entry (with a staged source file).
+
+## Capabilities
+
+### New Capabilities
+
+- `nix-home-manager-catalog`: the curated home-manager catalog accepts the additional concepts `fzf`,
+  `zoxide`, `bat`, `tmux`, and `ssh`, each mapped to a stable home-manager option, so a user declaring
+  these in Endstate's format is insulated from home-manager option renames without dropping to the raw
+  passthrough. Mistyped sub-keys are rejected at load; a raw passthrough colliding with a curated name
+  is a clear error.
+
+### Modified Capabilities
+
+- None. Purely additive to the existing catalog compile path; the four prior curated concepts, the raw
+  passthrough, and the files map are unchanged.
+
+## Impact
+
+- `internal/manifest/types.go` — `HomeManagerSettings` gains `Fzf`/`Zoxide` (`*ProgramToggle`), `Bat`
+  (`*BatSettings`), `Tmux` (`*TmuxSettings`), `SSH` (`*SSHSettings`); three small typed structs added.
+- `internal/realizer/nix/home_catalog.go` — `curatedPrograms` gains `fzf`/`zoxide`/`bat`/`tmux`/`ssh`;
+  `CompileHomeNix` renders each new concept following the existing git/direnv/starship patterns.
+- `internal/manifest/home_settings_test.go` — load + unknown-sub-key rejection tests for the new
+  concepts.
+- `internal/realizer/nix/home_catalog_test.go` — render + raw-overlap conflict tests; two pre-existing
+  tests that used `bat`/`fzf` as raw-passthrough placeholders switch to a non-curated name (`htop`).
+- `manifests/examples/home-manager-settings.jsonc` (+ a staged `hm-settings-assets/` source — kept out
+  of the gitignored `payload/` tree so the example is self-consistent in the repo) — example manifest.
+- Zero winget / Windows / package-capture regression; the catalog path is Nix-only.

--- a/openspec/changes/nix-home-manager-catalog-broaden/specs/nix-home-manager-catalog/spec.md
+++ b/openspec/changes/nix-home-manager-catalog-broaden/specs/nix-home-manager-catalog/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: The curated catalog maps additional developer programs to stable home-manager options
+
+The engine SHALL accept the curated home-manager catalog concepts `fzf`, `zoxide`, `bat`, `tmux`, and
+`ssh` declared in `homeManager.settings`, and SHALL map each to a **stable** home-manager option so the
+declaration keeps working when the underlying home-manager option surface changes. The user SHALL NOT
+have to author any Nix to declare these.
+
+- `fzf` and `zoxide` SHALL map to `programs.fzf.enable` and `programs.zoxide.enable` respectively.
+- `bat` SHALL map to `programs.bat.enable` plus an optional `programs.bat.config` key→value attrset.
+- `tmux` SHALL map to `programs.tmux.enable` plus an optional `programs.tmux.extraConfig` (a raw
+  `tmux.conf` string).
+- `ssh` SHALL map to `programs.ssh.enable` plus an optional `programs.ssh.extraConfig` (a raw ssh
+  config string).
+
+#### Scenario: A new curated concept is compiled into the generated home.nix
+
+- **WHEN** `apply` runs on the Nix realizer with configuration changes enabled and the manifest declares
+  one of the curated concepts `fzf`, `zoxide`, `bat`, `tmux`, or `ssh`
+- **THEN** the engine SHALL compile it into the corresponding `programs.<name>` option(s) in the
+  generated `home.nix`
+- **AND** the user SHALL NOT have to author any Nix, `home.nix`, or flake wiring
+
+#### Scenario: The mapping uses a stable surface
+
+- **WHEN** the declaration uses `tmux` or `ssh`
+- **THEN** the engine SHALL render the raw configuration string through `extraConfig` rather than a
+  per-feature typed option
+- **AND** the mapping SHALL shield the declaration from home-manager option renames, so the curated
+  concept keeps working when the underlying per-feature options change
+
+#### Scenario: An enable toggle can pin a program off
+
+- **WHEN** a curated toggle concept (`fzf`, `zoxide`) declares `enable: false`
+- **THEN** the engine SHALL render an explicit `programs.<name>.enable = false` in the generated
+  `home.nix`
+
+#### Scenario: The bat config attrset is forwarded and deterministic
+
+- **WHEN** the declaration sets `bat.config` to a set of key→value entries
+- **THEN** the engine SHALL render them as `programs.bat.config` in the generated `home.nix`
+- **AND** the rendering SHALL be deterministic, so identical settings produce an identical `home.nix`
+
+### Requirement: New curated concepts reject unknown sub-keys and conflict with overlapping raw passthrough
+
+The broadened curated concepts SHALL share the catalog's load-time and compile-time guards: a mistyped
+sub-key SHALL be rejected at load, and a raw `programs.<name>` passthrough that targets the same name as
+a curated concept SHALL be a clear error rather than a Nix double definition.
+
+#### Scenario: A mistyped sub-key on a new concept is rejected
+
+- **WHEN** a declaration uses a new curated concept with an unrecognized sub-key (for example
+  `bat.confgi`, `tmux.extraConfigg`, `ssh.extarConfig`, or `fzf.enabel`)
+- **THEN** the engine SHALL reject the manifest with a clear error rather than silently dropping the
+  setting
+
+#### Scenario: A raw passthrough overlapping a new curated concept is an error
+
+- **WHEN** a declaration sets both a new curated concept (for example `fzf`) and a raw `programs` entry
+  for the same name (`programs.fzf`)
+- **THEN** the engine SHALL reject the declaration with a clear conflict error rather than emitting a
+  duplicate `programs.<name>` definition

--- a/openspec/changes/nix-home-manager-catalog-broaden/tasks.md
+++ b/openspec/changes/nix-home-manager-catalog-broaden/tasks.md
@@ -1,0 +1,37 @@
+> TDD: write each test RED first, then implement to green. Hermetic (no live Nix calls). Verify:
+> `cd go-engine && go test ./...` + `go vet ./...` + `GOOS=windows go build ./...`; real-nix apply smoke.
+
+## 1. Schema — add typed curated fields
+
+- [x] 1.1 RED tests (`home_settings_test.go`): the new concepts (`fzf`, `zoxide`, `bat`, `tmux`, `ssh`)
+      round-trip through JSONC load; a mistyped sub-key (`bat.confgi`, `tmux.extraConfigg`,
+      `ssh.extarConfig`, `fzf.enabel`) fails to load.
+- [x] 1.2 `internal/manifest/types.go`: add `Fzf`/`Zoxide` (`*ProgramToggle`), `Bat` (`*BatSettings`),
+      `Tmux` (`*TmuxSettings`), `SSH` (`*SSHSettings`) to `HomeManagerSettings`; add the three small
+      typed structs.
+
+## 2. Rendering — map each concept to a stable home-manager option
+
+- [x] 2.1 RED tests (`home_catalog_test.go`): each new concept renders its expected statement(s)
+      (`programs.fzf.enable`, `programs.bat.config`, `programs.tmux.extraConfig`,
+      `programs.ssh.extraConfig`, …); an explicit `enable=false` toggle renders; a raw `programs.<name>`
+      colliding with a curated concept (all five) is a clear error; determinism preserved.
+- [x] 2.2 `internal/realizer/nix/home_catalog.go`: add the five names to `curatedPrograms`; render each
+      concept in `CompileHomeNix` following the git/direnv/starship patterns (sorted `bat.config`).
+- [x] 2.3 Fix the two pre-existing tests that used `bat`/`fzf` as raw-passthrough placeholders to use a
+      non-curated name (`htop`/`lsd`).
+
+## 3. Example manifest
+
+- [x] 3.1 `manifests/examples/home-manager-settings.jsonc`: curated concepts (incl. 2-3 new) + a raw
+      `programs` block + a `files` entry; stage the `files` source under `hm-settings-assets/` (NOT
+      `payload/`, which is gitignored — so the example is self-consistent in the repo).
+- [x] 3.2 Confirm it loads (`endstate plan --manifest …`).
+
+## 4. OpenSpec + verification
+
+- [x] 4.1 `cd go-engine && go test ./...` green
+- [x] 4.2 `go vet ./...` + `GOOS=windows go build ./...` clean
+- [x] 4.3 `openspec validate nix-home-manager-catalog-broaden --strict --no-interactive` passes
+- [ ] 4.4 Real-nix apply smoke (operator-run): apply a manifest with 2-3 new concepts
+      (`--enable-restore`) and assert the activated home-manager config exposes them.


### PR DESCRIPTION
## What

Broadens the curated `homeManager.settings` catalog with **5 new concepts**, each mapped to a **stable** home-manager surface (mirroring the existing `git → programs.git.extraConfig` rename-insulation pattern):

| Concept | Maps to | Type |
|---|---|---|
| `fzf` | `programs.fzf.enable` | `ProgramToggle` |
| `zoxide` | `programs.zoxide.enable` | `ProgramToggle` |
| `bat` | `programs.bat.enable` + `programs.bat.config` (attrset) | `BatSettings` |
| `tmux` | `programs.tmux.enable` + `programs.tmux.extraConfig` (raw) | `TmuxSettings` |
| `ssh` | `programs.ssh.enable` + `programs.ssh.extraConfig` (raw) | `SSHSettings` |

Each is a typed field so the existing strict `UnmarshalJSON` (`DisallowUnknownFields`) rejects mistyped sub-keys at load, and each is registered in `curatedPrograms` so a raw `programs.<name>` passthrough conflicts loudly. Raw `programs`/`files` stay permissive.

## Why

The shipped catalog (#91) covered git/shell/direnv/starship. This continues the "zero-Nix end-state" arc — users declare common config in Endstate's own format and never touch Nix — while preferring stable options to dodge home-manager option-rename churn.

## Changes

- `internal/manifest/types.go` — 5 new fields + `BatSettings`/`TmuxSettings`/`SSHSettings`.
- `internal/realizer/nix/home_catalog.go` — 5 names in `curatedPrograms`; render blocks in `CompileHomeNix` (deterministic, sorted).
- Tests (RED→GREEN): render, explicit-false toggle, and a table-driven raw-overlap-conflict test across all 5. Two pre-existing tests had their raw-passthrough placeholder swapped `bat`/`fzf` → `htop`/`lsd` (those names are now curated).
- `manifests/examples/home-manager-settings.jsonc` (+ `hm-settings-assets/starship.toml`) — example showing curated (incl. the 5 new) + raw `programs` + `files`.
- OpenSpec change `nix-home-manager-catalog-broaden` (strict-valid).

## Verification

- `go test ./...`, `go vet ./...`, `GOOS=windows go build ./...` — all green.
- `openspec validate nix-home-manager-catalog-broaden --strict` — valid.
- **Real-nix smoke (throwaway `$HOME`/`ENDSTATE_ROOT`):** a settings block with all 5 concepts → `apply --enable-restore` → `activated:true`; generated `home.nix` renders every statement; on activation `bat` config wrote `--theme=TwoDark`, `tmux.conf` got `set -g mouse on`, `~/.ssh/config` got `ServerAliveInterval`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
