### PR TITLE
feat(backup): add `backup estimate` to size a push without uploading

### DIFF
--- a/go-engine/cmd/endstate/main.go
+++ b/go-engine/cmd/endstate/main.go
@@ -80,6 +80,7 @@ Subcommands:
   backup subscribe     Start a Hosted Backup subscription checkout (returns checkoutUrl)
   backup browser-session Mint a short-lived /account portal handoff token (returns sessionToken + accountUrl)
   backup push          Encrypt and upload a profile (--profile required)
+  backup estimate      Report the upload size a push of a profile would use (--profile required)
   backup pull          Download and restore a profile (--backup-id, --to required)
   backup list          List backups
   backup versions      List versions of a backup (--backup-id required)

--- a/go-engine/internal/backup/upload/upload.go
+++ b/go-engine/internal/backup/upload/upload.go
@@ -127,62 +127,19 @@ func PushVersion(ctx context.Context, deps Dependencies, backupID, profilePath, 
 		}
 	}
 
-	chunks := chunkBytes(tarBytes, crypto.ChunkPlainSize)
-	chunkCount := len(chunks)
-
 	deps.Events.EmitPhase("backup-push")
 
-	encrypted := make([][]byte, chunkCount)
-	chunkMeta := make([]storage.ChunkMetaWire, chunkCount)
-	manifestChunks := make([]manifest.ChunkMeta, chunkCount)
-
-	for i, plain := range chunks {
-		blob, eerr := crypto.EncryptChunk(plain, uint32(i), dek)
-		if eerr != nil {
-			return nil, envelope.NewError(envelope.ErrInternalError, fmt.Sprintf("backup push: encrypt chunk %d: %s", i, eerr.Error()))
-		}
-		sum := sha256.Sum256(blob)
-		hexSum := hex.EncodeToString(sum[:])
-		encrypted[i] = blob
-		chunkMeta[i] = storage.ChunkMetaWire{Index: uint32(i), EncryptedSize: int64(len(blob)), SHA256: hexSum}
-		manifestChunks[i] = manifest.ChunkMeta{Index: uint32(i), EncryptedSize: int64(len(blob)), SHA256: hexSum}
+	// Bundle the profile (tar already done above for the --if-changed hash):
+	// chunk → encrypt → manifest → encrypt manifest. Shared with `backup
+	// estimate` via buildBundle so the two can never disagree on size.
+	bundle, bErr := buildBundle(deps, dek, tarBytes, contentSHA)
+	if bErr != nil {
+		return nil, bErr
 	}
-
-	now := deps.now().UTC().Format(time.RFC3339Nano)
-	versionID := newUUID()
-
-	// The manifest's `wrappedDEK` field is the masterKey-wrapped DEK
-	// substrate stored at signup (contract §3). We cache it in the
-	// keychain at login/signup/recover-finalize so push can read it
-	// without re-deriving the masterKey on every call.
-	wrappedDEKB64, werr := deps.Session.LoadWrappedDEK()
-	if werr != nil {
-		return nil, envelope.NewError(envelope.ErrAuthRequired,
-			"backup push: no wrappedDEK in keychain — sign in first").
-			WithRemediation("Run `endstate backup login` (or `endstate backup signup`) to populate the session.")
-	}
-
-	mf := &manifest.Manifest{
-		EnvelopeVersion: crypto.EnvelopeVersion,
-		VersionID:       versionID,
-		CreatedAt:       now,
-		OriginalSize:    int64(len(tarBytes)),
-		ChunkSize:       crypto.ChunkPlainSize,
-		ChunkCount:      chunkCount,
-		Chunks:          manifestChunks,
-		KDF:             crypto.DefaultKDFParams(),
-		WrappedDEK:      wrappedDEKB64,
-		ContentSHA256:   contentSHA,
-	}
-	mfJSON, mfErr := manifest.Marshal(mf)
-	if mfErr != nil {
-		return nil, envelope.NewError(envelope.ErrInternalError, "backup push: marshal manifest: "+mfErr.Error())
-	}
-
-	encManifest, emErr := crypto.EncryptManifest(mfJSON, dek)
-	if emErr != nil {
-		return nil, envelope.NewError(envelope.ErrInternalError, "backup push: encrypt manifest: "+emErr.Error())
-	}
+	chunkCount := bundle.chunkCount
+	encrypted := bundle.encrypted
+	encManifest := bundle.encManifest
+	chunkMeta := bundle.chunkMeta
 
 	resp, cvErr := deps.Storage.CreateVersion(ctx, resolvedBackupID, encManifest, chunkMeta)
 	if cvErr != nil {
@@ -232,6 +189,125 @@ func PushVersion(ctx context.Context, deps Dependencies, backupID, profilePath, 
 	deps.Events.EmitSummary("backup-push", chunkCount+1, successCount, 0, 0)
 
 	return &PushResult{BackupID: resolvedBackupID, VersionID: resp.VersionID}, nil
+}
+
+// encBundle is the fully client-side, encrypted result of bundling a profile —
+// the encrypted chunks plus the encrypted manifest — i.e. the exact set of
+// bytes a push uploads. Both PushVersion and EstimateSize build it through this
+// single path so a size estimate can never drift from a real push.
+type encBundle struct {
+	encrypted   [][]byte
+	encManifest []byte
+	chunkMeta   []storage.ChunkMetaWire
+	chunkCount  int
+}
+
+// buildBundle runs the encrypt pipeline (4 MiB chunks → AES-256-GCM → manifest
+// → encrypted manifest) over an already-tarred profile. No network I/O. The DEK
+// is the caller's; the wrappedDEK is read from the session.
+func buildBundle(deps Dependencies, dek, tarBytes []byte, contentSHA string) (*encBundle, *envelope.Error) {
+	chunks := chunkBytes(tarBytes, crypto.ChunkPlainSize)
+	chunkCount := len(chunks)
+
+	encrypted := make([][]byte, chunkCount)
+	chunkMeta := make([]storage.ChunkMetaWire, chunkCount)
+	manifestChunks := make([]manifest.ChunkMeta, chunkCount)
+
+	for i, plain := range chunks {
+		blob, eerr := crypto.EncryptChunk(plain, uint32(i), dek)
+		if eerr != nil {
+			return nil, envelope.NewError(envelope.ErrInternalError, fmt.Sprintf("backup: encrypt chunk %d: %s", i, eerr.Error()))
+		}
+		sum := sha256.Sum256(blob)
+		hexSum := hex.EncodeToString(sum[:])
+		encrypted[i] = blob
+		chunkMeta[i] = storage.ChunkMetaWire{Index: uint32(i), EncryptedSize: int64(len(blob)), SHA256: hexSum}
+		manifestChunks[i] = manifest.ChunkMeta{Index: uint32(i), EncryptedSize: int64(len(blob)), SHA256: hexSum}
+	}
+
+	// The manifest's `wrappedDEK` is the masterKey-wrapped DEK substrate stored
+	// at signup (contract §3), cached in the keychain at login/signup/recover.
+	wrappedDEKB64, werr := deps.Session.LoadWrappedDEK()
+	if werr != nil {
+		return nil, envelope.NewError(envelope.ErrAuthRequired,
+			"backup: no wrappedDEK in keychain — sign in first").
+			WithRemediation("Run `endstate backup login` (or `endstate backup signup`) to populate the session.")
+	}
+
+	mf := &manifest.Manifest{
+		EnvelopeVersion: crypto.EnvelopeVersion,
+		VersionID:       newUUID(),
+		CreatedAt:       deps.now().UTC().Format(time.RFC3339Nano),
+		OriginalSize:    int64(len(tarBytes)),
+		ChunkSize:       crypto.ChunkPlainSize,
+		ChunkCount:      chunkCount,
+		Chunks:          manifestChunks,
+		KDF:             crypto.DefaultKDFParams(),
+		WrappedDEK:      wrappedDEKB64,
+		ContentSHA256:   contentSHA,
+	}
+	mfJSON, mfErr := manifest.Marshal(mf)
+	if mfErr != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, "backup: marshal manifest: "+mfErr.Error())
+	}
+	encManifest, emErr := crypto.EncryptManifest(mfJSON, dek)
+	if emErr != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, "backup: encrypt manifest: "+emErr.Error())
+	}
+
+	return &encBundle{encrypted: encrypted, encManifest: encManifest, chunkMeta: chunkMeta, chunkCount: chunkCount}, nil
+}
+
+// SizeEstimate is the result of EstimateSize: the byte counts a push of the
+// same profile would produce, with no network I/O.
+type SizeEstimate struct {
+	EstimatedUploadBytes int64
+	PlaintextBytes       int64
+	ChunkCount           int
+}
+
+// EstimateSize computes the exact number of bytes a `backup push` of
+// profilePath would upload (encrypted chunks + encrypted manifest) WITHOUT any
+// network call. It runs the identical client-side bundling path push uses (via
+// buildBundle), so the estimate can't drift from a real push. Requires a
+// signed-in session — the DEK is needed to produce true ciphertext sizes.
+func EstimateSize(deps Dependencies, profilePath string) (*SizeEstimate, *envelope.Error) {
+	if strings.TrimSpace(profilePath) == "" {
+		return nil, envelope.NewError(envelope.ErrInternalError, "backup estimate: profile path is empty")
+	}
+
+	dek, err := deps.Session.LoadDEK()
+	if err != nil {
+		return nil, envelope.NewError(envelope.ErrAuthRequired,
+			"backup estimate: no DEK in keychain — sign in first").
+			WithRemediation("Run `endstate backup login` (or `endstate backup signup`) to populate the session.")
+	}
+	defer wipe(dek)
+
+	tarBytes, terr := tarProfile(profilePath)
+	if terr != nil {
+		return nil, envelope.NewError(envelope.ErrInternalError, "backup estimate: tar profile: "+terr.Error()).
+			WithRemediation("Verify --profile points at a readable file or directory.")
+	}
+	contentSum := sha256.Sum256(tarBytes)
+	contentSHA := hex.EncodeToString(contentSum[:])
+
+	bundle, bErr := buildBundle(deps, dek, tarBytes, contentSHA)
+	if bErr != nil {
+		return nil, bErr
+	}
+
+	var total int64
+	for _, blob := range bundle.encrypted {
+		total += int64(len(blob))
+	}
+	total += int64(len(bundle.encManifest))
+
+	return &SizeEstimate{
+		EstimatedUploadBytes: total,
+		PlaintextBytes:       int64(len(tarBytes)),
+		ChunkCount:           bundle.chunkCount,
+	}, nil
 }
 
 // resolveBackupID picks a backup id to write a version against. If the

