### PR TITLE
feat(engine): brew driver package (macOS Homebrew adapter, hermetic)

### DIFF
--- a/go-engine/internal/driver/brew/brew.go
+++ b/go-engine/internal/driver/brew/brew.go
@@ -1,0 +1,256 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+// Package brew implements the driver.Driver interface for the macOS Homebrew
+// package manager (`brew`). It mirrors the winget driver's structure: an
+// injectable command runner (ExecCommand) so tests can substitute a fake
+// process, and an exit-code/output classification that maps brew outcomes onto
+// the shared driver.Status/Reason constants.
+//
+// ---------------------------------------------------------------------------
+// REAL-OUTPUT ANCHORS ARE ASSUMPTIONS (the winget lesson).
+//
+// This package was written on a Linux box with NO macOS / Homebrew available,
+// so every brew exit code and output format below is an ASSUMPTION encoded into
+// the hermetic tests via the fake command runner. A real-macOS smoke test (run
+// in the later pipeline-wiring increment) MUST confirm each of these before the
+// driver is trusted in production:
+//
+//  1. EXIT CODES — brew is assumed to follow the conventional shell contract:
+//     `brew list <name>` (and `brew list --cask <name>`) exits 0 when the
+//     formula/cask is installed and NON-ZERO (assumed 1) when it is not.
+//     `brew install` exits 0 on success (both fresh install AND a no-op when the
+//     package is already present — see #3) and non-zero on failure.
+//     `brew uninstall` exits 0 when it removed something, and non-zero when
+//     nothing matched (assumed paired with a "No such keg"/"not installed"
+//     style message — see #4). brew does NOT use Windows HRESULTs, so its codes
+//     survive POSIX 8-bit truncation and the hermetic tests can drive them
+//     directly (unlike winget's already-installed/no-package HRESULTs).
+//
+//  2. `brew list --versions` FORMAT — assumed one package per line as
+//     "<name> <version> [<version> ...]", whitespace-separated, e.g.
+//     "node 20.11.0" or "python@3.11 3.11.7". A line with only a name and no
+//     version is tolerated (Installed=true, Version=""). Casks are queried with
+//     `brew list --cask --versions` and assumed to share the same shape.
+//
+//  3. ALREADY-INSTALLED DETECTION — `brew install` of an already-present
+//     package is assumed to exit 0 (a successful no-op), so it is NOT
+//     distinguishable from a fresh install by exit code alone. We therefore
+//     detect-before-install (like winget): if Detect reports the package
+//     present we short-circuit to StatusPresent/ReasonAlreadyInstalled without
+//     spawning `brew install`. The assumed already-installed stdout substrings
+//     (e.g. "already installed") are also matched defensively as a fallback.
+//
+//  4. ALREADY-ABSENT DETECTION (uninstall) — `brew uninstall` of a package that
+//     is not installed is assumed to exit non-zero with a message containing one
+//     of the assumed substrings in noPackageFoundPattern (e.g. "no such keg",
+//     "not installed", "no available formula"). Because the exit code alone is
+//     ambiguous (any failure is non-zero), the output substring is the primary
+//     "absent" signal — matching winget's cross-platform-reliable approach.
+//
+//  5. CASK vs FORMULA — selected by the engine via the `cask:` ref scheme (see
+//     parseRef), NOT auto-detected from brew output. A leading "cask:" marks a
+//     Cask (we pass `--cask`); a bare ref is a formula. brew's own
+//     formula-vs-cask disambiguation is assumed not needed because the manifest
+//     declares the kind.
+//
+//  6. VERSION PINNING is WEAK / advisory — see install_version.go.
+// ---------------------------------------------------------------------------
+package brew
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/Artexis10/endstate/go-engine/internal/driver"
+)
+
+// caskPrefix marks a ref as a Homebrew Cask (a GUI app / binary artifact)
+// rather than a formula. parseRef strips it and signals isCask=true.
+const caskPrefix = "cask:"
+
+// alreadyInstalledPattern matches brew stdout/stderr indicating the package was
+// already present. ASSUMPTION (see brew.go header #3): `brew install` of an
+// already-installed package exits 0, so this is a defensive fallback; the
+// primary already-installed signal is the detect-before-install short-circuit.
+var alreadyInstalledPattern = regexp.MustCompile(`(?i)(already installed|is already installed|already up-to-date)`)
+
+// BrewDriver implements driver.Driver using the Homebrew CLI.
+// ExecCommand is an injection point so tests can substitute a fake command
+// runner without spawning a real brew process. It mirrors winget's design.
+type BrewDriver struct {
+	// ExecCommand creates an *exec.Cmd for the named binary and args.
+	// Defaults to exec.Command; tests replace it with a helper-process shim.
+	ExecCommand func(name string, args ...string) *exec.Cmd
+}
+
+// New returns a BrewDriver backed by the real exec.Command.
+func New() *BrewDriver {
+	return &BrewDriver{
+		ExecCommand: exec.Command,
+	}
+}
+
+// Name satisfies driver.Driver and returns the stable driver identifier.
+func (b *BrewDriver) Name() string { return "brew" }
+
+// parseRef splits an Endstate ref into the brew package name and whether it
+// designates a Cask. A leading "cask:" (case-insensitive) marks a Cask and is
+// stripped; a bare ref is a formula. Surrounding whitespace is trimmed.
+//
+// Examples:
+//
+//	parseRef("node")            → ("node", false)
+//	parseRef("node@20")         → ("node@20", false)   // versioned formula, see install_version.go
+//	parseRef("cask:firefox")    → ("firefox", true)
+//	parseRef("CASK:  visual-studio-code") → ("visual-studio-code", true)
+func parseRef(ref string) (name string, isCask bool) {
+	trimmed := strings.TrimSpace(ref)
+	if len(trimmed) >= len(caskPrefix) && strings.EqualFold(trimmed[:len(caskPrefix)], caskPrefix) {
+		return strings.TrimSpace(trimmed[len(caskPrefix):]), true
+	}
+	return trimmed, false
+}
+
+// Install installs the package identified by ref via brew.
+//
+// It detects-before-install (like winget): if Detect reports the package
+// already present, Install short-circuits to StatusPresent /
+// ReasonAlreadyInstalled WITHOUT spawning `brew install` (ASSUMPTION: brew
+// install of a present package exits 0 and is otherwise indistinguishable from
+// a fresh install — see brew.go header #3).
+//
+// Otherwise the command spawned is:
+//
+//	brew install <name>            (formula)
+//	brew install --cask <name>     (cask)
+//
+// Exit/output semantics:
+//   - 0              → StatusInstalled
+//   - already-installed stdout substring (defensive fallback) → StatusPresent
+//   - other non-zero → StatusFailed / ReasonInstallFailed
+//
+// If the brew binary is not found, Install returns (nil, ErrBrewNotAvailable).
+func (b *BrewDriver) Install(ref string) (*driver.InstallResult, error) {
+	return b.install(ref, "", false)
+}
+
+// install is the shared brew-install implementation. The version/force
+// parameters drive the (weak) VersionedInstaller path; see install_version.go.
+// With version="" and force=false it installs the latest, the plain Install
+// behavior.
+//
+// Detect-before-install: a present package short-circuits to
+// StatusPresent/ReasonAlreadyInstalled. When force is true (ReinstallVersion)
+// the short-circuit is skipped so the install/reinstall actually runs.
+func (b *BrewDriver) install(ref, version string, force bool) (*driver.InstallResult, error) {
+	name, isCask := parseRef(ref)
+
+	// Detect-before-install (skipped on the force/reinstall path).
+	if !force {
+		present, _, derr := b.Detect(ref)
+		if derr != nil {
+			// Infrastructure failure (e.g. brew missing) — surface it.
+			return nil, derr
+		}
+		if present {
+			return &driver.InstallResult{
+				Status:  driver.StatusPresent,
+				Reason:  driver.ReasonAlreadyInstalled,
+				Message: "Already installed",
+			}, nil
+		}
+	}
+
+	args := []string{"install"}
+	if isCask {
+		args = append(args, "--cask")
+	}
+	if force {
+		args = append(args, "--force")
+	}
+	// The install target is the (possibly versioned-formula) name. brew has no
+	// general `--version` flag, so a separately-declared `version` is advisory
+	// only and is NOT appended here — see install_version.go for the weakness.
+	args = append(args, name)
+
+	cmd := b.ExecCommand("brew", args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+
+	// Detect missing binary before inspecting exit code.
+	if runErr != nil {
+		var execErr *exec.Error
+		if errors.As(runErr, &execErr) && execErr.Err == exec.ErrNotFound {
+			return nil, ErrBrewNotAvailable
+		}
+	}
+
+	combined := stdout.String() + stderr.String()
+
+	exitCode := 0
+	if runErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			// Process did not exit normally (e.g. killed); treat as failure.
+			return &driver.InstallResult{
+				Status:  driver.StatusFailed,
+				Reason:  driver.ReasonInstallFailed,
+				Message: fmt.Sprintf("brew did not exit normally: %v", runErr),
+			}, nil
+		}
+	}
+
+	switch {
+	case exitCode == 0:
+		// Defensive fallback: brew install of an already-present package is
+		// assumed to exit 0; if its output says so, report present rather than
+		// installed (the detect-before-install short-circuit usually catches
+		// this first).
+		if !force && alreadyInstalledPattern.MatchString(combined) {
+			return &driver.InstallResult{
+				Status:  driver.StatusPresent,
+				Reason:  driver.ReasonAlreadyInstalled,
+				Message: "Already installed",
+			}, nil
+		}
+		return &driver.InstallResult{
+			Status:  driver.StatusInstalled,
+			Message: installedMessage(version),
+		}, nil
+
+	default:
+		return &driver.InstallResult{
+			Status:  driver.StatusFailed,
+			Reason:  driver.ReasonInstallFailed,
+			Message: failedMessage(exitCode, version),
+		}, nil
+	}
+}
+
+// installedMessage / failedMessage keep messaging parallel to winget's, and
+// surface the requested version on the (weak) pinned path so a failed/advisory
+// pin records what was asked for.
+func installedMessage(version string) string {
+	if version != "" {
+		return "Installed (requested version " + version + "; brew pinning is advisory)"
+	}
+	return "Installed successfully"
+}
+
+func failedMessage(exitCode int, version string) string {
+	if version != "" {
+		return fmt.Sprintf("brew exited with code %d (requested version %s)", exitCode, version)
+	}
+	return fmt.Sprintf("brew exited with code %d", exitCode)
+}

