### PR TITLE
feat(engine): extend home-manager curated catalog (eza, gh, lazygit, neovim)

### DIFF
--- a/go-engine/internal/manifest/home_settings_test.go
+++ b/go-engine/internal/manifest/home_settings_test.go
@@ -163,6 +163,74 @@ func TestLoadManifest_HomeManagerSettings_RejectsUnknownBroadenedKey(t *testing.
 	}
 }
 
+// TestLoadManifest_HomeManagerSettings_MoreCurated verifies the additional curated
+// catalog concepts (eza, gh, lazygit, neovim) round-trip through JSONC load with
+// their typed fields retained.
+func TestLoadManifest_HomeManagerSettings_MoreCurated(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "m.jsonc")
+	content := `{
+  "version": 1,
+  "name": "hm-more",
+  "apps": [],
+  "homeManager": {
+    "settings": {
+      "eza": { "enable": true, "extraOptions": ["--git", "--icons"] },
+      "gh": { "enable": true, "settings": { "editor": "nvim" } },
+      "lazygit": { "enable": true, "settings": { "gui": { "theme": { "activeBorderColor": ["blue", "bold"] } } } },
+      "neovim": { "enable": true, "extraConfig": "set number\nset relativenumber" }
+    }
+  }
+}`
+	if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+	m, err := LoadManifest(p)
+	if err != nil {
+		t.Fatalf("unexpected error loading more curated catalog: %v", err)
+	}
+	if m.HomeManager == nil || m.HomeManager.Settings == nil {
+		t.Fatal("HomeManager.Settings = nil, want non-nil")
+	}
+	s := m.HomeManager.Settings
+	if s.Eza == nil || !s.Eza.Enable || len(s.Eza.ExtraOptions) != 2 || s.Eza.ExtraOptions[0] != "--git" {
+		t.Errorf("eza = %+v, want enable=true + extraOptions=[--git --icons]", s.Eza)
+	}
+	if s.Gh == nil || !s.Gh.Enable || s.Gh.Settings["editor"] != "nvim" {
+		t.Errorf("gh = %+v, want enable=true + settings.editor=nvim", s.Gh)
+	}
+	if s.Lazygit == nil || !s.Lazygit.Enable || s.Lazygit.Settings["gui"] == nil {
+		t.Errorf("lazygit = %+v, want enable=true + settings.gui non-nil", s.Lazygit)
+	}
+	if s.Neovim == nil || !s.Neovim.Enable || !strings.Contains(s.Neovim.ExtraConfig, "set number") {
+		t.Errorf("neovim = %+v, want enable=true + extraConfig with 'set number'", s.Neovim)
+	}
+}
+
+// TestLoadManifest_HomeManagerSettings_RejectsUnknownMoreCuratedKey verifies a typo'd
+// sub-key on the more-curated concepts fails to load rather than being silently dropped.
+func TestLoadManifest_HomeManagerSettings_RejectsUnknownMoreCuratedKey(t *testing.T) {
+	cases := map[string]string{
+		"eza-typo":     `"eza": { "enabel": true }`,
+		"gh-typo":      `"gh": { "settigns": {} }`,
+		"lazygit-typo": `"lazygit": { "settigns": {} }`,
+		"neovim-typo":  `"neovim": { "extraCfg": "x" }`,
+	}
+	for name, block := range cases {
+		t.Run(name, func(t *testing.T) {
+			dir := t.TempDir()
+			p := filepath.Join(dir, "m.jsonc")
+			content := `{ "version": 1, "name": "typo", "apps": [], "homeManager": { "settings": { ` + block + ` } } }`
+			if err := os.WriteFile(p, []byte(content), 0644); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := LoadManifest(p); err == nil {
+				t.Fatalf("%s: expected an error for an unknown sub-key, got nil", name)
+			}
+		})
+	}
+}
+
 // TestLoadManifest_HomeManagerInputsMutuallyExclusive verifies settings / config /
 // flake are mutually exclusive — any pair fails to load with a clear error.
 func TestLoadManifest_HomeManagerInputsMutuallyExclusive(t *testing.T) {

--- a/go-engine/internal/manifest/types.go
+++ b/go-engine/internal/manifest/types.go
@@ -75,6 +75,10 @@ type HomeManagerSettings struct {
 	Bat      *BatSettings      `json:"bat,omitempty"`
 	Tmux     *TmuxSettings     `json:"tmux,omitempty"`
 	SSH      *SSHSettings      `json:"ssh,omitempty"`
+	Eza      *EzaSettings      `json:"eza,omitempty"`
+	Gh       *GhSettings       `json:"gh,omitempty"`
+	Lazygit  *LazygitSettings  `json:"lazygit,omitempty"`
+	Neovim   *NeovimSettings   `json:"neovim,omitempty"`
 	Programs map[string]any    `json:"programs,omitempty"` // raw home-manager passthrough
 	Files    map[string]string `json:"files,omitempty"`    // target path -> source path (relative to manifest)
 }
@@ -136,6 +140,39 @@ type TmuxSettings struct {
 // programs.ssh.extraConfig — the raw ssh config string, the stable surface that
 // insulates the user from home-manager ssh option renames.
 type SSHSettings struct {
+	Enable      bool   `json:"enable,omitempty"`
+	ExtraConfig string `json:"extraConfig,omitempty"`
+}
+
+// EzaSettings are the curated eza concepts mapped to programs.eza.enable plus
+// programs.eza.extraOptions — a slice of raw eza CLI flags (e.g. ["--git","--icons"]),
+// the stable surface that insulates the user from home-manager eza option renames.
+type EzaSettings struct {
+	Enable       bool     `json:"enable,omitempty"`
+	ExtraOptions []string `json:"extraOptions,omitempty"`
+}
+
+// GhSettings are the curated gh (GitHub CLI) concepts mapped to programs.gh.enable plus
+// programs.gh.settings — a raw attrset forwarded verbatim to the gh config, the stable
+// surface (gh's own config key namespace) that insulates the user from option renames.
+type GhSettings struct {
+	Enable   bool           `json:"enable,omitempty"`
+	Settings map[string]any `json:"settings,omitempty"`
+}
+
+// LazygitSettings are the curated lazygit concepts mapped to programs.lazygit.enable
+// plus programs.lazygit.settings — a raw attrset forwarded verbatim to the lazygit
+// config, the stable surface (lazygit's own config structure) that insulates the user
+// from home-manager option renames.
+type LazygitSettings struct {
+	Enable   bool           `json:"enable,omitempty"`
+	Settings map[string]any `json:"settings,omitempty"`
+}
+
+// NeovimSettings are the curated neovim concepts mapped to programs.neovim.enable plus
+// programs.neovim.extraConfig — the raw vimscript/lua string, the stable surface that
+// insulates the user from home-manager neovim option renames.
+type NeovimSettings struct {
 	Enable      bool   `json:"enable,omitempty"`
 	ExtraConfig string `json:"extraConfig,omitempty"`
 }

--- a/go-engine/internal/realizer/nix/home_catalog.go
+++ b/go-engine/internal/realizer/nix/home_catalog.go
@@ -27,6 +27,10 @@ var curatedPrograms = map[string]bool{
 	"bat":      true,
 	"tmux":     true,
 	"ssh":      true,
+	"eza":      true,
+	"gh":       true,
+	"lazygit":  true,
+	"neovim":   true,
 }
 
 // GenerateHomeFlakeFromSettings compiles a declarative catalog (settings) into a
@@ -128,6 +132,42 @@ func CompileHomeNix(s *manifest.HomeManagerSettings, manifestDir string) ([]byte
 		stmts = append(stmts, "programs.ssh.enable = "+nixValue(s.SSH.Enable)+";")
 		if s.SSH.ExtraConfig != "" {
 			stmts = append(stmts, "programs.ssh.extraConfig = "+nixValue(s.SSH.ExtraConfig)+";")
+		}
+	}
+
+	// eza → enable + the STABLE programs.eza.extraOptions ([]string of CLI flags —
+	// insulates the user from home-manager eza option renames).
+	if s.Eza != nil {
+		stmts = append(stmts, "programs.eza.enable = "+nixValue(s.Eza.Enable)+";")
+		if len(s.Eza.ExtraOptions) > 0 {
+			stmts = append(stmts, "programs.eza.extraOptions = "+nixValue(stringSliceToAny(s.Eza.ExtraOptions))+";")
+		}
+	}
+
+	// gh → enable + the STABLE programs.gh.settings (raw attrset forwarded verbatim —
+	// gh's own config key namespace, insulates from home-manager option renames).
+	if s.Gh != nil {
+		stmts = append(stmts, "programs.gh.enable = "+nixValue(s.Gh.Enable)+";")
+		if len(s.Gh.Settings) > 0 {
+			stmts = append(stmts, "programs.gh.settings = "+nixValue(s.Gh.Settings)+";")
+		}
+	}
+
+	// lazygit → enable + the STABLE programs.lazygit.settings (raw attrset forwarded
+	// verbatim — lazygit's own config structure, insulates from option renames).
+	if s.Lazygit != nil {
+		stmts = append(stmts, "programs.lazygit.enable = "+nixValue(s.Lazygit.Enable)+";")
+		if len(s.Lazygit.Settings) > 0 {
+			stmts = append(stmts, "programs.lazygit.settings = "+nixValue(s.Lazygit.Settings)+";")
+		}
+	}
+
+	// neovim → enable + the STABLE programs.neovim.extraConfig (raw vimscript/lua string —
+	// insulates the user from home-manager neovim option renames).
+	if s.Neovim != nil {
+		stmts = append(stmts, "programs.neovim.enable = "+nixValue(s.Neovim.Enable)+";")
+		if s.Neovim.ExtraConfig != "" {
+			stmts = append(stmts, "programs.neovim.extraConfig = "+nixValue(s.Neovim.ExtraConfig)+";")
 		}
 	}
 
@@ -240,6 +280,15 @@ func stringMapToAny(m map[string]string) map[string]any {
 	out := make(map[string]any, len(m))
 	for k, v := range m {
 		out[k] = v
+	}
+	return out
+}
+
+// stringSliceToAny lifts a []string to []any for nixValue (renders as a Nix list).
+func stringSliceToAny(s []string) []any {
+	out := make([]any, len(s))
+	for i, v := range s {
+		out[i] = v
 	}
 	return out
 }

--- a/go-engine/internal/realizer/nix/home_catalog_test.go
+++ b/go-engine/internal/realizer/nix/home_catalog_test.go
@@ -155,6 +155,57 @@ func TestCompileHomeNix_BroadenedRawOverlapErrors(t *testing.T) {
 	}
 }
 
+// TestCompileHomeNix_MoreCurated: the additional curated concepts (eza, gh, lazygit,
+// neovim) render the expected stable home-manager statements.
+func TestCompileHomeNix_MoreCurated(t *testing.T) {
+	s := &manifest.HomeManagerSettings{
+		Eza:     &manifest.EzaSettings{Enable: true, ExtraOptions: []string{"--git", "--icons"}},
+		Gh:      &manifest.GhSettings{Enable: true, Settings: map[string]any{"editor": "nvim"}},
+		Lazygit: &manifest.LazygitSettings{Enable: true, Settings: map[string]any{"gui": map[string]any{"theme": "catppuccin"}}},
+		Neovim:  &manifest.NeovimSettings{Enable: true, ExtraConfig: "set number\nset relativenumber"},
+	}
+	home, _, err := CompileHomeNix(s, t.TempDir())
+	if err != nil {
+		t.Fatalf("CompileHomeNix: %v", err)
+	}
+	out := string(home)
+	for _, w := range []string{
+		"programs.eza.enable = true;",
+		`programs.eza.extraOptions = [ "--git" "--icons" ];`,
+		"programs.gh.enable = true;",
+		`programs.gh.settings = `,
+		`"editor" = "nvim"`,
+		"programs.lazygit.enable = true;",
+		`programs.lazygit.settings = `,
+		`"gui"`,
+		"programs.neovim.enable = true;",
+		`programs.neovim.extraConfig = "set number\nset relativenumber";`,
+	} {
+		if !strings.Contains(out, w) {
+			t.Errorf("compiled home.nix missing %q\n---\n%s", w, out)
+		}
+	}
+}
+
+// TestCompileHomeNix_MoreCuratedRawOverlapErrors: a raw programs key colliding with a
+// more-curated concept (eza, gh, lazygit, neovim) is a clear error.
+func TestCompileHomeNix_MoreCuratedRawOverlapErrors(t *testing.T) {
+	for _, name := range []string{"eza", "gh", "lazygit", "neovim"} {
+		t.Run(name, func(t *testing.T) {
+			s := &manifest.HomeManagerSettings{
+				Eza:      &manifest.EzaSettings{Enable: true},
+				Gh:       &manifest.GhSettings{Enable: true},
+				Lazygit:  &manifest.LazygitSettings{Enable: true},
+				Neovim:   &manifest.NeovimSettings{Enable: true},
+				Programs: map[string]any{name: map[string]any{"enable": true}},
+			}
+			if _, _, err := CompileHomeNix(s, t.TempDir()); err == nil {
+				t.Fatalf("expected an error for raw programs.%s overlapping curated %s, got nil", name, name)
+			}
+		})
+	}
+}
+
 // TestCompileHomeNix_Deterministic: identical settings → identical output.
 func TestCompileHomeNix_Deterministic(t *testing.T) {
 	s := &manifest.HomeManagerSettings{

--- a/manifests/examples/home-manager-settings.jsonc
+++ b/manifests/examples/home-manager-settings.jsonc
@@ -42,6 +42,18 @@
         "extraConfig": "Host *\n  ServerAliveInterval 60\n  ServerAliveCountMax 3"
       },
 
+      // More curated concepts — extended catalog.
+      "eza": {
+        "enable": true,
+        // Extra CLI flags forwarded verbatim via programs.eza.extraOptions.
+        "extraOptions": ["--git", "--icons", "--group-directories-first"]
+      },
+      "neovim": {
+        "enable": true,
+        // Raw vimscript/lua — the stable surface (programs.neovim.extraConfig).
+        "extraConfig": "set number\nset relativenumber\nset expandtab\nset tabstop=2"
+      },
+
       // Raw home-manager passthrough — forwarded verbatim. Use this for any
       // program NOT in the curated set above (a curated name here would conflict).
       "programs": {

--- a/openspec/changes/nix-home-manager-catalog-more/.openspec.yaml
+++ b/openspec/changes/nix-home-manager-catalog-more/.openspec.yaml
@@ -1,0 +1,10 @@
+id: nix-home-manager-catalog-more
+title: "Extend the curated home-manager catalog (eza, gh, lazygit, neovim)"
+status: implementing
+spec: nix-home-manager-catalog
+created: "2026-06-03"
+author: Hugo Ander Kivi
+artifacts:
+  - proposal.md
+  - design.md
+  - tasks.md

--- a/openspec/changes/nix-home-manager-catalog-more/design.md
+++ b/openspec/changes/nix-home-manager-catalog-more/design.md
@@ -1,0 +1,133 @@
+## Context
+
+- `manifest.HomeManagerSettings` (`internal/manifest/types.go`) is the declarative catalog struct:
+  typed curated fields + a permissive `Programs` raw passthrough + a `Files` map. Its custom
+  `UnmarshalJSON` decodes with `DisallowUnknownFields`, so a mistyped sub-key WITHIN a typed curated
+  concept fails to load. `Programs`/`Files` are maps and stay permissive (maps have no "unknown fields").
+- `CompileHomeNix` (`internal/realizer/nix/home_catalog.go`) renders the `home.nix`: curated concepts
+  become fixed `programs.*`/`home.*` statements, the raw `programs` block is forwarded verbatim
+  (`nixValue`), and `files` are staged + placed via `home.file`. Output is deterministic (sorted keys).
+- `curatedPrograms` lists each curated concept that owns a `programs.<name>` entry. A raw `programs`
+  key matching one is rejected (`programs.<name> conflicts with the curated "<name>" concept`).
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add four curated concepts (`eza`, `gh`, `lazygit`, `neovim`), each mapped to a STABLE home-manager
+  surface, so the catalog covers more of a common developer shell without dropping to the raw passthrough.
+- Preserve unknown-sub-key rejection, the raw-overlap conflict, and deterministic rendering.
+- Hermetic tests only; no live Nix invocations.
+
+**Non-Goals:**
+- No change to the nine existing curated concepts, the raw passthrough, or the files map.
+- No capture-side change (a settings-applied machine already round-trips via `HomeManagerSettings`).
+- No exhaustive home-manager option surface — only the stable, rename-insulated keys below.
+
+## Decisions
+
+- **`eza.extraOptions` as `[]string`** — `programs.eza.extraOptions` is a `listOf str` in home-manager;
+  exposing it as a string slice keeps the surface idiomatic in JSON and avoids escaping. A new
+  `stringSliceToAny` helper (mirroring `stringMapToAny`) lifts it to `[]any` for `nixValue` which
+  renders it as `[ "--git" "--icons" ]`.
+- **`gh.settings` and `lazygit.settings` as `map[string]any`** (not `map[string]string`) — lazygit's
+  config is a deeply-nested YAML structure (e.g. `gui.theme.activeBorderColor`). `map[string]any`
+  supports arbitrary nesting; `nixValue` already handles nested `map[string]any` as attrsets
+  recursively. `gh` uses the same type for consistency even though its config is shallower.
+- **`neovim.extraConfig` as raw string** — mirrors `tmux`/`ssh`. `programs.neovim.extraConfig` accepts
+  both vimscript and Lua; it is the documented stable surface for arbitrary neovim configuration. The
+  engine simply passes the string through `nixValue` (which escapes newlines, quotes, `${`).
+- **Register all four in `curatedPrograms`** — each owns a `programs.<name>` entry; a raw
+  `programs.<name>` must conflict for the same reason as the existing nine.
+- **`enable` rendered explicitly even when false** — same policy as existing curated concepts (user can
+  pin OFF). Optional second fields (`extraOptions`/`settings`/`extraConfig`) are omitted when empty.
+
+## Design
+
+### Curated mapping table
+
+| Endstate concept         | Stable home-manager option(s)                          | Typed struct       | Why stable |
+|--------------------------|--------------------------------------------------------|--------------------|------------|
+| `eza.enable`             | `programs.eza.enable`                                  | `EzaSettings`      | `enable` is the permanent on/off surface. |
+| `eza.extraOptions`       | `programs.eza.extraOptions` (`listOf str`)             | `EzaSettings`      | Raw CLI flags forwarded verbatim; eza's own flag namespace. |
+| `gh.enable`              | `programs.gh.enable`                                   | `GhSettings`       | `enable` is permanent on/off. |
+| `gh.settings`            | `programs.gh.settings` (attrset passthrough)           | `GhSettings`       | gh's own config key namespace; mirrors the gh CLI config format directly. |
+| `lazygit.enable`         | `programs.lazygit.enable`                              | `LazygitSettings`  | `enable` is permanent on/off. |
+| `lazygit.settings`       | `programs.lazygit.settings` (attrset passthrough)      | `LazygitSettings`  | lazygit's own config structure; raw passthrough avoids binding to renamed home-manager sub-options. |
+| `neovim.enable`          | `programs.neovim.enable`                               | `NeovimSettings`   | `enable` is permanent on/off. |
+| `neovim.extraConfig`     | `programs.neovim.extraConfig` (raw vimscript/lua)      | `NeovimSettings`   | `extraConfig` is the documented, stable surface (like `tmux`/`ssh`); insulates from per-option renames. |
+
+### Schema additions (`internal/manifest/types.go`)
+
+```go
+// HomeManagerSettings gains four new fields:
+Eza     *EzaSettings     `json:"eza,omitempty"`
+Gh      *GhSettings      `json:"gh,omitempty"`
+Lazygit *LazygitSettings `json:"lazygit,omitempty"`
+Neovim  *NeovimSettings  `json:"neovim,omitempty"`
+
+type EzaSettings struct {
+    Enable       bool     `json:"enable,omitempty"`
+    ExtraOptions []string `json:"extraOptions,omitempty"`
+}
+type GhSettings struct {
+    Enable   bool           `json:"enable,omitempty"`
+    Settings map[string]any `json:"settings,omitempty"`
+}
+type LazygitSettings struct {
+    Enable   bool           `json:"enable,omitempty"`
+    Settings map[string]any `json:"settings,omitempty"`
+}
+type NeovimSettings struct {
+    Enable      bool   `json:"enable,omitempty"`
+    ExtraConfig string `json:"extraConfig,omitempty"`
+}
+```
+
+### Rendering additions (`internal/realizer/nix/home_catalog.go`)
+
+`curatedPrograms` gains `eza`, `gh`, `lazygit`, `neovim`. `CompileHomeNix` appends, after the ssh block:
+
+```go
+if s.Eza != nil {
+    stmts = append(stmts, "programs.eza.enable = "+nixValue(s.Eza.Enable)+";")
+    if len(s.Eza.ExtraOptions) > 0 {
+        stmts = append(stmts, "programs.eza.extraOptions = "+nixValue(stringSliceToAny(s.Eza.ExtraOptions))+";")
+    }
+}
+if s.Gh != nil {
+    stmts = append(stmts, "programs.gh.enable = "+nixValue(s.Gh.Enable)+";")
+    if len(s.Gh.Settings) > 0 {
+        stmts = append(stmts, "programs.gh.settings = "+nixValue(s.Gh.Settings)+";")
+    }
+}
+if s.Lazygit != nil {
+    stmts = append(stmts, "programs.lazygit.enable = "+nixValue(s.Lazygit.Enable)+";")
+    if len(s.Lazygit.Settings) > 0 {
+        stmts = append(stmts, "programs.lazygit.settings = "+nixValue(s.Lazygit.Settings)+";")
+    }
+}
+if s.Neovim != nil {
+    stmts = append(stmts, "programs.neovim.enable = "+nixValue(s.Neovim.Enable)+";")
+    if s.Neovim.ExtraConfig != "" {
+        stmts = append(stmts, "programs.neovim.extraConfig = "+nixValue(s.Neovim.ExtraConfig)+";")
+    }
+}
+```
+
+`stringSliceToAny` helper (next to `stringMapToAny`):
+```go
+func stringSliceToAny(s []string) []any {
+    out := make([]any, len(s))
+    for i, v := range s { out[i] = v }
+    return out
+}
+```
+
+## Risks / Verification
+
+- **Hermetic tests** — render each new concept; raw-overlap conflict for all four; unknown-sub-key
+  rejection (`eza.enabel`, `gh.settigns`, `lazygit.settigns`, `neovim.extraCfg`); determinism unchanged.
+- **`GOOS=windows` build + `go vet`** — the catalog path is Nix-only; Windows never reaches it.
+- **Real-nix smoke** (Linux dev box): apply a manifest declaring 2-3 new concepts with
+  `--enable-restore`, assert the generated `home.nix` contains the expected statements, and assert
+  home-manager activation succeeds (e.g. `eza` binary appears on PATH, `nvim` binary exists).

--- a/openspec/changes/nix-home-manager-catalog-more/proposal.md
+++ b/openspec/changes/nix-home-manager-catalog-more/proposal.md
@@ -1,0 +1,60 @@
+## Why
+
+`homeManager.settings` now has a curated set of nine concepts (`git`, `shell`, `direnv`, `starship`,
+`fzf`, `zoxide`, `bat`, `tmux`, `ssh`). Each curated concept maps to a **stable** home-manager option,
+insulating the user from option renames that would silently break a raw `programs` passthrough entry.
+
+A common developer shell still lacks coverage for four widely-used tools: `eza` (a modern `ls`
+replacement), `gh` (GitHub CLI), `lazygit` (a terminal UI for git), and `neovim` (the modal editor).
+Users who declare these today must drop to the raw `programs` passthrough and lose the rename-insulation
+the curated layer exists to provide. Extending the curated set is the natural next step of the catalog arc.
+
+## What Changes
+
+- **Add four curated concepts**, each mapped to a stable home-manager surface:
+  - `eza` → `programs.eza.enable` + `programs.eza.extraOptions` (a `[]string` of raw CLI flags —
+    the stable surface that avoids binding to per-feature home-manager option names that churn).
+  - `gh` → `programs.gh.enable` + `programs.gh.settings` (a raw attrset passthrough — gh's own
+    config key namespace, which is stable because it mirrors the gh CLI's config format directly).
+  - `lazygit` → `programs.lazygit.enable` + `programs.lazygit.settings` (a raw attrset passthrough —
+    lazygit's own config structure, stable for the same reason as gh).
+  - `neovim` → `programs.neovim.enable` + `programs.neovim.extraConfig` (raw vimscript/lua string —
+    the stable `extraConfig` surface, exactly like `tmux`/`ssh`, insulating from per-option renames).
+- **Each concept is a typed field** on `HomeManagerSettings` with its own small struct, so the existing
+  `UnmarshalJSON` + `DisallowUnknownFields` guard catches mistyped sub-keys at load.
+- **Each concept registers in `curatedPrograms`**, so a raw `programs.<name>` passthrough that targets
+  the same name conflicts loudly rather than producing a Nix double-definition.
+- **`eza.extraOptions`** requires a small `stringSliceToAny` helper in `home_catalog.go` (next to the
+  existing `stringMapToAny`) so `nixValue` renders the `[]string` as a Nix list literal.
+- **`gh.settings` / `lazygit.settings`** are `map[string]any` (not `map[string]string`) because
+  lazygit's config is deeply nested — `nixValue` already handles arbitrarily nested maps.
+- **Example manifest** under `manifests/examples/home-manager-settings.jsonc` gains `eza` + `neovim`
+  entries. The existing raw `programs.htop` passthrough demo is left intact (htop is NOT curated).
+
+## Capabilities
+
+### New Capabilities
+
+- `nix-home-manager-catalog`: the curated catalog accepts four additional concepts (`eza`, `gh`,
+  `lazygit`, `neovim`), each mapped to a stable home-manager option, so a user declaring these in
+  Endstate's format is insulated from home-manager option renames without dropping to the raw passthrough.
+  Mistyped sub-keys are rejected at load; a raw passthrough colliding with a curated name is a clear error.
+
+### Modified Capabilities
+
+- None. Purely additive to the existing catalog compile path; all nine prior curated concepts, the raw
+  passthrough, and the files map are unchanged.
+
+## Impact
+
+- `internal/manifest/types.go` — `HomeManagerSettings` gains `Eza` (`*EzaSettings`), `Gh`
+  (`*GhSettings`), `Lazygit` (`*LazygitSettings`), `Neovim` (`*NeovimSettings`); four small typed
+  structs added.
+- `internal/realizer/nix/home_catalog.go` — `curatedPrograms` gains `eza`/`gh`/`lazygit`/`neovim`;
+  `CompileHomeNix` renders each new concept; `stringSliceToAny` helper added.
+- `internal/manifest/home_settings_test.go` — load + unknown-sub-key rejection tests for the new
+  concepts.
+- `internal/realizer/nix/home_catalog_test.go` — render + raw-overlap conflict tests for all four new
+  concepts.
+- `manifests/examples/home-manager-settings.jsonc` — gains `eza` + `neovim` curated entries.
+- Zero winget / Windows / package-capture regression; the catalog path is Nix-only.

--- a/openspec/changes/nix-home-manager-catalog-more/specs/nix-home-manager-catalog/spec.md
+++ b/openspec/changes/nix-home-manager-catalog-more/specs/nix-home-manager-catalog/spec.md
@@ -1,0 +1,67 @@
+## ADDED Requirements
+
+### Requirement: The curated catalog maps four additional developer programs to stable home-manager options
+
+The engine SHALL accept the curated home-manager catalog concepts `eza`, `gh`, `lazygit`, and `neovim`
+declared in `homeManager.settings`, and SHALL map each to a **stable** home-manager option so the
+declaration keeps working when the underlying home-manager option surface changes. The user SHALL NOT
+have to author any Nix to declare these.
+
+- `eza` SHALL map to `programs.eza.enable` plus an optional `programs.eza.extraOptions` list of raw
+  CLI flag strings (e.g. `["--git", "--icons"]`).
+- `gh` SHALL map to `programs.gh.enable` plus an optional `programs.gh.settings` attrset forwarded
+  verbatim (gh's own config key namespace).
+- `lazygit` SHALL map to `programs.lazygit.enable` plus an optional `programs.lazygit.settings`
+  attrset forwarded verbatim (lazygit's own config structure, which may be deeply nested).
+- `neovim` SHALL map to `programs.neovim.enable` plus an optional `programs.neovim.extraConfig` raw
+  vimscript/lua string.
+
+#### Scenario: A new curated concept is compiled into the generated home.nix
+
+- **WHEN** `apply` runs on the Nix realizer with configuration changes enabled and the manifest
+  declares one of the curated concepts `eza`, `gh`, `lazygit`, or `neovim`
+- **THEN** the engine SHALL compile it into the corresponding `programs.<name>` option(s) in the
+  generated `home.nix`
+- **AND** the user SHALL NOT have to author any Nix, `home.nix`, or flake wiring
+
+#### Scenario: eza extraOptions render as a Nix list
+
+- **WHEN** the declaration sets `eza.extraOptions` to a list of flag strings (e.g. `["--git","--icons"]`)
+- **THEN** the engine SHALL render them as `programs.eza.extraOptions = [ "--git" "--icons" ];` in the
+  generated `home.nix`
+- **AND** the rendering SHALL be deterministic, so identical settings produce an identical `home.nix`
+
+#### Scenario: gh and lazygit settings attrsets are forwarded verbatim
+
+- **WHEN** the declaration sets `gh.settings` or `lazygit.settings` to a (possibly nested) attrset
+- **THEN** the engine SHALL render it as `programs.gh.settings = { ... };` or
+  `programs.lazygit.settings = { ... };` in the generated `home.nix`, with sorted keys for determinism
+- **AND** nested attrsets SHALL be rendered recursively as Nix attrsets
+
+#### Scenario: neovim extraConfig uses the stable extraConfig surface
+
+- **WHEN** the declaration sets `neovim.extraConfig` to a raw vimscript/lua string
+- **THEN** the engine SHALL render it as `programs.neovim.extraConfig = "...";` in the generated
+  `home.nix`, with newlines, quotes, and `${` escaped for valid Nix string syntax
+- **AND** the mapping SHALL shield the declaration from home-manager neovim option renames, so the
+  curated concept keeps working when the underlying per-feature options change
+
+### Requirement: The four new curated concepts reject unknown sub-keys and conflict with overlapping raw passthrough
+
+The new curated concepts SHALL share the catalog's load-time and compile-time guards: a mistyped
+sub-key SHALL be rejected at load, and a raw `programs.<name>` passthrough that targets the same name
+as a curated concept SHALL be a clear error rather than a Nix double definition.
+
+#### Scenario: A mistyped sub-key on a new concept is rejected
+
+- **WHEN** a declaration uses one of the new curated concepts with an unrecognized sub-key (for example
+  `eza.enabel`, `gh.settigns`, `lazygit.settigns`, or `neovim.extraCfg`)
+- **THEN** the engine SHALL reject the manifest with a clear error rather than silently dropping the
+  setting
+
+#### Scenario: A raw passthrough overlapping a new curated concept is an error
+
+- **WHEN** a declaration sets both a new curated concept (for example `eza`) and a raw `programs` entry
+  for the same name (`programs.eza`)
+- **THEN** the engine SHALL reject the declaration with a clear conflict error rather than emitting a
+  duplicate `programs.<name>` definition that Nix would reject with an opaque error

--- a/openspec/changes/nix-home-manager-catalog-more/tasks.md
+++ b/openspec/changes/nix-home-manager-catalog-more/tasks.md
@@ -1,0 +1,35 @@
+> TDD: write each test RED first, then implement to green. Hermetic (no live Nix calls). Verify:
+> `cd go-engine && go test ./...` + `go vet ./...` + `GOOS=windows go build ./...`; real-nix apply smoke.
+
+## 1. Schema — add typed curated fields
+
+- [x] 1.1 RED tests (`home_settings_test.go`): the new concepts (`eza`, `gh`, `lazygit`, `neovim`)
+      round-trip through JSONC load; a mistyped sub-key (`eza.enabel`, `gh.settigns`,
+      `lazygit.settigns`, `neovim.extraCfg`) fails to load.
+- [x] 1.2 `internal/manifest/types.go`: add `Eza` (`*EzaSettings`), `Gh` (`*GhSettings`),
+      `Lazygit` (`*LazygitSettings`), `Neovim` (`*NeovimSettings`) to `HomeManagerSettings`;
+      add the four small typed structs.
+
+## 2. Rendering — map each concept to a stable home-manager option
+
+- [x] 2.1 RED tests (`home_catalog_test.go`): each new concept renders its expected statement(s)
+      (`programs.eza.enable`, `programs.eza.extraOptions`, `programs.gh.settings`,
+      `programs.lazygit.settings`, `programs.neovim.extraConfig`, …); raw `programs.<name>`
+      colliding with a curated concept (all four) is a clear error.
+- [x] 2.2 `internal/realizer/nix/home_catalog.go`: add the four names to `curatedPrograms`; render
+      each concept in `CompileHomeNix` following the git/bat/tmux/ssh patterns; add
+      `stringSliceToAny` helper next to `stringMapToAny`.
+
+## 3. Example manifest
+
+- [x] 3.1 `manifests/examples/home-manager-settings.jsonc`: add `eza` + `neovim` curated entries;
+      leave `programs.htop` raw passthrough intact (htop is NOT curated).
+
+## 4. OpenSpec + verification
+
+- [x] 4.1 `cd go-engine && go test ./...` green
+- [x] 4.2 `go vet ./...` + `GOOS=windows go build ./...` clean
+- [x] 4.3 `openspec validate nix-home-manager-catalog-more --strict --no-interactive` passes
+- [ ] 4.4 Real-nix apply smoke (operator-run): apply a manifest with 2-3 new concepts
+      (`--enable-restore`) and assert the generated `home.nix` contains the expected statements
+      and home-manager activation succeeds.


### PR DESCRIPTION
## What

Extends the curated `homeManager.settings` catalog with **4 more concepts**, each a real home-manager `programs.*` option mapped to a stable surface (continuing the rename-insulation pattern):

| Concept | Maps to | Type |
|---|---|---|
| `eza` | `programs.eza.enable` + `programs.eza.extraOptions` (`[]string`) | `EzaSettings` |
| `gh` | `programs.gh.enable` + `programs.gh.settings` (attrset) | `GhSettings` |
| `lazygit` | `programs.lazygit.enable` + `programs.lazygit.settings` (attrset) | `LazygitSettings` |
| `neovim` | `programs.neovim.enable` + `programs.neovim.extraConfig` (raw) | `NeovimSettings` |

Each is a typed field (strict `UnmarshalJSON` rejects mistyped sub-keys) and registered in `curatedPrograms` (a raw `programs.<name>` passthrough conflicts loudly). Added a `stringSliceToAny` helper for `eza.extraOptions`.

## Changes

- `internal/manifest/types.go` — 4 new fields + structs.
- `internal/realizer/nix/home_catalog.go` — `curatedPrograms` + render blocks + `stringSliceToAny`.
- Tests (RED→GREEN): render, unknown-sub-key rejection, and a table-driven raw-overlap conflict test across all 4.
- `manifests/examples/home-manager-settings.jsonc` — adds `eza` + `neovim` (the raw `programs.htop` demo left intact).
- OpenSpec change `nix-home-manager-catalog-more` (strict-valid).

## Verification

- `go test ./...`, `go vet ./...`, `GOOS=windows go build ./...` — all green.
- `openspec validate nix-home-manager-catalog-more --strict` — valid.
- **Real-nix smoke (throwaway `$HOME`/`ENDSTATE_ROOT`):** a settings block with all 4 → `apply --enable-restore` → `activated:true`; the generated `home.nix` renders every statement and activation succeeded (proving all 4 option names are valid home-manager options).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