--- a/go-engine/internal/commands/backup.go
+++ b/go-engine/internal/commands/backup.go
@@ -95,9 +95,11 @@ func RunBackup(flags BackupFlags) (interface{}, *envelope.Error) {
 		return runBackupSubscribe(flags)
 	case "browser-session":
 		return runBackupBrowserSession(flags)
+	case "estimate":
+		return runBackupEstimate(flags)
 	case "":
 		return nil, envelope.NewError(envelope.ErrInternalError,
-			"backup requires a subcommand (signup, claim, login, logout, status, subscribe, browser-session, push, pull, list, versions, delete, delete-version, recover)")
+			"backup requires a subcommand (signup, claim, login, logout, status, subscribe, browser-session, push, estimate, pull, list, versions, delete, delete-version, recover)")
 	case "list":
 		return runBackupList(flags)
 	case "versions":

--- a/go-engine/internal/commands/backup_estimate.go
+++ b/go-engine/internal/commands/backup_estimate.go
@@ -1,0 +1,51 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"strings"
+
+	"github.com/Artexis10/endstate/go-engine/internal/backup/upload"
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// EstimateResult is the data payload for `backup estimate`.
+//
+// It reports the exact number of bytes a `backup push` of the same profile
+// would upload — computed entirely client-side with no network I/O — so the
+// GUI can warn before a push that would approach or exceed the hosted-backup
+// quota. Read-only: emits no events and creates no version.
+//
+//	{
+//	  "estimatedUploadBytes": number,  // encrypted chunks + encrypted manifest
+//	  "plaintextBytes":       number,  // tarred profile size before encryption
+//	  "chunkCount":           number
+//	}
+type EstimateResult struct {
+	EstimatedUploadBytes int64 `json:"estimatedUploadBytes"`
+	PlaintextBytes       int64 `json:"plaintextBytes"`
+	ChunkCount           int   `json:"chunkCount"`
+}
+
+func runBackupEstimate(flags BackupFlags) (interface{}, *envelope.Error) {
+	if strings.TrimSpace(flags.Profile) == "" {
+		return nil, envelope.NewError(envelope.ErrInternalError,
+			"backup estimate requires --profile <path>").
+			WithRemediation("Pass --profile <path> pointing at the file or directory you want to size.")
+	}
+
+	st := newBackupStack()
+	est, envErr := upload.EstimateSize(upload.Dependencies{
+		Storage: st.Storage,
+		Session: st.Session,
+	}, flags.Profile)
+	if envErr != nil {
+		return nil, envErr
+	}
+	return &EstimateResult{
+		EstimatedUploadBytes: est.EstimatedUploadBytes,
+		PlaintextBytes:       est.PlaintextBytes,
+		ChunkCount:           est.ChunkCount,
+	}, nil
+}