--- a/go-engine/internal/driver/brew/brew_test.go
+++ b/go-engine/internal/driver/brew/brew_test.go
@@ -1,0 +1,330 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package brew
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/driver"
+)
+
+// ---------------------------------------------------------------------------
+// Helper-process shim (mirrors winget's fake command runner).
+//
+// Tests replace BrewDriver.ExecCommand with a fake that spawns THIS test binary
+// with GO_WANT_HELPER_PROCESS=1 and encodes the desired exit code and optional
+// stdout/stderr via environment variables. TestHelperProcess runs inside that
+// re-invocation and emulates what brew would do.
+//
+// Because brew uses ordinary POSIX exit codes (no Windows HRESULTs), every code
+// path here is exercisable on Linux/macOS alike — unlike winget's HRESULT cases.
+// ---------------------------------------------------------------------------
+
+// TestHelperProcess is the entry point for the fake-brew subprocess.
+func TestHelperProcess(t *testing.T) {
+	if os.Getenv("GO_WANT_HELPER_PROCESS") != "1" {
+		return
+	}
+
+	stdout := os.Getenv("FAKE_STDOUT")
+	stderr := os.Getenv("FAKE_STDERR")
+	if stdout != "" {
+		fmt.Fprint(os.Stdout, stdout)
+	}
+	if stderr != "" {
+		fmt.Fprint(os.Stderr, stderr)
+	}
+
+	code := 0
+	if s := os.Getenv("FAKE_EXIT_CODE"); s != "" {
+		if parsed, err := strconv.Atoi(s); err == nil {
+			code = parsed
+		}
+	}
+	os.Exit(code)
+}
+
+// fakeCommand returns an ExecCommand func that re-invokes the test binary as a
+// helper process exiting with exitCode and writing the supplied stdout/stderr.
+func fakeCommand(exitCode int, stdout, stderr string) func(string, ...string) *exec.Cmd {
+	return func(name string, args ...string) *exec.Cmd {
+		cs := append([]string{"-test.run=TestHelperProcess", "--"}, args...)
+		cmd := exec.Command(os.Args[0], cs...)
+		cmd.Env = append(os.Environ(),
+			"GO_WANT_HELPER_PROCESS=1",
+			fmt.Sprintf("FAKE_EXIT_CODE=%d", exitCode),
+			fmt.Sprintf("FAKE_STDOUT=%s", stdout),
+			fmt.Sprintf("FAKE_STDERR=%s", stderr),
+		)
+		return cmd
+	}
+}
+
+// scriptedCommand drives a different (exitCode, stdout, stderr) response per
+// brew subcommand, so a test can simulate e.g. `brew list` (detect) returning
+// absent while `brew install` returns success. The key is args[0] (the brew
+// subcommand: "list", "install", "uninstall"). It also records each argv.
+type scriptedResponse struct {
+	exitCode int
+	stdout   string
+	stderr   string
+}
+
+func scriptedCommand(bySubcommand map[string]scriptedResponse, calls *[][]string) func(string, ...string) *exec.Cmd {
+	return func(name string, args ...string) *exec.Cmd {
+		if calls != nil {
+			*calls = append(*calls, append([]string{name}, args...))
+		}
+		sub := ""
+		if len(args) > 0 {
+			sub = args[0]
+		}
+		resp := bySubcommand[sub]
+		cs := append([]string{"-test.run=TestHelperProcess", "--"}, args...)
+		cmd := exec.Command(os.Args[0], cs...)
+		cmd.Env = append(os.Environ(),
+			"GO_WANT_HELPER_PROCESS=1",
+			fmt.Sprintf("FAKE_EXIT_CODE=%d", resp.exitCode),
+			fmt.Sprintf("FAKE_STDOUT=%s", resp.stdout),
+			fmt.Sprintf("FAKE_STDERR=%s", resp.stderr),
+		)
+		return cmd
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Name / parseRef
+// ---------------------------------------------------------------------------
+
+func TestName(t *testing.T) {
+	if New().Name() != "brew" {
+		t.Errorf("expected driver name %q, got %q", "brew", New().Name())
+	}
+}
+
+func TestParseRef(t *testing.T) {
+	tests := []struct {
+		ref      string
+		wantName string
+		wantCask bool
+	}{
+		{"node", "node", false},
+		{"node@20", "node@20", false},
+		{"cask:firefox", "firefox", true},
+		{"CASK:visual-studio-code", "visual-studio-code", true},
+		{"  ripgrep  ", "ripgrep", false},
+		{"cask:  google-chrome ", "google-chrome", true},
+		{"cask:", "", true},
+	}
+	for _, tc := range tests {
+		gotName, gotCask := parseRef(tc.ref)
+		if gotName != tc.wantName || gotCask != tc.wantCask {
+			t.Errorf("parseRef(%q) = (%q, %v), want (%q, %v)", tc.ref, gotName, gotCask, tc.wantName, tc.wantCask)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Detect
+// ---------------------------------------------------------------------------
+
+func TestDetect_FormulaInstalled(t *testing.T) {
+	var calls [][]string
+	d := &BrewDriver{ExecCommand: scriptedCommand(map[string]scriptedResponse{
+		"list": {exitCode: 0},
+	}, &calls)}
+	got, name, err := d.Detect("ripgrep")
+	if err != nil {
+		t.Fatalf("Detect returned unexpected error: %v", err)
+	}
+	if !got {
+		t.Error("expected Detect to return true for exit code 0")
+	}
+	if name != "ripgrep" {
+		t.Errorf("expected display name %q, got %q", "ripgrep", name)
+	}
+	joined := strings.Join(calls[0], " ")
+	if strings.Contains(joined, "--cask") {
+		t.Errorf("formula detect must not pass --cask: %q", joined)
+	}
+	if !strings.Contains(joined, "list ripgrep") {
+		t.Errorf("unexpected brew argv: %q", joined)
+	}
+}
+
+func TestDetect_FormulaNotInstalled(t *testing.T) {
+	d := &BrewDriver{ExecCommand: fakeCommand(1, "", "Error: No such keg")}
+	got, name, err := d.Detect("not-installed")
+	if err != nil {
+		t.Fatalf("Detect returned unexpected error: %v", err)
+	}
+	if got {
+		t.Error("expected Detect to return false for non-zero exit code")
+	}
+	if name != "" {
+		t.Errorf("expected empty display name for missing package, got %q", name)
+	}
+}
+
+func TestDetect_CaskInstalled(t *testing.T) {
+	var calls [][]string
+	d := &BrewDriver{ExecCommand: scriptedCommand(map[string]scriptedResponse{
+		"list": {exitCode: 0},
+	}, &calls)}
+	got, name, err := d.Detect("cask:firefox")
+	if err != nil {
+		t.Fatalf("Detect returned unexpected error: %v", err)
+	}
+	if !got {
+		t.Error("expected Detect to return true for installed cask")
+	}
+	if name != "firefox" {
+		t.Errorf("expected display name %q, got %q", "firefox", name)
+	}
+	joined := strings.Join(calls[0], " ")
+	if !strings.Contains(joined, "list --cask firefox") {
+		t.Errorf("cask detect must pass --cask: %q", joined)
+	}
+}
+
+func TestDetect_CaskNotInstalled(t *testing.T) {
+	d := &BrewDriver{ExecCommand: fakeCommand(1, "", "Error: Cask 'firefox' is not installed.")}
+	got, _, err := d.Detect("cask:firefox")
+	if err != nil {
+		t.Fatalf("Detect returned unexpected error: %v", err)
+	}
+	if got {
+		t.Error("expected Detect to return false for absent cask")
+	}
+}
+
+func TestDetect_MissingBinary(t *testing.T) {
+	d := &BrewDriver{ExecCommand: func(name string, args ...string) *exec.Cmd {
+		return exec.Command("endstate-no-such-brew-binary-xyz")
+	}}
+	_, _, err := d.Detect("ripgrep")
+	if err != ErrBrewNotAvailable {
+		t.Fatalf("expected ErrBrewNotAvailable, got %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Install
+// ---------------------------------------------------------------------------
+
+func TestInstall_FreshFormula(t *testing.T) {
+	var calls [][]string
+	d := &BrewDriver{ExecCommand: scriptedCommand(map[string]scriptedResponse{
+		"list":    {exitCode: 1, stderr: "Error: No such keg"}, // detect-before-install: absent
+		"install": {exitCode: 0, stdout: "🍺  /opt/homebrew/Cellar/ripgrep/14.1.0"},
+	}, &calls)}
+
+	res, err := d.Install("ripgrep")
+	if err != nil {
+		t.Fatalf("Install returned unexpected error: %v", err)
+	}
+	if res.Status != driver.StatusInstalled {
+		t.Errorf("expected status %q, got %q", driver.StatusInstalled, res.Status)
+	}
+	if res.Reason != "" {
+		t.Errorf("expected empty reason, got %q", res.Reason)
+	}
+	// Verify install actually spawned (detect said absent).
+	sawInstall := false
+	for _, c := range calls {
+		if len(c) > 1 && c[1] == "install" {
+			sawInstall = true
+			if strings.Contains(strings.Join(c, " "), "--cask") {
+				t.Errorf("formula install must not pass --cask: %v", c)
+			}
+		}
+	}
+	if !sawInstall {
+		t.Errorf("expected `brew install` to be spawned; calls=%v", calls)
+	}
+}
+
+func TestInstall_FreshCask(t *testing.T) {
+	var calls [][]string
+	d := &BrewDriver{ExecCommand: scriptedCommand(map[string]scriptedResponse{
+		"list":    {exitCode: 1, stderr: "Error: Cask 'firefox' is not installed."},
+		"install": {exitCode: 0, stdout: "🍺  firefox was successfully installed!"},
+	}, &calls)}
+
+	res, err := d.Install("cask:firefox")
+	if err != nil {
+		t.Fatalf("Install returned unexpected error: %v", err)
+	}
+	if res.Status != driver.StatusInstalled {
+		t.Errorf("expected status %q, got %q", driver.StatusInstalled, res.Status)
+	}
+	sawCaskInstall := false
+	for _, c := range calls {
+		if len(c) > 1 && c[1] == "install" && strings.Contains(strings.Join(c, " "), "--cask firefox") {
+			sawCaskInstall = true
+		}
+	}
+	if !sawCaskInstall {
+		t.Errorf("expected `brew install --cask firefox`; calls=%v", calls)
+	}
+}
+
+func TestInstall_AlreadyInstalledShortCircuits(t *testing.T) {
+	var calls [][]string
+	d := &BrewDriver{ExecCommand: scriptedCommand(map[string]scriptedResponse{
+		"list": {exitCode: 0}, // detect-before-install: present
+		// install intentionally not scripted — it must NOT be called.
+	}, &calls)}
+
+	res, err := d.Install("ripgrep")
+	if err != nil {
+		t.Fatalf("Install returned unexpected error: %v", err)
+	}
+	if res.Status != driver.StatusPresent {
+		t.Errorf("expected status %q, got %q", driver.StatusPresent, res.Status)
+	}
+	if res.Reason != driver.ReasonAlreadyInstalled {
+		t.Errorf("expected reason %q, got %q", driver.ReasonAlreadyInstalled, res.Reason)
+	}
+	for _, c := range calls {
+		if len(c) > 1 && c[1] == "install" {
+			t.Errorf("Install must NOT spawn `brew install` when already present: %v", calls)
+		}
+	}
+}
+
+func TestInstall_Failed(t *testing.T) {
+	d := &BrewDriver{ExecCommand: scriptedCommand(map[string]scriptedResponse{
+		"list":    {exitCode: 1}, // absent → proceed to install
+		"install": {exitCode: 1, stderr: "Error: No available formula with the name \"no-such-pkg\"."},
+	}, nil)}
+
+	res, err := d.Install("no-such-pkg")
+	if err != nil {
+		t.Fatalf("Install returned unexpected error: %v", err)
+	}
+	if res.Status != driver.StatusFailed {
+		t.Errorf("expected status %q, got %q", driver.StatusFailed, res.Status)
+	}
+	if res.Reason != driver.ReasonInstallFailed {
+		t.Errorf("expected reason %q, got %q", driver.ReasonInstallFailed, res.Reason)
+	}
+}
+
+func TestInstall_MissingBinary(t *testing.T) {
+	// Detect runs first; a missing binary there surfaces ErrBrewNotAvailable
+	// out of Install (infrastructure failure, not a per-package failure).
+	d := &BrewDriver{ExecCommand: func(name string, args ...string) *exec.Cmd {
+		return exec.Command("endstate-no-such-brew-binary-xyz")
+	}}
+	_, err := d.Install("ripgrep")
+	if err != ErrBrewNotAvailable {
+		t.Fatalf("expected ErrBrewNotAvailable, got %v", err)
+	}
+}

--- a/go-engine/internal/driver/brew/capabilities.go
+++ b/go-engine/internal/driver/brew/capabilities.go
@@ -1,0 +1,15 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package brew
+
+import "github.com/Artexis10/endstate/go-engine/internal/provision"
+
+// Capabilities reports the brew driver's capabilities. Like winget, Homebrew
+// installs per-package and non-atomically, with no native rollback and no
+// whole-set transaction, so every capability is false (AtomicSet=false,
+// NativeRollback=false, Transactional=false, BatchInstall=false). It satisfies
+// provision.CapabilityReporter for symmetry with the realizer and winget.
+func (b *BrewDriver) Capabilities() provision.Capabilities {
+	return provision.Capabilities{}
+}

--- a/go-engine/internal/driver/brew/capabilities_test.go
+++ b/go-engine/internal/driver/brew/capabilities_test.go
@@ -1,0 +1,19 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package brew
+
+import (
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/provision"
+)
+
+var _ provision.CapabilityReporter = (*BrewDriver)(nil)
+
+func TestCapabilities_BrewIsAllFalse(t *testing.T) {
+	c := New().Capabilities()
+	if c.AtomicSet || c.NativeRollback || c.Transactional || c.BatchInstall {
+		t.Fatalf("brew capabilities should all be false, got %+v", c)
+	}
+}

--- a/go-engine/internal/driver/brew/detect.go
+++ b/go-engine/internal/driver/brew/detect.go
@@ -1,0 +1,170 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package brew
+
+import (
+	"errors"
+	"os/exec"
+	"strings"
+
+	"github.com/Artexis10/endstate/go-engine/internal/driver"
+)
+
+// ErrBrewNotAvailable is returned when the brew binary cannot be found on PATH.
+// Callers should surface this as a backend-unavailable condition in the JSON
+// envelope rather than treating it as a per-package failure (mirrors winget's
+// ErrWingetNotAvailable).
+var ErrBrewNotAvailable = errors.New("brew is not installed or not available on PATH")
+
+// Detect reports whether the package identified by ref is currently installed.
+//
+// It runs (ASSUMPTION: exit 0 == present, non-zero == absent — see brew.go #1):
+//
+//	brew list <name>            (formula)
+//	brew list --cask <name>     (cask)
+//
+// and interprets the exit code:
+//   - 0        → installed (true, name, nil)
+//   - non-zero → not installed (false, "", nil)
+//   - binary not found → (false, "", ErrBrewNotAvailable)
+//
+// The display name is simply the bare package name (brew's identifier is the
+// human-facing name); we keep this simple rather than parsing `brew info`.
+func (b *BrewDriver) Detect(ref string) (bool, string, error) {
+	name, isCask := parseRef(ref)
+
+	args := []string{"list"}
+	if isCask {
+		args = append(args, "--cask")
+	}
+	args = append(args, name)
+
+	cmd := b.ExecCommand("brew", args...)
+
+	// brew list writes the package contents to stdout; we only need the exit
+	// code, so we discard output but still must not let a missing binary slip
+	// past as "not installed".
+	err := cmd.Run()
+	if err == nil {
+		return true, name, nil
+	}
+
+	// Distinguish "brew not found" from "package not found".
+	var execErr *exec.Error
+	if errors.As(err, &execErr) && execErr.Err == exec.ErrNotFound {
+		return false, "", ErrBrewNotAvailable
+	}
+
+	// Any non-zero exit code from brew means the package is not listed.
+	return false, "", nil
+}
+
+// DetectBatch checks multiple refs by parsing `brew list --versions` (formulae)
+// and `brew list --cask --versions` (casks). It runs at most two brew processes
+// total regardless of ref count (one per kind that appears in refs), each
+// parsed into name→version, then matches each ref against the right map.
+//
+// ASSUMPTION (see brew.go header #2): `brew list --versions` prints one package
+// per line as "<name> <version> [<version> ...]"; the first token is the name,
+// the second (if any) is the version we capture.
+func (b *BrewDriver) DetectBatch(refs []string) (map[string]driver.DetectResult, error) {
+	// Determine which kinds we actually need to query.
+	needFormula, needCask := false, false
+	for _, ref := range refs {
+		if _, isCask := parseRef(ref); isCask {
+			needCask = true
+		} else {
+			needFormula = true
+		}
+	}
+
+	var formulaVersions, caskVersions map[string]string
+
+	if needFormula {
+		m, err := b.listVersions(false)
+		if err != nil {
+			return nil, err
+		}
+		formulaVersions = m
+	}
+	if needCask {
+		m, err := b.listVersions(true)
+		if err != nil {
+			return nil, err
+		}
+		caskVersions = m
+	}
+
+	results := make(map[string]driver.DetectResult, len(refs))
+	for _, ref := range refs {
+		name, isCask := parseRef(ref)
+		versions := formulaVersions
+		if isCask {
+			versions = caskVersions
+		}
+		version, found := versions[strings.ToLower(name)]
+		results[ref] = driver.DetectResult{
+			Installed:   found,
+			DisplayName: name,
+			Version:     version,
+		}
+	}
+	return results, nil
+}
+
+// listVersions runs `brew list --versions` (or with `--cask`) and parses the
+// output into a case-insensitive name→version map. A missing brew binary
+// surfaces as ErrBrewNotAvailable; a non-zero exit with output is still parsed
+// best-effort (brew may exit non-zero yet emit a usable list), and an empty map
+// is returned when nothing parses.
+func (b *BrewDriver) listVersions(cask bool) (map[string]string, error) {
+	args := []string{"list", "--versions"}
+	if cask {
+		// `brew list --cask --versions` — kind flag before the query flag,
+		// matching the install/detect ordering.
+		args = []string{"list", "--cask", "--versions"}
+	}
+
+	cmd := b.ExecCommand("brew", args...)
+
+	var stdout strings.Builder
+	cmd.Stdout = &stdout
+
+	err := cmd.Run()
+	if err != nil {
+		var execErr *exec.Error
+		if errors.As(err, &execErr) && execErr.Err == exec.ErrNotFound {
+			return nil, ErrBrewNotAvailable
+		}
+		// Non-zero exit (not a missing binary): parse whatever was emitted.
+	}
+
+	return parseVersions(stdout.String()), nil
+}
+
+// parseVersions parses `brew list --versions` output into a case-insensitive
+// name→version map. Each non-empty line is split on whitespace: token[0] is the
+// package name, token[1] (if present) is the version. A name-only line is
+// recorded with an empty version (still "installed"). Defensive: blank lines and
+// all-whitespace lines are skipped.
+func parseVersions(output string) map[string]string {
+	out := make(map[string]string)
+	for _, raw := range strings.Split(output, "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" {
+			continue
+		}
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		name := fields[0]
+		version := ""
+		if len(fields) > 1 {
+			version = fields[1]
+		}
+		out[strings.ToLower(name)] = version
+	}
+	return out
+}

--- a/go-engine/internal/driver/brew/detect_test.go
+++ b/go-engine/internal/driver/brew/detect_test.go
@@ -1,0 +1,171 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package brew
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// parseVersions (pure parser for `brew list --versions` output)
+// ---------------------------------------------------------------------------
+
+func TestParseVersions_SinglePackage(t *testing.T) {
+	got := parseVersions("node 20.11.0\n")
+	if v, ok := got["node"]; !ok || v != "20.11.0" {
+		t.Errorf("expected node→20.11.0, got %+v", got)
+	}
+}
+
+func TestParseVersions_MultiplePackages(t *testing.T) {
+	output := "node 20.11.0\nripgrep 14.1.0\npython@3.11 3.11.7\n"
+	got := parseVersions(output)
+	want := map[string]string{
+		"node":       "20.11.0",
+		"ripgrep":    "14.1.0",
+		"python@3.11": "3.11.7",
+	}
+	for name, ver := range want {
+		if got[name] != ver {
+			t.Errorf("expected %s→%s, got %q (full=%+v)", name, ver, got[name], got)
+		}
+	}
+}
+
+func TestParseVersions_MultipleVersionsTakesFirst(t *testing.T) {
+	// brew can list several installed versions on one line; we capture the first.
+	got := parseVersions("openssl@3 3.2.1 3.2.0\n")
+	if got["openssl@3"] != "3.2.1" {
+		t.Errorf("expected first version 3.2.1, got %q", got["openssl@3"])
+	}
+}
+
+func TestParseVersions_NameOnlyLine(t *testing.T) {
+	// A name with no version is still "installed" (empty version).
+	got := parseVersions("somepkg\n")
+	v, ok := got["somepkg"]
+	if !ok || v != "" {
+		t.Errorf("expected somepkg present with empty version, got %q (ok=%v)", v, ok)
+	}
+}
+
+func TestParseVersions_BlankAndWhitespaceLines(t *testing.T) {
+	got := parseVersions("\n  \nnode 20.11.0\n\n")
+	if len(got) != 1 || got["node"] != "20.11.0" {
+		t.Errorf("expected only node→20.11.0, got %+v", got)
+	}
+}
+
+func TestParseVersions_Empty(t *testing.T) {
+	if got := parseVersions(""); len(got) != 0 {
+		t.Errorf("expected empty map, got %+v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DetectBatch
+// ---------------------------------------------------------------------------
+
+func TestDetectBatch_FormulaeVersionsAndMisses(t *testing.T) {
+	var calls [][]string
+	d := &BrewDriver{ExecCommand: scriptedCommand(map[string]scriptedResponse{
+		"list": {exitCode: 0, stdout: "node 20.11.0\nripgrep 14.1.0\n"},
+	}, &calls)}
+
+	results, err := d.DetectBatch([]string{"node", "ripgrep", "not-installed"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r := results["node"]; !r.Installed || r.Version != "20.11.0" || r.DisplayName != "node" {
+		t.Errorf("node result = %+v, want installed 20.11.0", r)
+	}
+	if r := results["ripgrep"]; !r.Installed || r.Version != "14.1.0" {
+		t.Errorf("ripgrep result = %+v, want installed 14.1.0", r)
+	}
+	if r := results["not-installed"]; r.Installed || r.Version != "" {
+		t.Errorf("not-installed result = %+v, want absent with no version", r)
+	}
+
+	// Only one `brew list --versions` (formula) call — no --cask call when no
+	// cask refs are present.
+	listVersionCalls := 0
+	for _, c := range calls {
+		joined := strings.Join(c, " ")
+		if strings.Contains(joined, "list --versions") || strings.Contains(joined, "list --cask --versions") {
+			listVersionCalls++
+		}
+		if strings.Contains(joined, "--cask") {
+			t.Errorf("no cask refs present, must not query --cask: %v", calls)
+		}
+	}
+	if listVersionCalls != 1 {
+		t.Errorf("expected exactly one list --versions call, got %d (%v)", listVersionCalls, calls)
+	}
+}
+
+func TestDetectBatch_CaskVersions(t *testing.T) {
+	var calls [][]string
+	d := &BrewDriver{ExecCommand: scriptedCommand(map[string]scriptedResponse{
+		// args[0] is "list" for both formula and cask version listings; the
+		// scriptedCommand keys on args[0], so both share this response. We supply
+		// cask-shaped output and assert the --cask flag was passed.
+		"list": {exitCode: 0, stdout: "firefox 122.0\n"},
+	}, &calls)}
+
+	results, err := d.DetectBatch([]string{"cask:firefox", "cask:not-a-cask"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r := results["cask:firefox"]; !r.Installed || r.Version != "122.0" || r.DisplayName != "firefox" {
+		t.Errorf("firefox cask result = %+v, want installed 122.0", r)
+	}
+	if r := results["cask:not-a-cask"]; r.Installed {
+		t.Errorf("absent cask should be Installed=false: %+v", r)
+	}
+	// The cask version listing must pass --cask.
+	sawCaskList := false
+	for _, c := range calls {
+		if strings.Contains(strings.Join(c, " "), "list --cask --versions") {
+			sawCaskList = true
+		}
+	}
+	if !sawCaskList {
+		t.Errorf("expected a `brew list --cask --versions` call: %v", calls)
+	}
+}
+
+func TestDetectBatch_MixedFormulaAndCask(t *testing.T) {
+	var calls [][]string
+	// Both formula and cask listings key on "list"; supply a superset of output
+	// (both maps get the same parse, but each ref reads from the right kind).
+	d := &BrewDriver{ExecCommand: scriptedCommand(map[string]scriptedResponse{
+		"list": {exitCode: 0, stdout: "node 20.11.0\nfirefox 122.0\n"},
+	}, &calls)}
+
+	results, err := d.DetectBatch([]string{"node", "cask:firefox"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r := results["node"]; !r.Installed || r.Version != "20.11.0" {
+		t.Errorf("node = %+v, want installed 20.11.0", r)
+	}
+	if r := results["cask:firefox"]; !r.Installed || r.Version != "122.0" {
+		t.Errorf("firefox cask = %+v, want installed 122.0", r)
+	}
+	// Two listing calls: one formula, one cask.
+	formula, cask := false, false
+	for _, c := range calls {
+		joined := strings.Join(c, " ")
+		if joined == "brew list --versions" {
+			formula = true
+		}
+		if joined == "brew list --cask --versions" {
+			cask = true
+		}
+	}
+	if !formula || !cask {
+		t.Errorf("expected both formula and cask version listings; calls=%v", calls)
+	}
+}

--- a/go-engine/internal/driver/brew/install_version.go
+++ b/go-engine/internal/driver/brew/install_version.go
@@ -1,0 +1,38 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package brew
+
+import "github.com/Artexis10/endstate/go-engine/internal/driver"
+
+// compile-time assertion: the brew driver implements the optional
+// VersionedInstaller capability, so the apply path can discover version-pinning
+// eligibility by type-assertion — exactly as it does for winget.
+var _ driver.VersionedInstaller = (*BrewDriver)(nil)
+
+// InstallVersion installs ref, honoring a version in the WEAK / advisory sense.
+//
+// Homebrew is fundamentally a rolling, latest-only package manager: it has no
+// general `--version <v>` flag and cannot install an arbitrary historical
+// version of a formula. The ONLY supported pinning mechanism is a
+// versioned-formula ref (e.g. "node@20", "python@3.11"), where the version is
+// encoded in the package NAME and selected as a distinct formula. Such a ref
+// flows through unchanged (parseRef keeps the "@version" suffix on the name).
+//
+// For a bare ref with a separately-declared version, the version is ADVISORY:
+// we install the latest and record the requested version in the message rather
+// than attempting an unsupported downgrade. We deliberately do NOT try to force
+// an arbitrary version — that is the documented weakness of this backend versus
+// winget's true `--version` pinning. A real-macOS smoke (later increment) should
+// confirm versioned-formula refs install the expected major version.
+func (b *BrewDriver) InstallVersion(ref, version string) (*driver.InstallResult, error) {
+	return b.install(ref, version, false)
+}
+
+// ReinstallVersion force-reinstalls ref (skipping the detect-before-install
+// short-circuit) via `brew install --force`. It is the convergence step of
+// `apply --repin`; like InstallVersion, the version is honored only weakly
+// (versioned-formula ref) — brew cannot force an arbitrary historical version.
+func (b *BrewDriver) ReinstallVersion(ref, version string) (*driver.InstallResult, error) {
+	return b.install(ref, version, true)
+}

--- a/go-engine/internal/driver/brew/install_version_test.go
+++ b/go-engine/internal/driver/brew/install_version_test.go
@@ -1,0 +1,142 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package brew
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/driver"
+)
+
+// InstallVersion honors a versioned-formula ref (e.g. "node@20") by passing the
+// version-bearing NAME through to brew unchanged — brew has no general
+// `--version` flag, so the name IS the version selector.
+func TestInstallVersion_VersionedFormulaRefPassthrough(t *testing.T) {
+	var calls [][]string
+	d := &BrewDriver{ExecCommand: scriptedCommand(map[string]scriptedResponse{
+		"list":    {exitCode: 1}, // absent → proceed to install
+		"install": {exitCode: 0},
+	}, &calls)}
+
+	res, err := d.InstallVersion("node@20", "20")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != driver.StatusInstalled {
+		t.Fatalf("Status = %q, want installed", res.Status)
+	}
+	// The versioned-formula token must reach brew install verbatim.
+	sawTarget := false
+	for _, c := range calls {
+		if len(c) > 1 && c[1] == "install" && strings.Contains(strings.Join(c, " "), "node@20") {
+			sawTarget = true
+		}
+		// brew has no --version flag; we must never emit one.
+		if strings.Contains(strings.Join(c, " "), "--version") {
+			t.Fatalf("brew install must not pass --version (unsupported): %v", c)
+		}
+	}
+	if !sawTarget {
+		t.Fatalf("expected `brew install node@20`; calls=%v", calls)
+	}
+}
+
+// A bare ref with a separately-declared version installs latest; the version is
+// advisory and surfaced in the message, NOT passed as an unsupported flag.
+func TestInstallVersion_BareRefVersionIsAdvisory(t *testing.T) {
+	var calls [][]string
+	d := &BrewDriver{ExecCommand: scriptedCommand(map[string]scriptedResponse{
+		"list":    {exitCode: 1},
+		"install": {exitCode: 0},
+	}, &calls)}
+
+	res, err := d.InstallVersion("ripgrep", "14.1.0")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != driver.StatusInstalled {
+		t.Fatalf("Status = %q, want installed", res.Status)
+	}
+	if !strings.Contains(res.Message, "14.1.0") || !strings.Contains(res.Message, "advisory") {
+		t.Fatalf("advisory-version message should surface the requested version and weakness: %q", res.Message)
+	}
+	for _, c := range calls {
+		if strings.Contains(strings.Join(c, " "), "--version") {
+			t.Fatalf("must not pass --version: %v", c)
+		}
+	}
+}
+
+// The plain Install path keeps its historical success message and passes no
+// version anywhere (regression guard for the shared-impl refactor).
+func TestInstall_Unpinned_PlainMessage(t *testing.T) {
+	d := &BrewDriver{ExecCommand: scriptedCommand(map[string]scriptedResponse{
+		"list":    {exitCode: 1},
+		"install": {exitCode: 0},
+	}, nil)}
+
+	res, err := d.Install("ripgrep")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Message != "Installed successfully" {
+		t.Fatalf("unpinned success message changed: %q", res.Message)
+	}
+}
+
+// ReinstallVersion skips the detect-before-install short-circuit and passes
+// --force, so an already-present (drifted) package is reinstalled rather than
+// reported as already installed.
+func TestReinstallVersion_ForcesAndSkipsShortCircuit(t *testing.T) {
+	var calls [][]string
+	d := &BrewDriver{ExecCommand: scriptedCommand(map[string]scriptedResponse{
+		"list":    {exitCode: 0}, // present — Install would short-circuit, Reinstall must NOT
+		"install": {exitCode: 0},
+	}, &calls)}
+
+	res, err := d.ReinstallVersion("node@20", "20")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != driver.StatusInstalled {
+		t.Fatalf("Status = %q, want installed (reinstall must run despite present)", res.Status)
+	}
+	forced, sawInstall := false, false
+	for _, c := range calls {
+		joined := strings.Join(c, " ")
+		if len(c) > 1 && c[1] == "install" {
+			sawInstall = true
+			if strings.Contains(joined, "--force") {
+				forced = true
+			}
+		}
+	}
+	if !sawInstall {
+		t.Fatalf("ReinstallVersion must spawn `brew install` even when present: %v", calls)
+	}
+	if !forced {
+		t.Fatalf("ReinstallVersion must pass --force: %v", calls)
+	}
+}
+
+// A failed install via InstallVersion classifies as failed/install_failed and
+// surfaces the requested version in the message.
+func TestInstallVersion_FailureSurfacesVersion(t *testing.T) {
+	d := &BrewDriver{ExecCommand: scriptedCommand(map[string]scriptedResponse{
+		"list":    {exitCode: 1},
+		"install": {exitCode: 1, stderr: "Error: No available formula"},
+	}, nil)}
+
+	res, err := d.InstallVersion("ripgrep", "9.9.9")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Status != driver.StatusFailed || res.Reason != driver.ReasonInstallFailed {
+		t.Fatalf("want failed/install_failed, got %q/%q", res.Status, res.Reason)
+	}
+	if !strings.Contains(res.Message, "9.9.9") {
+		t.Fatalf("failure message should surface the requested version: %q", res.Message)
+	}
+}

--- a/go-engine/internal/driver/brew/uninstall.go
+++ b/go-engine/internal/driver/brew/uninstall.go
@@ -1,0 +1,105 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package brew
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os/exec"
+	"regexp"
+
+	"github.com/Artexis10/endstate/go-engine/internal/driver"
+)
+
+// compile-time assertion: the brew driver implements driver.Uninstaller, so the
+// rollback command can discover best-effort rollback by type-assertion.
+var _ driver.Uninstaller = (*BrewDriver)(nil)
+
+// noPackageFoundPattern matches brew output indicating nothing matched the
+// uninstall request. ASSUMPTION (see brew.go header #4): `brew uninstall` of an
+// absent package exits non-zero with one of these substrings; this output match
+// is the primary "absent" signal because the exit code alone is ambiguous (any
+// failure is non-zero). The phrasings below are assumed and MUST be confirmed on
+// real macOS.
+var noPackageFoundPattern = regexp.MustCompile(`(?i)(no such keg|not installed|no available formula|no installed keg|no cask(s)? found|is not installed)`)
+
+// Uninstall removes the package identified by ref via brew, satisfying
+// driver.Uninstaller. It is NON-DESTRUCTIVE: it never passes `--zap` (which
+// would also remove app data/config), honoring Endstate's non-destructive
+// defaults.
+//
+// The command spawned is:
+//
+//	brew uninstall <name>            (formula)
+//	brew uninstall --cask <name>     (cask)
+//
+// Exit/output semantics:
+//   - 0                                    → StatusUninstalled
+//   - already-absent output substring      → StatusAbsent (no-op)
+//   - other non-zero                       → StatusFailed
+//
+// If the brew binary is not found, Uninstall returns (nil, ErrBrewNotAvailable).
+func (b *BrewDriver) Uninstall(ref string) (*driver.UninstallResult, error) {
+	name, isCask := parseRef(ref)
+
+	args := []string{"uninstall"}
+	if isCask {
+		args = append(args, "--cask")
+	}
+	args = append(args, name)
+
+	cmd := b.ExecCommand("brew", args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	runErr := cmd.Run()
+
+	// Detect missing binary before inspecting exit code.
+	if runErr != nil {
+		var execErr *exec.Error
+		if errors.As(runErr, &execErr) && execErr.Err == exec.ErrNotFound {
+			return nil, ErrBrewNotAvailable
+		}
+	}
+
+	combined := stdout.String() + stderr.String()
+
+	exitCode := 0
+	if runErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			// Process did not exit normally (e.g. killed); treat as failure.
+			return &driver.UninstallResult{
+				Status:  driver.StatusFailed,
+				Message: fmt.Sprintf("brew did not exit normally: %v", runErr),
+			}, nil
+		}
+	}
+
+	switch {
+	case exitCode == 0:
+		return &driver.UninstallResult{
+			Status:  driver.StatusUninstalled,
+			Message: "Uninstalled successfully",
+		}, nil
+
+	case noPackageFoundPattern.MatchString(combined):
+		// Already not installed — a successful no-op for rollback idempotency.
+		return &driver.UninstallResult{
+			Status:  driver.StatusAbsent,
+			Message: "Package was not installed",
+		}, nil
+
+	default:
+		return &driver.UninstallResult{
+			Status:  driver.StatusFailed,
+			Message: fmt.Sprintf("brew exited with code %d", exitCode),
+		}, nil
+	}
+}

--- a/go-engine/internal/driver/brew/uninstall_test.go
+++ b/go-engine/internal/driver/brew/uninstall_test.go
@@ -1,0 +1,103 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package brew
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/driver"
+)
+
+func TestUninstall_FormulaRemoved(t *testing.T) {
+	var calls [][]string
+	d := &BrewDriver{ExecCommand: scriptedCommand(map[string]scriptedResponse{
+		"uninstall": {exitCode: 0, stdout: "Uninstalling /opt/homebrew/Cellar/ripgrep/14.1.0... (12 files)"},
+	}, &calls)}
+
+	res, err := d.Uninstall("ripgrep")
+	if err != nil {
+		t.Fatalf("Uninstall returned unexpected error: %v", err)
+	}
+	if res.Status != driver.StatusUninstalled {
+		t.Errorf("Status = %q, want %q", res.Status, driver.StatusUninstalled)
+	}
+	joined := strings.Join(calls[0], " ")
+	if !strings.Contains(joined, "uninstall ripgrep") {
+		t.Errorf("unexpected brew argv: %q", joined)
+	}
+	// Non-destructive: must never pass --zap.
+	if strings.Contains(joined, "--zap") {
+		t.Errorf("Uninstall must NEVER pass --zap (non-destructive): %q", joined)
+	}
+}
+
+func TestUninstall_CaskRemoved(t *testing.T) {
+	var calls [][]string
+	d := &BrewDriver{ExecCommand: scriptedCommand(map[string]scriptedResponse{
+		"uninstall": {exitCode: 0, stdout: "Uninstalling Cask firefox..."},
+	}, &calls)}
+
+	res, err := d.Uninstall("cask:firefox")
+	if err != nil {
+		t.Fatalf("Uninstall returned unexpected error: %v", err)
+	}
+	if res.Status != driver.StatusUninstalled {
+		t.Errorf("Status = %q, want %q", res.Status, driver.StatusUninstalled)
+	}
+	joined := strings.Join(calls[0], " ")
+	if !strings.Contains(joined, "uninstall --cask firefox") {
+		t.Errorf("cask uninstall must pass --cask: %q", joined)
+	}
+	if strings.Contains(joined, "--zap") {
+		t.Errorf("Uninstall must NEVER pass --zap (non-destructive): %q", joined)
+	}
+}
+
+func TestUninstall_AlreadyAbsentViaOutput(t *testing.T) {
+	// ASSUMPTION: brew uninstall of an absent formula exits non-zero with a
+	// "No such keg" style message; the output substring is the absent signal.
+	d := &BrewDriver{ExecCommand: fakeCommand(1, "", "Error: No such keg: /opt/homebrew/Cellar/ripgrep")}
+	res, err := d.Uninstall("ripgrep")
+	if err != nil {
+		t.Fatalf("Uninstall returned unexpected error: %v", err)
+	}
+	if res.Status != driver.StatusAbsent {
+		t.Errorf("Status = %q, want %q (already-absent is a no-op)", res.Status, driver.StatusAbsent)
+	}
+}
+
+func TestUninstall_AlreadyAbsentCaskViaOutput(t *testing.T) {
+	d := &BrewDriver{ExecCommand: fakeCommand(1, "", "Error: Cask 'firefox' is not installed.")}
+	res, err := d.Uninstall("cask:firefox")
+	if err != nil {
+		t.Fatalf("Uninstall returned unexpected error: %v", err)
+	}
+	if res.Status != driver.StatusAbsent {
+		t.Errorf("Status = %q, want %q", res.Status, driver.StatusAbsent)
+	}
+}
+
+func TestUninstall_Failed(t *testing.T) {
+	// Non-zero exit with NO already-absent substring → a genuine failure.
+	d := &BrewDriver{ExecCommand: fakeCommand(1, "", "Error: Refusing to uninstall because it is required by other formulae")}
+	res, err := d.Uninstall("openssl")
+	if err != nil {
+		t.Fatalf("Uninstall returned unexpected error: %v", err)
+	}
+	if res.Status != driver.StatusFailed {
+		t.Errorf("Status = %q, want %q", res.Status, driver.StatusFailed)
+	}
+}
+
+func TestUninstall_MissingBinary(t *testing.T) {
+	d := &BrewDriver{ExecCommand: func(name string, args ...string) *exec.Cmd {
+		return exec.Command("endstate-no-such-brew-binary-xyz")
+	}}
+	_, err := d.Uninstall("ripgrep")
+	if err != ErrBrewNotAvailable {
+		t.Fatalf("expected ErrBrewNotAvailable, got %v", err)
+	}
+}


### PR DESCRIPTION
## What — brew driver, increment 1 (foundational package)

A new `internal/driver/brew` package: a macOS Homebrew adapter implementing `driver.Driver` and its optional interfaces, **mirroring `internal/driver/winget`**.

- `Detect` / `Install` (formula + cask), `Uninstaller` (non-destructive, never `--zap`), `BatchDetector` (`brew list --versions` parsing), `VersionedInstaller` (weak/advisory — brew has no general `--version`), `CapabilityReporter` (best-effort: no atomic set / native rollback).
- **`cask:` ref scheme** — a leading `cask:` marks a Cask (`--cask`); a bare ref is a formula.
- Injectable command runner (winget's helper-process shim pattern) so all tests are hermetic — no real `brew`.

## Scope — deliberately narrow

**This increment is the package + hermetic tests only.** No pipeline wiring: no `select.go`, `apply.go`, `capture.go`, `verify.go`, `plan.go`, `.github/workflows/`, or OpenSpec change touched. An unwired package ships **no observable behavior** and has **zero blast radius**. The darwin two-lane routing + the real-brew macOS-CI smoke is the next increment (scoped by the merged `macos-brew-driver` design).

## Real-output anchors are ASSUMPTIONS (the winget lesson)

Written on Linux with no macOS/brew available, so every brew exit-code/output format is an assumption documented in a top-of-file comment block and pinned by the hermetic tests (detect exit codes, `brew list --versions` columns, already-installed/absent detection, cask vs formula). These **must be confirmed on real macOS** in the wiring increment before the driver is trusted.

## Verification

`go test ./...`, `go vet ./...`, `GOOS=windows go build ./...`, `GOOS=darwin go build ./...` — all green. Scope is exactly the 10 files under `internal/driver/brew/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
