### PR TITLE
feat(capture): defense-in-depth bloat guard (baseline excludes + oversized-installer skip)

### DIFF
--- a/go-engine/internal/bundle/collect.go
+++ b/go-engine/internal/bundle/collect.go
@@ -77,6 +77,12 @@ func CollectConfigFiles(module *modules.Module, stagingDir string) ([]string, in
 			return collected, secretsExcluded, fmt.Errorf("missing required file: %s (module: %s)", sourcePath, module.ID)
 		}
 
+		// Defense-in-depth: skip an oversized installer/executable even if the
+		// module explicitly declared it (a config file is never a 10 MiB binary).
+		if !info.IsDir() && isOversizedInstaller(sourcePath, info.Size()) {
+			continue
+		}
+
 		// Ensure destination directory exists.
 		destDir := filepath.Dir(destPath)
 		if err := os.MkdirAll(destDir, 0755); err != nil {
@@ -185,6 +191,62 @@ func matchesExcludeGlobs(path string, excludeGlobs []string) bool {
 	return false
 }
 
+// captureBloatDirs are directory names (matched case-insensitively, any depth)
+// that are never legitimate config — downloaded-update/installer staging,
+// caches, and crash dumps. Every module inherits these as a defense-in-depth
+// baseline (on top of its own excludeGlobs) so a single misconfigured module
+// can't silently bloat the backup and burn the user's quota (cf. the PowerToys
+// `Updates/` installer leak that made a capture ~283× larger than it should be).
+var captureBloatDirs = map[string]bool{
+	"updates":       true,
+	"installer":     true,
+	"setup":         true,
+	"cache":         true,
+	"gpucache":      true,
+	"code cache":    true,
+	"shadercache":   true,
+	"crashpad":      true,
+	"crash reports": true,
+	"temp":          true,
+	"logs":          true,
+}
+
+// captureBloatBinaryExts are installer/executable extensions that are never
+// config. Files with these extensions are skipped above captureBloatBinaryMaxBytes.
+var captureBloatBinaryExts = map[string]bool{
+	".exe":  true,
+	".msi":  true,
+	".msix": true,
+	".appx": true,
+	".dmg":  true,
+	".pkg":  true,
+}
+
+// captureBloatBinaryMaxBytes is the size over which an installer/executable is
+// treated as bloat and skipped. A small bundled helper binary still rides along.
+const captureBloatBinaryMaxBytes = 10 * 1024 * 1024 // 10 MiB
+
+// isBloatDirSegment reports whether any segment of relPath is a known bloat
+// directory (case-insensitive). relPath is relative to the captured source root,
+// so only dirs WITHIN a recursively-captured subtree are matched — never a
+// coincidentally-named ancestor of the source itself.
+func isBloatDirSegment(relPath string) bool {
+	for _, seg := range strings.Split(filepath.ToSlash(relPath), "/") {
+		if captureBloatDirs[strings.ToLower(seg)] {
+			return true
+		}
+	}
+	return false
+}
+
+// isOversizedInstaller reports whether path is an installer/executable larger
+// than captureBloatBinaryMaxBytes — defense-in-depth against a bloated binary
+// that escapes the directory baseline (e.g. a stray installer in an app root).
+func isOversizedInstaller(path string, size int64) bool {
+	return captureBloatBinaryExts[strings.ToLower(filepath.Ext(path))] &&
+		size > captureBloatBinaryMaxBytes
+}
+
 // copyFile copies a single file from src to dst.
 func copyFile(src, dst string) error {
 	in, err := os.Open(src)
@@ -244,6 +306,19 @@ func copyDir(src, dst string, excludeGlobs, secretsFiles []string) (int, error) 
 		if err != nil {
 			return err
 		}
+
+		// Defense-in-depth: never bundle known bloat dirs (caches, update/installer
+		// staging, crash dumps) or oversized installers, regardless of module config.
+		if isBloatDirSegment(relPath) {
+			if info.IsDir() {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		if !info.IsDir() && isOversizedInstaller(path, info.Size()) {
+			return nil
+		}
+
 		destPath := filepath.Join(dst, relPath)
 
 		if info.IsDir() {

--- a/go-engine/internal/bundle/collect_bloat_test.go
+++ b/go-engine/internal/bundle/collect_bloat_test.go
@@ -1,0 +1,146 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package bundle
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/modules"
+)
+
+func TestIsBloatDirSegment(t *testing.T) {
+	cases := []struct {
+		rel  string
+		want bool
+	}{
+		{"Cache/data.bin", true},
+		{"config/UPDATES/installer", true}, // case-insensitive
+		{"powertoys/Updates/setup.exe", true},
+		{"Code Cache/index", true}, // multi-word segment
+		{"Crash Reports/x.dmp", true},
+		{"logs/app.log", true},
+		{"config.json", false},
+		{"settings/keybindings.json", false},
+		{"cached_data.json", false}, // substring, not a full segment → kept
+	}
+	for _, c := range cases {
+		if got := isBloatDirSegment(c.rel); got != c.want {
+			t.Errorf("isBloatDirSegment(%q) = %v, want %v", c.rel, got, c.want)
+		}
+	}
+}
+
+func TestIsOversizedInstaller(t *testing.T) {
+	const big = captureBloatBinaryMaxBytes + 1
+	const small = captureBloatBinaryMaxBytes - 1
+	cases := []struct {
+		path string
+		size int64
+		want bool
+	}{
+		{"powertoysusersetup-0.98.1-x64.exe", big, true},
+		{"installer.msi", big, true},
+		{"app.MSIX", big, true},      // case-insensitive ext
+		{"helper.exe", small, false}, // small binary rides along
+		{"settings.json", big, false}, // not an installer ext
+		{"notes.txt", big * 100, false},
+	}
+	for _, c := range cases {
+		if got := isOversizedInstaller(c.path, c.size); got != c.want {
+			t.Errorf("isOversizedInstaller(%q, %d) = %v, want %v", c.path, c.size, got, c.want)
+		}
+	}
+}
+
+// The bloat-dir baseline is inherited by every module — a module with NO
+// excludeGlobs still skips Updates/Crashpad/etc. within a captured directory.
+func TestCollectConfigFiles_BloatBaselineInherited(t *testing.T) {
+	dir := t.TempDir()
+	stagingDir := filepath.Join(dir, "staging")
+	if err := os.MkdirAll(stagingDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	srcDir := filepath.Join(dir, "source")
+	for _, d := range []string{"Updates", "Crashpad"} {
+		if err := os.MkdirAll(filepath.Join(srcDir, d), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "config.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "Updates", "setup.dat"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "Crashpad", "dump"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// NB: no ExcludeGlobs on the module — the baseline must apply anyway.
+	mod := &modules.Module{
+		ID: "apps.test",
+		Capture: &modules.CaptureDef{
+			Files: []modules.CaptureFile{{Source: srcDir, Dest: "apps/test/source"}},
+		},
+	}
+
+	if _, _, err := CollectConfigFiles(mod, stagingDir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	base := filepath.Join(stagingDir, "configs", "test", "source")
+	if _, err := os.Stat(filepath.Join(base, "config.json")); err != nil {
+		t.Errorf("config.json should be kept: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(base, "Updates", "setup.dat")); !os.IsNotExist(err) {
+		t.Error("Updates/ should be excluded by the inherited baseline")
+	}
+	if _, err := os.Stat(filepath.Join(base, "Crashpad", "dump")); !os.IsNotExist(err) {
+		t.Error("Crashpad/ should be excluded by the inherited baseline")
+	}
+}
+
+// An oversized installer inside a captured directory is skipped even when it's
+// not under a bloat dir (the size guard), while config + small files are kept.
+func TestCollectConfigFiles_OversizedInstallerSkipped(t *testing.T) {
+	dir := t.TempDir()
+	stagingDir := filepath.Join(dir, "staging")
+	if err := os.MkdirAll(stagingDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	srcDir := filepath.Join(dir, "source")
+	if err := os.MkdirAll(srcDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "config.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	big := make([]byte, captureBloatBinaryMaxBytes+1)
+	if err := os.WriteFile(filepath.Join(srcDir, "huge-installer.exe"), big, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mod := &modules.Module{
+		ID: "apps.test",
+		Capture: &modules.CaptureDef{
+			Files: []modules.CaptureFile{{Source: srcDir, Dest: "apps/test/source"}},
+		},
+	}
+
+	if _, _, err := CollectConfigFiles(mod, stagingDir); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	base := filepath.Join(stagingDir, "configs", "test", "source")
+	if _, err := os.Stat(filepath.Join(base, "config.json")); err != nil {
+		t.Errorf("config.json should be kept: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(base, "huge-installer.exe")); !os.IsNotExist(err) {
+		t.Error("oversized installer should be skipped by the size guard")
+	}
+}


### PR DESCRIPTION
## What
Defense-in-depth so a single misconfigured module can't silently bloat a backup and burn the user's quota — the failure mode behind the **PowerToys `Updates/` leak** (a downloaded 394 MB installer made a capture ~283× larger; a per-module glob fixed *that* one — this stops the *next*).

Every module now inherits, on top of its own `excludeGlobs`:
1. **Baseline bloat dirs** (case-insensitive, within a captured subtree): `Updates`, `Installer`, `Setup`, `Cache`, `GPUCache`, `Code Cache`, `ShaderCache`, `Crashpad`, `Crash Reports`, `Temp`, `logs`.
2. **Oversized-installer guard**: skip `*.exe`/`*.msi`/`*.msix`/`*.appx`/`*.dmg`/`*.pkg` files over **10 MiB** (a config file is never a 10 MiB binary; a small bundled helper still rides along).

## How (`bundle/collect.go`)
- The dir baseline runs in `copyDir` against the path **relative to the captured source** — so a coincidentally-named *ancestor* of the source (e.g. `C:\Users\…\Temp\…` as a prefix) is never matched, only bloat dirs *inside* the captured tree.
- The size guard runs in both `copyDir` and the single declared-file path.
- Two small unexported helpers (`isBloatDirSegment`, `isOversizedInstaller`); per-module `ExcludeGlobs` and the secrets-exclusion invariant are untouched.

## Tests
- Unit tests for both helpers (case-insensitivity, multi-word segments like "Code Cache", substring-not-segment safety, size threshold, ext set).
- Integration: baseline is **inherited with no module `excludeGlobs`** (Updates/Crashpad skipped, config kept); oversized installer skipped, config + small files kept.
- `go test ./internal/bundle/...` + `go vet` green; existing collect/exclude tests unchanged.

Pure engine capture behavior — no GUI change needed. Closes the last hosted-backup hardening follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)