--- a/go-engine/internal/commands/backup_estimate_test.go
+++ b/go-engine/internal/commands/backup_estimate_test.go
@@ -1,0 +1,64 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/backup"
+	"github.com/Artexis10/endstate/go-engine/internal/commands"
+)
+
+// `backup estimate` reports the would-be upload size of a profile by running
+// the identical client-side bundling path push uses (shared buildBundle), so
+// the result must exceed the plaintext by the AES-256-GCM overhead and include
+// the encrypted manifest. No network call is made.
+func TestBackupEstimate_ReportsBundleSize(t *testing.T) {
+	pp := newPushPullBackend(t)
+	st, _ := stackForPushPull(pp)
+	defer commands.ReplaceBackupStackFactoryForTest(func() *backup.Stack { return st })()
+
+	profile := filepath.Join(t.TempDir(), "profile")
+	if err := os.MkdirAll(profile, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := []byte(`{"name":"estimate-me","apps":["a","b","c"]}`)
+	if err := os.WriteFile(filepath.Join(profile, "manifest.jsonc"), content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := commands.RunBackup(commands.BackupFlags{Subcommand: "estimate", Profile: profile})
+	if err != nil {
+		t.Fatalf("estimate: %+v", err)
+	}
+	res := data.(*commands.EstimateResult)
+
+	if res.ChunkCount != 1 {
+		t.Errorf("ChunkCount = %d, want 1 (tiny profile fits one 4 MiB chunk)", res.ChunkCount)
+	}
+	// PlaintextBytes is the tar size — tar wraps the file in a 512-byte header
+	// plus padding, so it strictly exceeds the raw file content.
+	if res.PlaintextBytes <= int64(len(content)) {
+		t.Errorf("PlaintextBytes = %d, want > raw content (%d)", res.PlaintextBytes, len(content))
+	}
+	// Upload = chunk ciphertext (plaintext + 12-byte nonce + 16-byte tag) +
+	// encrypted manifest. So it must exceed plaintext by more than one chunk's
+	// 28-byte AEAD overhead alone (the manifest adds the rest).
+	if res.EstimatedUploadBytes <= res.PlaintextBytes+28 {
+		t.Errorf("EstimatedUploadBytes = %d, want > PlaintextBytes(%d)+28", res.EstimatedUploadBytes, res.PlaintextBytes)
+	}
+}
+
+// Empty --profile is rejected before any work is done.
+func TestBackupEstimate_RequiresProfile(t *testing.T) {
+	pp := newPushPullBackend(t)
+	st, _ := stackForPushPull(pp)
+	defer commands.ReplaceBackupStackFactoryForTest(func() *backup.Stack { return st })()
+
+	if _, err := commands.RunBackup(commands.BackupFlags{Subcommand: "estimate", Profile: ""}); err == nil {
+		t.Fatal("estimate with empty --profile: want error, got nil")
+	}
+}


### PR DESCRIPTION
## What
New read-only **`endstate backup estimate --profile <path>`** that reports the exact bytes a `backup push` of the same profile would upload (encrypted chunks + encrypted manifest), computed **entirely client-side, no network call**. This unblocks an accurate **pre-push quota warning** in the GUI (the GUI compares the estimate to remaining quota from `backup status`).

```json
{ "estimatedUploadBytes": 12345, "plaintextBytes": 10000, "chunkCount": 1 }
```

## How
- Refactors `internal/backup/upload/upload.go`: the chunk→encrypt→manifest→encrypt-manifest step is extracted into a shared **`buildBundle`** that both `PushVersion` and the new **`EstimateSize`** call — so the estimate **cannot drift** from a real push (same code path; estimate just sums the sizes instead of uploading).
- `EstimateSize` needs a signed-in session (the DEK yields true ciphertext sizes) but does **no** backup-id resolution and **no** network I/O.
- New command handler `backup_estimate.go`; `estimate` case added to the `backup` dispatch + concise `--help` + the no-subcommand error list.

## Contract / OpenSpec
Read-only, **standard CLI-JSON envelope, emits no events, no crypto-contract change** — so no `hosted-backup-contract.md` / event-contract delta is needed. Happy to add an OpenSpec change if you'd like it tracked.

## Tests
- New `backup_estimate_test.go`: asserts the estimate exceeds plaintext by the AES-256-GCM overhead + manifest, and that `--profile` is required.
- `go test ./internal/commands/... ./internal/backup/...` green (existing push/upload tests unchanged — the refactor is behavior-preserving). `go vet` clean.

Pairs with the GUI pre-push size warning (separate PR in endstate-gui, which pins the engine version this releases).

🤖 Generated with [Claude Code](https://claude.com/claude-code)