### PR TITLE
docs(openspec): scope macOS Homebrew driver (design only)

### DIFF
--- a/openspec/changes/macos-brew-driver/.openspec.yaml
+++ b/openspec/changes/macos-brew-driver/.openspec.yaml
@@ -1,0 +1,10 @@
+id: macos-brew-driver
+title: "Scope a macOS Homebrew driver (design only)"
+status: exploring
+spec: macos-brew-driver
+created: "2026-06-03"
+author: Hugo Ander Kivi
+artifacts:
+  - proposal.md
+  - design.md
+  - tasks.md

--- a/openspec/changes/macos-brew-driver/design.md
+++ b/openspec/changes/macos-brew-driver/design.md
@@ -1,0 +1,329 @@
+## Context
+
+- **Two backend shapes already exist.** `driver.Driver` (`internal/driver/driver.go`) is per-package
+  and non-atomic — `Detect(ref) (bool, name, err)` + `Install(ref) (*InstallResult, err)` — with
+  three **optional** interfaces a driver may also implement: `Uninstaller` (best-effort rollback),
+  `VersionedInstaller` (`InstallVersion` / `ReinstallVersion` pinning), and `BatchDetector`
+  (`DetectBatch(refs) → map[ref]DetectResult`, where `DetectResult` carries `Installed`,
+  `DisplayName`, and best-effort `Version`). `winget` is the only `Driver` and implements all three.
+  `realizer.Realizer` is the whole-set, atomic-generation model (Nix), deliberately **not** a
+  `Driver`.
+- **Selection is GOOS-keyed and mutually exclusive today.** `selectBackend(goos)` returns the winget
+  `Driver` for `windows` and `ErrNoBackend` otherwise; `selectRealizer(goos)` returns `nix.New()` for
+  `linux`/`darwin` and `ErrNoRealizer` otherwise. The doc comment states the invariant plainly: *"on
+  any host at most one succeeds."* `apply`/`capture`/`plan`/`verify` all call `newRealizerFn()`
+  **first** and, when it succeeds, **return the realizer path** — the per-package driver loop below is
+  unreachable on darwin. This single short-circuit is the crux this design must break.
+- **The per-app selection seam already exists in the schema.** `manifest.App`
+  (`internal/manifest/types.go`) already has `Refs map[goos]string`, `Driver string` (`json:"driver"`,
+  omitempty), and `Version string`. The GOOS-keyed ref and a per-app `driver` field are exactly the
+  hooks a brew/nix split needs — no new schema invention is required for routing, only a meaning for
+  `driver: "brew"` and a ref convention for Casks.
+- **Winget already set the precedent brew mirrors.** `winget-best-effort-rollback` specifies the
+  non-native rollback-by-uninstall pattern (uninstall the union of later generations' added refs,
+  per-package failure tolerated, confirmation required, append a rollback generation).
+  `windows-version-capture-pinning` specifies version capture (record installed version, empty is not
+  a failure) and pinning (declared version installs that exact version, pinning only applies to
+  drivers that support a specific version; the realizer ignores per-package version). Brew reuses both
+  shapes, with brew-specific caveats noted below.
+- **The primary audience is non-technical.** Endstate targets non-technical users first (technical users
+  second). For them the headline macOS need is reinstalling *GUI apps* (Chrome, Zoom, Spotify, Office…)
+  with zero terminal and zero knowledge of any package manager — a need Nix on macOS cannot meet and brew
+  Casks can. This reframes brew from a developer convenience into the **core app-recovery path** for the
+  people Endstate is for, and it bears directly on the routing-default decision (§3 / Open Question 2) and
+  on bootstrapping the backend invisibly (§8).
+
+## Goals / Non-Goals
+
+**Goals (of the eventual feature this scopes):**
+
+- A Mac user can declare native GUI apps (Casks) and CLI tools (formulae) and have Endstate install,
+  verify, and capture them through Homebrew.
+- Brew coexists with the Nix realizer on the same darwin host: config + Nix packages via the realizer
+  (default), brew apps via the driver (opt-in).
+- Brew follows winget's driver shape (optional `Uninstaller` / `VersionedInstaller` / `BatchDetector`)
+  so the engine's per-package machinery is reused, not reinvented.
+- A no-Nix adoption path: a manifest that uses **only** brew apps should be installable on a Mac that
+  has Homebrew but not Nix.
+
+**Non-Goals:**
+
+- No implementation in this change. No Go, no new driver package, no `select.go` edit, no dependency.
+- Not replacing Nix on macOS. Brew is additive and opt-in; the realizer stays the default backend for
+  config and for Nix packages.
+- Not a Linuxbrew story. Homebrew-on-Linux exists, but on Linux the Nix realizer is the established
+  backend; this scopes brew as the **macOS** driver only.
+- Not selecting the final ref scheme or routing rule — the recommendation is a starting position; the
+  decisions are the human's (see Open Questions + `tasks.md`).
+
+---
+
+## 1. Driver shape — brew as `driver.Driver`, winget's macOS sibling
+
+Brew is a per-package, non-atomic `driver.Driver`. It implements the same surface winget does:
+
+| Interface | Method(s) | Brew mapping |
+|---|---|---|
+| `Driver` (core) | `Name() → "brew"` | stable identifier |
+| `Driver` (core) | `Detect(ref)` | `brew list <name>` / `brew list --cask <name>` exit code → installed; display name from `brew info` or the bare name |
+| `Driver` (core) | `Install(ref)` | `brew install <formula>` or `brew install --cask <app>`; non-zero, non-already-installed exit → `StatusFailed`/`ReasonInstallFailed` |
+| `Uninstaller` (optional) | `Uninstall(ref)` | `brew uninstall <name>` / `brew uninstall --cask <name>`; already-absent → `StatusAbsent` |
+| `VersionedInstaller` (optional) | `InstallVersion` / `ReinstallVersion` | best-effort pin — see §5; brew's pin model is weaker than winget's `--version` |
+| `BatchDetector` (optional) | `DetectBatch(refs)` | one `brew list --versions` + one `brew list --cask --versions` parsed into `map[ref]DetectResult` with `Version` filled |
+
+**Best-effort and non-atomic, like winget.** Brew installs one package at a time; a failure on one
+package does not abort the others. Rollback is the **winget best-effort pattern**, reused verbatim:
+because brew exposes `brew uninstall`, the engine's existing best-effort rollback
+(`winget-best-effort-rollback`) extends to brew unchanged — uninstall the union of added refs from
+generations after the target, tolerate per-package failure, require confirmation, append a
+rollback-produced generation, and surface the untracked-transitive-dependency caveat (brew's
+auto-installed dependencies are exactly such a caveat). Brew gets **no** generation/native rollback —
+that is a realizer-only (Nix) property and stays so.
+
+This means brew adds **no new core interface** to `driver.go`. It is a second implementation of an
+interface set winget already proves out, which is the strongest argument that the driver/realizer
+split was the right abstraction.
+
+## 2. Formula vs Cask — how a manifest ref distinguishes them
+
+`brew install <formula>` installs a CLI package; `brew install --cask <app>` installs a GUI `.app`.
+The engine must know which from the manifest. Three candidate schemes:
+
+| Scheme | Example | Pros | Cons |
+|---|---|---|---|
+| **A. `cask:` prefix in the darwin ref** (recommended) | `"refs": { "darwin": "cask:google-chrome" }`; bare `"darwin": "ripgrep"` = formula | Lives entirely in the existing `Refs` map; no schema change; one ref string carries name **and** kind; reads naturally; the bare-name default is the formula (the CLI-package case that matches Nix's package shape) | A magic prefix is a micro-DSL inside a string; the parser must strip and route it |
+| **B. A new per-app field** | `"darwin": "google-chrome", "darwinKind": "cask"` | Explicit, typed, validatable | New schema field for a darwin-only concern; redundant with the ref; clutters `App` for every other OS |
+| **C. Two ref keys** | `"darwin-cask": "google-chrome"` vs `"darwin": "ripgrep"` | No prefix parsing | Pollutes the GOOS keyspace with a non-GOOS key; `Refs[runtime.GOOS]` lookups (used throughout apply/verify) would miss it |
+
+**Recommendation: Scheme A, the `cask:` prefix.** It keeps Casks first-class while requiring **zero
+schema change** — `Refs[runtime.GOOS]` already returns the ref string, and the brew driver strips a
+leading `cask:` to decide `--cask`. The bare-name default is the formula, which lines up with how Nix
+refs already name CLI packages, so a CLI tool's `darwin` ref can often be written once and routed to
+either backend. Because Casks are the headline value, the spec calls them out explicitly and the
+prefix makes them visually obvious in the manifest. (If the human prefers an explicit typed field for
+validatability, Scheme B is the fallback; the spec is written kind-agnostic so either survives.)
+
+A subtlety: a `cask:` ref is **only meaningful to the brew driver**. An app with `"driver": "brew"`
+and `"darwin": "cask:slack"` is unambiguous. An app **without** `driver: "brew"` whose darwin ref is
+`cask:...` is a manifest error (the realizer cannot install a Cask) and should fail loudly at load —
+see §3 routing.
+
+## 3. THE HARD PART — the selection model on darwin (both backends live)
+
+**The problem.** macOS is the first OS where `selectRealizer` returns a realizer **and**
+`selectBackend` would return a driver. Today exactly one backend exists per host and apply/capture/
+plan/verify encode that by calling `newRealizerFn()` first and returning its path when it succeeds —
+on darwin that always happens, so the winget-style driver loop never runs. Adding a brew driver
+without changing that control flow would make brew **unreachable**.
+
+**The routing rule (recommended).**
+
+1. **The Nix realizer stays the default backend for darwin.** Config (`homeManager.*`) and any app
+   **without** an explicit driver go through the realizer, exactly as today. Nothing about a
+   pure-Nix Mac manifest changes.
+2. **`"driver": "brew"` opts an app into the brew driver.** It is per-app and explicit. The value of
+   the existing `App.Driver` field selects the backend; absent/empty means "the host default," which
+   on darwin is the realizer.
+3. **The pipeline splits darwin apps into two lanes, not one.** Instead of "realizer present →
+   realizer owns everything," the engine partitions `manifest.Apps` by resolved backend: apps routed
+   to brew form the **driver lane**; everything else (config + default apps) forms the **realizer
+   lane**. Both lanes run; results merge into one envelope. This is the load-bearing structural change
+   the implementation must make and the design's central recommendation.
+4. **Manual apps stay manual.** `manual` apps are orthogonal to backend and unaffected.
+
+**How each command coexists:**
+
+- **apply:** run the realizer lane (config + default/Nix apps) and the brew driver lane (best-effort
+  per-package installs, batch-detected first). Order: realizer first (it may provide the toolchain),
+  then brew. Each lane records its own provisioning, attributed to its backend (§ capture attribution).
+- **plan / verify:** compute the realizer diff for its lane and per-package presence (and optional
+  version) for the brew lane; emit both into one plan/verify report. `verify` of a brew app is
+  `brew list` presence + optional version (§5).
+- **capture:** run **both** capture lanes on darwin — the realizer recovery (home-manager + Nix
+  packages from provisioning history) **and** a brew enumeration (`brew leaves`, `brew list --cask`).
+  Merge into one manifest.
+
+**Capture attribution — which backend did a discovered package come from?** This is the genuinely
+hard sub-question, because a Mac may have both Nix-provisioned and brew-installed packages.
+Recommended rule, in priority order:
+
+1. **Provisioning history is authoritative for what Endstate installed.** A package recorded in a
+   realizer Provisioning Generation is attributed to the realizer; a package recorded in a brew-driver
+   generation is attributed to brew. This is exact for Endstate-managed packages and matches how
+   winget capture already prefers recorded refs.
+2. **`brew leaves` / `brew list --cask` enumerate the brew-owned set directly.** Homebrew has its own
+   prefix (`/opt/homebrew` or `/usr/local`) and its own database; `brew leaves` (top-level formulae,
+   excluding dependencies) and `brew list --cask` are the authoritative brew inventory. Anything brew
+   reports is a brew app, emitted with `driver: "brew"` and a `cask:`-prefixed ref for casks.
+3. **Nix packages come from the realizer's recovery path, not from brew.** They are disjoint by
+   construction (different stores, different databases), so double-counting is structurally avoided.
+4. **Unprovisioned, non-brew, non-Nix apps** (hand-installed `.app`s, Mac App Store) are out of scope —
+   capture records what brew and the realizer own, not arbitrary `/Applications` contents.
+
+**Conflict / validation rules to spec:**
+
+- A `cask:` ref on an app **not** routed to brew is a load error (the realizer cannot install a Cask).
+- `driver: "brew"` on a non-darwin host: the design recommends treating brew as **darwin-only**; a
+  `brew`-driver app with no `darwin` ref is simply not applicable on other hosts (skipped), and on
+  Windows `driver: "brew"` with a `windows` ref should fail loudly rather than silently use winget.
+- An app may declare refs for multiple OSes; `driver: "brew"` only takes effect when the host is
+  darwin and a `darwin` ref is present.
+
+## 4. Capture — `brew leaves` / `brew list` → manifest
+
+- **Formulae:** `brew leaves` lists top-level (explicitly installed) formulae, excluding dependencies
+  brew pulled in — the right granularity for a manifest (you declare what you wanted, not its
+  closure). Each becomes an app with a bare `darwin` ref and `driver: "brew"`.
+- **Casks:** `brew list --cask` lists installed casks. Each becomes an app with a `cask:`-prefixed
+  `darwin` ref and `driver: "brew"`.
+- **Versions:** `brew list --versions <name>` (and `--cask --versions`) yields the installed version,
+  recorded best-effort exactly like winget — an unavailable version is recorded empty and does **not**
+  fail capture (`windows-version-capture-pinning` precedent).
+- **Round-trip:** capture → manifest → apply must converge. Because `brew leaves` excludes
+  dependencies, re-applying the captured manifest reinstalls the same top-level set; brew re-resolves
+  the dependency closure. Casks round-trip by bare cask token. The capture attribution rule (§3)
+  ensures a brew app is re-emitted as a brew app, not mis-attributed to the realizer.
+
+## 5. Verify + version
+
+- **Presence:** `brew list <formula>` / `brew list --cask <app>` exit code is the presence check
+  (the `DetectBatch` fast path runs `brew list --versions` once for all formulae and once for all
+  casks).
+- **Version pin (weaker than winget):** brew is **not** a precise version-pinning tool. `brew install`
+  installs the current formula/cask version; brew has no first-class `--version` flag like winget.
+  Pinning a formula to an older version means an explicit `brew pin` (which only **freezes** the
+  currently-installed version against upgrade, it does not *select* an arbitrary past version) or
+  installing a versioned formula (`name@X`) when the tap provides one, or an `extract`/URL pin —
+  all fragile. **Recommendation:** brew implements `VersionedInstaller` only in the weak sense —
+  honor a versioned-formula ref (`node@20`) where the tap offers one, and otherwise treat a declared
+  version as **advisory**: verify reports drift if the installed version differs, but `apply` does not
+  attempt arbitrary downgrades. This mirrors `windows-version-capture-pinning`'s rule that pinning
+  applies only where the backend genuinely supports a specific version, and that an unavailable
+  pinned version is an install failure rather than a silent substitution. The spec states brew's
+  pin is best-effort and may be a no-op for formulae the tap does not version.
+
+## 6. Real-macOS verification plan
+
+The winget lesson (recorded across the Nix-realizer effort): **real package-manager output parsing is
+not reasonable-by-inspection.** Winget capture had two real bugs that only surfaced against real
+winget v1.28 — exit codes, column layout, and batch-vs-per-ref name differences were all wrong on
+paper. Brew has the same traps:
+
+- `brew list` exit codes (0 present / 1 absent) and whether a missing formula prints to stderr.
+- `brew list --versions` column layout (name + space-separated versions, possibly multiple).
+- Cask vs formula output divergence (`brew list --cask` token format vs formula names).
+- `brew leaves` semantics (top-level only) vs `brew list` (everything, including dependencies).
+- `brew info --json` shape if used for display names.
+- Exit code on "already installed" vs "newly installed" for the install idempotency mapping.
+
+**Plan:** hermetic unit tests (fake `ExecCommand`, like winget's `_test.go` suite) for all parsing,
+**plus** a real-brew smoke on a real Mac. The vehicle already exists: `.github/workflows/
+nix-integration.yml` runs a `macos-latest` runner (`continue-on-error`, non-blocking). A future
+implementation change adds a `brew-realbrew-smoke.sh` step there (install a tiny formula + a tiny
+cask, capture, assert round-trip), so the brew parsing is validated against real Homebrew exactly as
+the Nix path is validated against real Nix. **No smoke is added by this design-only change** — this
+is the recorded plan for the implementation.
+
+## 7. Phased path
+
+- **Phase 1 — formulae + Casks install/capture/verify (the value, together).** Brew `Driver`
+  (`Detect`/`Install`) with the `cask:` ref scheme so Casks ship **with** formulae, not after — Casks
+  are the headline "rebuild my Mac" value and splitting them out would ship the less-valuable half
+  first. `BatchDetector` for fast presence. Capture via `brew leaves` + `brew list --cask`. Verify via
+  `brew list`. The darwin two-lane routing (§3) lands here because nothing works without it.
+- **Phase 2 — best-effort rollback + version.** Implement `Uninstaller` so the existing
+  `winget-best-effort-rollback` pattern extends to brew, and `VersionedInstaller` in the weak sense of
+  §5 (versioned-formula refs + advisory drift). Add the real-brew smoke to `nix-integration.yml`.
+- **Phase 3 — polish / no-Nix adoption ergonomics.** Make a brew-only manifest installable on a Mac
+  with Homebrew but no Nix (the realizer lane is empty, so `newRealizerFn()` must not be a hard
+  requirement when no `homeManager`/Nix apps are declared). Tap management, `brew bundle`
+  interop, and Mac App Store (`mas`) coverage are explicitly deferred.
+
+**Recommendation:** ship **Phase 1 with Casks included** — formulae-only would deliver the smaller
+half of the value. Treat rollback/version (Phase 2) as the immediate follow-up, and the no-Nix
+ergonomics (Phase 3) as the adoption unlock once the core is proven.
+
+## 8. Invisible Homebrew bootstrap (install Homebrew if absent)
+
+For the non-technical audience the backend must be **set up by the engine**, not by the user. Today the
+engine treats a missing backend as a hard stop (the realizer returns `REALIZER_UNAVAILABLE` when Nix is
+absent); a brew driver would similarly fail if `brew` is not on `PATH`. That is the wrong behavior for
+someone who just wants their apps back — "go install Homebrew first" is exactly the wall this feature
+exists to remove.
+
+**The model: detect → consent → bootstrap → verify → proceed (or fail gracefully).**
+
+- **Detect.** Before the brew lane runs, check for a working `brew` (on `PATH` / at the Homebrew prefix).
+  Present and working → no-op, no prompt.
+- **Consent — and why it cannot be fully silent.** The official Homebrew install triggers an **Xcode
+  Command Line Tools** install and asks for the user's **admin password** (sudo). Those prompts are
+  enforced by macOS; the engine cannot and must not suppress them. So "invisible" means the *concepts*
+  are hidden (the user never learns the word "Homebrew"), **not** that consent is hidden. The engine
+  explains in plain language ("Endstate needs to set up its installer — this is safe; macOS will ask for
+  your password") and asks once.
+- **Bootstrap.** Run the **official** Homebrew installer (the upstream `install.sh`) — the engine
+  *orchestrates* it; it does not vendor or fork the installer. This is a privileged, system-modifying
+  step, so it must be **explicit, consented, and inspectable** (the user can see exactly what will run),
+  consistent with Endstate's non-destructive / no-silent-mutation posture.
+- **Verify.** After install, confirm `brew` works (`brew --version`) before continuing; a failed
+  bootstrap surfaces a clear, plain-language error and never leaves the apply silently half-done.
+- **Graceful decline.** If the user declines, the brew lane is skipped with a clear message and the rest
+  of the apply still runs. Declining is not a crash.
+
+**Scope note.** This is the **Homebrew** half of a broader "the engine installs its own backends"
+capability that also covers **Nix** (the Determinate installer — the same one `nix-integration.yml`
+already uses in CI) on macOS/Linux. The Nix half is broader (root/daemon, a macOS volume, the
+uninstall-the-backend question) and is scoped **separately**; what belongs *here* is the brew-specific
+bootstrap. Windows is unaffected (winget ships with the OS). Whether this lands in Phase 1 (it is
+arguably part of the "rebuild my Mac with zero prerequisites" promise) or as a fast-follow is an open
+question.
+
+## Open Questions (for the human)
+
+1. **Ref scheme.** Confirm the `cask:` prefix (Scheme A) over a typed `darwinKind` field (Scheme B).
+   Is a string micro-DSL acceptable, or is an explicit typed field preferred for validatability?
+2. **Routing default — the key product decision.** The recommendation above keeps the Nix realizer as
+   the darwin default with `driver: "brew"` as per-app opt-in (conservative, backward-compatible). **But
+   weigh that against the primary audience:** non-technical users mostly want *apps*, and on macOS those
+   come from brew/Casks — so for them, **brew arguably should be the default backend for `apps` on
+   darwin**, with the Nix realizer reserved for `homeManager` config and explicitly Nix-routed packages.
+   That reverses today's default and is a bigger behavior change, but it is the stronger "rebuild my Mac
+   with zero Nix" story and aligns the default with who Endstate is for. A middle path: keep the
+   *engine* default at realizer, but have the **GUI / non-technical flow** emit brew-routed app entries
+   by default, so the *product* default is brew even if the *engine* default stays nix. Decide:
+   realizer-default+brew-opt-in (conservative), brew-default-for-apps+nix-for-config (audience-aligned),
+   or the GUI-default middle path.
+3. **No-Nix adoption.** How hard a requirement is "installable on a Mac without Nix"? It implies the
+   pipeline must run the brew lane even when `newRealizerFn()` would otherwise own the host — i.e. the
+   realizer becomes optional when no Nix/config work is declared. Phase 1 or Phase 3?
+4. **Capture attribution edge.** Is "provisioning history first, then `brew leaves`/`brew list --cask`"
+   the right attribution? What about a package present in **both** Nix and brew (unlikely but possible
+   for some CLI tools)? Recommend: report it once, attributed to whichever Endstate provisioning
+   recorded it; if neither, attribute to brew (it is in the brew database).
+5. **Version semantics.** Accept brew's weak pin (advisory drift + versioned-formula refs only), or
+   require precise pinning (and therefore reject formulae the tap does not version)? The winget spec
+   makes an unavailable pinned version an install failure; should brew match that strictness or be
+   lenient given brew's model?
+6. **Cask uninstall destructiveness.** `brew uninstall --cask` removes an app but may leave user data
+   (or, with `--zap`, remove it). Best-effort rollback should use the **non-zap** uninstall
+   (non-destructive default), consistent with Endstate's backup-before-overwrite / no-silent-deletion
+   posture. Confirm.
+7. **Invisible bootstrap (§8).** Should the engine bootstrap **Homebrew when absent** (detect → consent
+   → official install → verify → graceful decline), and in which phase (Phase 1 as part of the "zero
+   prerequisites" promise, or a fast-follow)? Confirm the consent model (one plain-language prompt; the
+   macOS password / Xcode-CLT prompts cannot be suppressed), and that the parallel **Nix** bootstrap is a
+   separate, broader capability scoped on its own.
+
+## Risks / Verification (of the eventual feature)
+
+- **Real-output drift** — the headline risk (the winget lesson). Mitigation: hermetic parse tests +
+  the real-brew smoke on the macOS runner before any claim of correctness.
+- **Routing regression on pure-Nix Macs** — the two-lane split must be byte-identical for a manifest
+  with no `driver: "brew"` apps. Mitigation: a test asserting a no-brew darwin manifest produces the
+  same envelope as today's realizer-only path.
+- **Cask write-permission / GUI-app surprises** — casks may prompt, need `/Applications` write access,
+  or require Rosetta. These are runtime realities the smoke must surface, not reason about.
+- **Best-effort uninstall caveats** — brew auto-installed dependencies are untracked transitive
+  installs; rollback must surface the same caveat winget does and default to non-destructive uninstall.
+- These are verification *targets for the future implementation*, recorded so the eventual proposal
+  inherits them. **No code is verified by this design-only change.**

--- a/openspec/changes/macos-brew-driver/proposal.md
+++ b/openspec/changes/macos-brew-driver/proposal.md
@@ -1,0 +1,111 @@
+## Why
+
+On macOS, Endstate today provisions packages and home-manager config through the **Nix realizer**
+(`selectRealizer("darwin")` → `nix.New()`). That is the right backend for cross-OS declarative CLI
+packages and for the home-manager config story. It is the **wrong** backend for the single most
+important "rebuild my Mac" use case: **native GUI apps**. Nix on macOS cannot idiomatically install
+a `.app` bundle into `/Applications` (nixpkgs Darwin GUI coverage is thin and non-native), and it
+forces a full, heavy Nix install on a user who may want none of it.
+
+The native way Mac users install GUI apps is **Homebrew Casks** — `brew install --cask google-chrome`,
+`slack`, `docker`, `rectangle`, `visual-studio-code`. Casks (and, for CLI tools, formulae) are the
+backbone of a believable Mac rebuild. So Homebrew is **complementary to Nix, not redundant**:
+
+- **Nix** = cross-OS declarative config + pinned CLI packages + the home-manager catalog.
+- **Homebrew** = native macOS apps/casks + a **no-Nix adoption path** for users who just want their
+  Mac apps back without installing Nix at all.
+
+**Who this is for.** Endstate targets **non-technical users first** (technical users benefit too). For a
+non-technical person, "rebuild my Mac" means *their actual apps* — Chrome, Zoom, Spotify, Office, Slack —
+reinstalled without ever opening a terminal or learning what a package manager is. Those are GUI apps,
+which Nix on macOS cannot install idiomatically and which the user will never install Nix to get.
+**Homebrew Casks are the only realistic path to that promise**, which makes brew — for the primary
+audience — the *core* macOS app-recovery mechanism, not a developer convenience. The backend stays
+invisible (the user sees Endstate, never "brew"), and the engine even **installs Homebrew itself when it
+is absent** (with consent) so "go install a package manager first" never blocks a non-technical user —
+see §8 of `design.md`.
+
+Architecturally, `brew` is the macOS analog of **winget**: a **per-package, non-atomic
+`driver.Driver`**, NOT a whole-set `realizer.Realizer`. It mirrors winget's optional-interface shape
+(`Uninstaller` for best-effort rollback, `VersionedInstaller` for pinning, `BatchDetector` for fast
+detection) and reuses the already-specified winget best-effort-rollback pattern. This change scopes —
+**design only, no implementation** — how that driver is shaped, how a manifest distinguishes a Cask
+from a formula, and (the hard part) how the engine routes apps between `brew` and the Nix realizer on
+the first OS to have **both a driver and a realizer live at once**.
+
+## What Changes
+
+This is a **design-only** OpenSpec change. It produces the comparison, the recommendation, and a
+delta-spec **sketch**; it changes **no Go code, no engine behavior, and no real manifest**.
+
+The direction it proposes (for the human to ratify) is to **ADD a `brew` Driver beside the existing
+`winget` driver and `nix` realizer**, specifically:
+
+- **Brew is a `driver.Driver`, winget's macOS sibling.** Per-package, non-atomic, best-effort. It
+  implements the same optional interfaces winget does — `Uninstaller` (best-effort rollback),
+  `VersionedInstaller` (pinning, with brew's weaker pin semantics noted), `BatchDetector` (fast
+  presence via `brew list`) — and explicitly does **not** offer generation/native rollback (that
+  stays Nix-only).
+- **A manifest ref distinguishes Cask from formula.** Casks are the headline value, so the scheme
+  must make them first-class. The design recommends a `cask:` prefix inside the `darwin` ref (e.g.
+  `"refs": { "darwin": "cask:google-chrome" }`), with a bare `darwin` ref meaning a formula.
+- **Per-app routing on darwin via the existing `driver` field.** macOS becomes the first host with
+  both a realizer and a driver available. The Nix realizer stays the **default** (config + Nix
+  packages); `brew` is **opt-in per app** via `"driver": "brew"`. The design specifies how
+  `apply`/`capture`/`verify`/`plan` coexist when both backends are present, and how capture decides
+  which backend a discovered package came from.
+- **Capture from `brew leaves` / `brew list --cask`** into manifest formulae + casks (bare names,
+  version via `brew list --versions`).
+- **A real-macOS verification plan** that treats real `brew` output as ground truth (the winget
+  lesson), wired into the existing `nix-integration.yml` macOS runner as the vehicle for a future
+  real-brew smoke.
+
+No final routing model or ref scheme is *selected* by this change. The recommendation (see
+`design.md`) is a starting position; the open decisions are left explicit for review.
+
+## Capabilities
+
+### New Capabilities
+
+- `macos-brew-driver`: A capability, specified here at requirement level only (no implementation),
+  under which Endstate installs, captures, and verifies macOS packages through Homebrew as a
+  per-package `driver.Driver` that coexists with the Nix realizer. The load-bearing requirements
+  (sketched in `specs/macos-brew-driver/spec.md`):
+  - **Brew installs both formulae and Casks** — a manifest `darwin` ref distinguishes the two, and
+    Casks are first-class (the headline value).
+  - **Capture records both formulae and Casks** as bare names with best-effort versions.
+  - **Brew is best-effort, not atomic** — no whole-set generation and no native rollback; rollback is
+    the winget-style best-effort uninstall pattern.
+  - **Per-app driver selection routes brew vs nix on darwin** — the Nix realizer stays default;
+    `"driver": "brew"` opts an app into the brew driver; the two backends coexist across
+    apply/capture/verify/plan.
+
+### Modified Capabilities
+
+- None in this design-only change. It is additive: it introduces a new driver capability beside the
+  existing `winget` driver and `nix` realizer capabilities, and ratifies how the existing
+  per-app `driver` selection seam (`manifest.App.Driver` + GOOS-keyed `Refs`) extends to darwin.
+
+## Impact
+
+**This change is design-only. It modifies no Go code and ships no behavior.** The list below is the
+surface a *future* implementation would touch, recorded here so the eventual proposal is pre-scoped:
+
+- `go-engine/internal/driver/brew/` — a new driver package mirroring `internal/driver/winget/`:
+  `Detect` / `Install` (core `Driver`), plus optional `Uninstall` (`Uninstaller`),
+  `InstallVersion` / `ReinstallVersion` (`VersionedInstaller`), `DetectBatch` (`BatchDetector`), and
+  `Capabilities`. Formula-vs-Cask is resolved from the ref here.
+- `go-engine/internal/commands/select.go` — `selectBackend("darwin")` would return the brew driver so
+  darwin has **both** a driver and a realizer; today darwin returns `ErrNoBackend` from
+  `selectBackend` and `nix.New()` from `selectRealizer`. The routing rule (realizer default, brew
+  per-app opt-in) is the design's hard part.
+- `go-engine/internal/commands/apply.go` / `capture.go` / `plan.go` / `verify.go` — these currently
+  **short-circuit to the realizer** when `newRealizerFn()` succeeds (it always does on darwin), making
+  the driver loop unreachable. Co-existence requires splitting darwin apps into a realizer set and a
+  brew-driver set and running both lanes.
+- `go-engine/internal/commands/capture_realizer.go` / `capture.go` — capture would gain a brew lane
+  (`brew leaves`, `brew list --cask`, `brew list --versions`) and a rule for which backend a
+  discovered package is attributed to.
+- `.github/workflows/nix-integration.yml` — the existing macOS runner is the vehicle for a future
+  **real-brew smoke** (added by the implementation change, not here).
+- `openspec/specs/macos-brew-driver/` — the spec this sketch graduates into on adoption.

--- a/openspec/changes/macos-brew-driver/specs/macos-brew-driver/spec.md
+++ b/openspec/changes/macos-brew-driver/specs/macos-brew-driver/spec.md
@@ -1,0 +1,166 @@
+## ADDED Requirements
+
+> SKETCH — this delta-spec is part of a DESIGN-ONLY change. The requirements below define the behavior
+> the eventual implementation MUST satisfy; no engine code implements them yet. They are stated
+> behavior-level so they survive the human's decisions on ref scheme and routing default (see
+> `design.md` Open Questions).
+
+### Requirement: Brew installs both formulae and Casks
+
+The engine SHALL install macOS packages through Homebrew as a per-package driver, installing a CLI
+**formula** (`brew install <name>`) or a GUI **Cask** (`brew install --cask <name>`) according to the
+app's `darwin` reference, with Casks treated as a first-class package kind. The driver SHALL determine
+formula-vs-Cask from the reference (recommended: a `cask:` prefix marks a Cask; a bare reference is a
+formula) without requiring the manifest to encode any other macOS-specific package metadata.
+
+#### Scenario: A Cask reference installs a GUI app
+
+- **WHEN** `apply` runs on macOS for an app routed to the brew driver whose `darwin` reference marks it
+  as a Cask
+- **THEN** the engine SHALL install it as a Homebrew Cask (the `brew install --cask` path)
+- **AND** the result SHALL be reported as installed (or present when it is already installed)
+
+#### Scenario: A bare reference installs a formula
+
+- **WHEN** `apply` runs on macOS for an app routed to the brew driver whose `darwin` reference is a
+  bare name with no Cask marker
+- **THEN** the engine SHALL install it as a Homebrew formula (the `brew install <name>` path)
+
+#### Scenario: A failed install does not abort the remaining packages
+
+- **WHEN** one brew package fails to install during an `apply`
+- **THEN** the engine SHALL report that package as failed
+- **AND** it SHALL continue attempting the remaining brew packages
+
+### Requirement: Capture records both formulae and Casks
+
+When capturing on macOS, the engine SHALL record installed Homebrew formulae and Casks into the
+manifest as bare package names routed to the brew driver, recording top-level formulae (those a user
+explicitly installed, excluding dependencies) and installed Casks, each with its installed version
+recorded best-effort. A version the package manager does not expose SHALL be recorded as empty rather
+than failing the capture.
+
+#### Scenario: Capture records top-level formulae and Casks
+
+- **WHEN** `capture` runs on a macOS host that has Homebrew formulae and Casks installed
+- **THEN** the captured manifest SHALL include the top-level formulae (excluding dependency-only
+  formulae) and the installed Casks
+- **AND** each captured brew app SHALL be routed to the brew driver, with Casks marked as Casks
+
+#### Scenario: A missing version does not fail capture
+
+- **WHEN** Homebrew exposes no version for a captured package
+- **THEN** the engine SHALL record an empty version for that package
+- **AND** the capture SHALL NOT fail because a version was unavailable
+
+#### Scenario: Captured brew apps round-trip back to brew
+
+- **WHEN** a manifest captured from a brew-provisioned macOS host is re-applied
+- **THEN** the previously captured formulae and Casks SHALL be installed again through the brew driver
+- **AND** they SHALL NOT be mis-attributed to the Nix realizer
+
+### Requirement: The brew backend is best-effort and non-atomic
+
+The brew driver SHALL operate per package without a whole-set atomic generation and without native
+rollback. Rollback for the brew backend SHALL reuse the engine's best-effort uninstall pattern —
+uninstalling the packages recorded as added after the target generation — rather than a native
+generation switch, and SHALL surface that package-manager-pulled transitive dependencies are not
+tracked and may remain installed. The brew driver SHALL default to a non-destructive uninstall that
+does not remove user data.
+
+#### Scenario: Brew rollback uninstalls later additions best-effort
+
+- **WHEN** `rollback` runs against the brew backend for a target generation
+- **THEN** the engine SHALL uninstall the brew packages recorded as added after the target generation
+- **AND** it SHALL continue past a per-package uninstall failure and report it
+- **AND** it SHALL surface the untracked-transitive-dependency caveat
+
+#### Scenario: Brew offers no native generation rollback
+
+- **WHEN** a rollback is requested on the brew backend
+- **THEN** the engine SHALL NOT attempt a native whole-set generation switch
+- **AND** it SHALL use the best-effort uninstall path instead
+
+### Requirement: Per-app driver selection routes brew versus nix on darwin
+
+On macOS, where both the Nix realizer and the brew driver are available, the engine SHALL route each
+manifest app to a backend using the per-app `driver` field: an app declaring the brew driver SHALL be
+provisioned through Homebrew, and every other app together with all home-manager configuration SHALL
+be provisioned through the Nix realizer, which remains the default. The engine SHALL run both backends
+in the same `apply`, `capture`, `verify`, and `plan` invocation rather than letting one backend
+exclude the other.
+
+#### Scenario: A brew-driver app and a default app coexist in one apply
+
+- **WHEN** `apply` runs on macOS for a manifest containing one app that declares the brew driver and
+  one app (or home-manager configuration) with no driver declared
+- **THEN** the engine SHALL provision the brew-driver app through Homebrew
+- **AND** it SHALL provision the default app and the home-manager configuration through the Nix
+  realizer in the same run
+
+#### Scenario: The Nix realizer remains the darwin default
+
+- **WHEN** an app on macOS declares no driver
+- **THEN** the engine SHALL provision it through the Nix realizer
+- **AND** the behavior of a manifest that declares no brew-driver apps SHALL be unchanged from the
+  realizer-only path
+
+#### Scenario: A Cask reference without the brew driver is rejected
+
+- **WHEN** a manifest declares an app whose `darwin` reference marks it as a Cask but does not route it
+  to the brew driver
+- **THEN** the engine SHALL reject the manifest at load with a clear error
+- **AND** it SHALL NOT attempt to install the Cask through the Nix realizer
+
+### Requirement: Brew verifies presence and best-effort version
+
+The engine SHALL verify a brew app by its installed presence (`brew list`) and SHALL treat a declared
+version as a best-effort pin, given Homebrew's weak version-selection model. Verify SHALL report
+version drift when the installed version differs from a declared version, but `apply` SHALL NOT
+downgrade or reinstall a present package solely to match a declared version that Homebrew cannot
+select.
+
+#### Scenario: Presence is the verify check
+
+- **WHEN** `verify` runs for a brew app that is installed
+- **THEN** the engine SHALL report it as present based on its Homebrew installation
+- **AND** a brew app that is not installed SHALL be reported as missing
+
+#### Scenario: A declared version is advisory for formulae brew cannot version-select
+
+- **WHEN** a brew app declares a version that Homebrew cannot select for that formula
+- **THEN** `verify` SHALL report version drift if the installed version differs
+- **AND** `apply` SHALL NOT downgrade or reinstall the present package solely to match the declared
+  version
+
+### Requirement: Homebrew is bootstrapped when absent, with consent
+
+When the brew backend is needed on macOS and Homebrew is not installed, the engine SHALL offer to install
+Homebrew via its official installer, proceed only after explicit user consent, and verify Homebrew works
+before using it. The engine SHALL NOT install Homebrew silently or without consent, SHALL surface a clear
+error rather than a silently half-completed state if the bootstrap fails, and SHALL — if the user
+declines — skip the brew backend with a clear message while continuing the rest of the run.
+
+#### Scenario: Homebrew absent — bootstrapped after consent
+
+- **WHEN** `apply` needs the brew backend on macOS and Homebrew is not installed
+- **THEN** the engine SHALL explain in plain language that it will set up the installer and request consent
+- **AND** on consent it SHALL run the official Homebrew installer and verify Homebrew works before
+  installing any packages
+
+#### Scenario: Consent declined — brew lane skipped, run continues
+
+- **WHEN** the user declines the Homebrew bootstrap
+- **THEN** the engine SHALL NOT install Homebrew
+- **AND** it SHALL skip the brew-routed apps with a clear message and still run the rest of the apply
+
+#### Scenario: Bootstrap failure is surfaced, not silent
+
+- **WHEN** the Homebrew bootstrap is attempted and fails
+- **THEN** the engine SHALL report a clear error
+- **AND** it SHALL NOT proceed as if the brew backend were available
+
+#### Scenario: Homebrew already present — no bootstrap
+
+- **WHEN** the brew backend is needed and Homebrew is already installed and working
+- **THEN** the engine SHALL use it directly without attempting a bootstrap or prompting

--- a/openspec/changes/macos-brew-driver/tasks.md
+++ b/openspec/changes/macos-brew-driver/tasks.md
@@ -1,0 +1,73 @@
+> DESIGN-ONLY change. These are decision/scoping tasks, not code tasks. No Go is written, no engine
+> behavior ships, no dependency is added. "Done" items are the comparison/scoping work completed in
+> `design.md`; "open" items are the decisions the human makes on review before any implementation
+> proposal is opened.
+
+## 1. Scoping & comparison (done — captured in design.md)
+
+- [x] 1.1 Frame brew as **complementary to Nix, not redundant**: Nix = cross-OS config + CLI
+      packages; brew = native macOS apps/casks + a no-Nix adoption path.
+- [x] 1.2 Establish the driver shape: brew is a `driver.Driver` (winget's macOS sibling), with the
+      same optional interfaces (`Uninstaller`, `VersionedInstaller`, `BatchDetector`); best-effort and
+      non-atomic; **no** generation/native rollback (that stays Nix-only).
+- [x] 1.3 Compare formula-vs-Cask ref schemes (`cask:` prefix vs typed field vs two ref keys) and
+      recommend the `cask:` prefix in the darwin ref, keeping Casks first-class.
+- [x] 1.4 Resolve the hard part — the darwin selection model with **both** a realizer and a driver
+      live: realizer default, `driver: "brew"` opt-in, a two-lane pipeline, and the capture
+      attribution rule (provisioning history → `brew leaves`/`brew list --cask`).
+- [x] 1.5 Specify capture (`brew leaves` / `brew list --cask` / `brew list --versions`), verify
+      (`brew list` presence + advisory version), and brew's weak pin semantics vs winget's `--version`.
+- [x] 1.6 Record the real-macOS verification plan (the winget lesson) and name `nix-integration.yml`'s
+      macOS runner as the vehicle for a future real-brew smoke.
+- [x] 1.7 Define the phased path (P1 formulae + Casks together, P2 rollback + version, P3 no-Nix
+      ergonomics) with a recommendation.
+- [x] 1.8 Sketch the delta-spec requirements in `specs/macos-brew-driver/spec.md`.
+- [x] 1.9 Scope the **invisible Homebrew bootstrap** (detect → consent → official install → verify →
+      graceful decline) as the non-technical "zero prerequisites" path, and frame brew (for the primary,
+      non-technical audience) as the core macOS app-recovery path rather than a developer convenience;
+      note the parallel **Nix** bootstrap is a separate, broader capability (§8).
+
+## 2. Decisions (open — the human ratifies)
+
+- [ ] 2.1 **Decide the ref scheme.** Confirm the `cask:` prefix (Scheme A) over a typed `darwinKind`
+      field (Scheme B), or choose B for validatability.
+- [ ] 2.2 **Decide the routing default.** Confirm "realizer is the darwin default; `driver: "brew"`
+      opts in per app," or whether brew should be the default for *apps* (realizer only for config).
+- [ ] 2.3 **Decide the no-Nix adoption bar.** Whether a brew-only manifest must be installable on a Mac
+      without Nix, and whether that lands in Phase 1 or Phase 3 (it makes the realizer optional when no
+      Nix/config work is declared).
+- [ ] 2.4 **Decide capture attribution** for a package present in both Nix and brew, and confirm
+      "provisioning history first, then `brew leaves`/`brew list --cask`."
+- [ ] 2.5 **Decide version strictness.** Accept brew's weak/advisory pin, or require precise pinning
+      (and reject formulae the tap does not version), matching the winget unavailable-pin-is-failure
+      rule.
+- [ ] 2.6 **Confirm non-destructive cask uninstall** (non-`--zap`) for best-effort rollback.
+- [ ] 2.7 **Decide the routing default through the non-technical lens** — realizer-default+brew-opt-in
+      (conservative), brew-default-for-apps+nix-for-config (audience-aligned), or the GUI-default middle
+      path (§3 / Open Question 2).
+- [ ] 2.8 **Decide the invisible Homebrew bootstrap** — confirm detect→consent→install→verify, the
+      one-prompt consent model, and whether it lands in Phase 1 or a fast-follow (§8 / Open Question 7).
+
+## 3. Spec hardening (open — before implementation)
+
+- [ ] 3.1 **Spec the formula/Cask install** as a testable requirement (a `cask:` ref installs a Cask;
+      a bare ref installs a formula).
+- [ ] 3.2 **Spec capture of both kinds** (formulae via `brew leaves`, casks via `brew list --cask`,
+      versions best-effort).
+- [ ] 3.3 **Spec brew as best-effort** (no whole-set generation, no native rollback; rollback reuses
+      the winget best-effort-uninstall pattern).
+- [ ] 3.4 **Spec the darwin per-app routing** (realizer default, `driver: "brew"` opt-in, two-lane
+      coexistence; conflicting `cask:` ref without brew driver fails loudly).
+- [ ] 3.5 Graduate the ratified subset of `specs/macos-brew-driver/spec.md` into an implementation
+      proposal (separate, non-design-only change).
+- [ ] 3.6 **Spec the bootstrap** (absent → consent → official install → verify; decline → skip + continue;
+      failure → clear error; present → no-op) — sketched in `spec.md`, harden on ratification.
+
+## 4. Non-tasks (explicitly out of scope here)
+
+- [ ] 4.1 (NOT in this change) Any Go / engine implementation — no `internal/driver/brew/` package,
+      no `select.go` edit, no apply/capture/plan/verify two-lane wiring.
+- [ ] 4.2 (NOT in this change) Adding any dependency, tap, or `brew bundle` / `mas` integration.
+- [ ] 4.3 (NOT in this change) Adding a real-brew smoke step to `nix-integration.yml` — recorded as the
+      implementation's vehicle, but the workflow is a protected area and is not touched here.
+- [ ] 4.4 (NOT in this change) Linuxbrew — brew is scoped as the macOS driver only.


### PR DESCRIPTION
## What — DESIGN ONLY (no implementation)

A strict-valid OpenSpec change (`macos-brew-driver`) scoping a macOS **Homebrew** driver for review. **Zero `.go` changes.**

## Framing — non-technical users first

Endstate targets **non-technical users first**. For them, "rebuild my Mac" means *their actual apps back* (Chrome, Zoom, Spotify, Office, Slack) — GUI apps that **Nix on macOS can't install idiomatically** and that the user would never install Nix to get. **Homebrew Casks are the only realistic path**, so brew is the **core macOS app-recovery mechanism**, not a developer convenience — complementary to nix (nix = cross-OS declarative config + CLI packages; brew = native apps/casks + a no-Nix adoption path).

## What the design resolves

- **Brew as a `driver.Driver`** — winget's macOS sibling (per-package, best-effort, non-atomic), reusing winget's optional interfaces (`Uninstaller`/`VersionedInstaller`/`BatchDetector`) — no new core interface.
- **Formula vs Cask** via a `cask:` prefix in the `darwin` ref (zero schema change; Casks first-class).
- **The hard part — the darwin selection model** (first OS with both a realizer *and* a driver live): a two-lane pipeline + capture attribution (provisioning history → `brew leaves`/`brew list --cask`).
- **§8 Invisible Homebrew bootstrap** — detect → consent → official install → verify → graceful decline. Honest that it *can't be fully silent* (macOS forces the password/Xcode-CLT prompt), so it's **one-click + consented** with the concepts hidden. The parallel **Nix** bootstrap is flagged as a separate, broader capability.
- Real-macOS verification plan (the winget-reality lesson), capture/round-trip, weak version-pin semantics.

## Key decisions left for you (open questions in the doc)

- **Routing default** — realizer-default + brew-opt-in (conservative) vs **brew-default-for-apps + nix-for-config** (audience-aligned, my lean) vs a GUI-default middle path.
- **Bootstrap phasing** — Homebrew bootstrap in Phase 1 (part of "zero prerequisites") or a fast-follow.

`openspec validate macos-brew-driver --strict` — valid. Design-only; the implementation is a separate, ratified-decisions change later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
