### PR TITLE
docs(openspec): scope engine-installed backends — invisible Nix/Homebrew bootstrap (design only)

### DIFF
--- a/openspec/changes/engine-backend-bootstrap/.openspec.yaml
+++ b/openspec/changes/engine-backend-bootstrap/.openspec.yaml
@@ -1,0 +1,10 @@
+id: engine-backend-bootstrap
+title: "Scope engine-installed backends — invisible Nix/Homebrew bootstrap (design only)"
+status: exploring
+spec: engine-backend-bootstrap
+created: "2026-06-04"
+author: Hugo Ander Kivi
+artifacts:
+  - proposal.md
+  - design.md
+  - tasks.md

--- a/openspec/changes/engine-backend-bootstrap/design.md
+++ b/openspec/changes/engine-backend-bootstrap/design.md
@@ -1,0 +1,181 @@
+## Context
+
+- **Windows gets backends for free; Unix does not.** `winget` ships with Windows, so on Windows the
+  package backend is always present. On macOS/Linux Endstate's backends are **not** preinstalled: the
+  **Nix realizer** (`selectRealizer("linux"|"darwin") → nix.New()`) needs a Nix installation, and the
+  **Homebrew driver** (scoped in `macos-brew-driver`) needs `brew` on `PATH`. A missing backend is a
+  hard stop today: `nix.New()`/the realizer surface `REALIZER_UNAVAILABLE`; a brew driver would fail
+  identically when `brew` is absent.
+- **The audience makes "install it for me" load-bearing.** Endstate targets **non-technical users
+  first**. "Rebuild my Mac/Linux box" must not require the user to first install a package manager they
+  have never heard of. The backend must be **set up by the engine**, invisibly at the concept level.
+- **Invisible ≠ unconsented.** The governing principle is **invisible but inspectable**: hide the
+  *concepts* (the user never learns "Nix"/"Homebrew"), never the *consent*. macOS enforces this: the
+  Homebrew installer triggers an Xcode Command Line Tools install and a sudo password prompt; the
+  Determinate Nix installer is a privileged multi-user system change. Those prompts cannot and must not
+  be suppressed. So the only honest model is **one plain-language consent**, then the official
+  installer, then verify.
+- **The brew design already did the brew half.** `macos-brew-driver` §8 + its Requirement "Homebrew is
+  bootstrapped when absent, with consent" sketch the Homebrew bootstrap. It explicitly flags that the
+  Nix half is **broader** (root/daemon, a macOS volume, the uninstall-the-backend question) and is
+  "scoped separately." **This change is that separate scope** — generalized into one capability so the
+  two bootstraps share a contract instead of drifting into two ad-hoc flows.
+
+## Goals / Non-Goals
+
+**Goals (of the eventual feature this scopes):**
+
+- One backend-agnostic bootstrap contract — *detect → consent → official install → verify →
+  proceed-or-decline* — that both the Nix realizer and the Homebrew driver satisfy.
+- Turn today's "backend absent → hard stop" into "backend absent → offer to set it up," without ever
+  installing a backend silently or leaving an apply half-done.
+- Capture the **Nix-specific** footprint (multi-user daemon, macOS APFS volume, root, the
+  uninstall-the-backend question) the brew §8 sketch does not cover.
+- Keep the privileged step explicit, consented, inspectable, and consistent with Endstate's
+  non-destructive / no-silent-mutation posture.
+
+**Non-Goals:**
+
+- No implementation in this change. No Go, no `internal/bootstrap/` package, no `select.go`/`apply.go`
+  edit, no installer is run.
+- Not re-specifying the Homebrew-specific bootstrap — that requirement stays in `macos-brew-driver` §8
+  and graduates from there. This capability provides the **shared contract** it is one instance of.
+- Not selecting the final installer flags, the exact consent UX, or whether the engine ever offers to
+  *uninstall* a backend — those are the human's decisions (see Open Questions).
+- Not a Windows concern — winget ships with the OS; the only Windows angle is asserting "no bootstrap
+  needed."
+
+---
+
+## 1. The unified contract — five states, both backends
+
+The bootstrap is one small state machine, identical in shape for Nix and Homebrew, differing only in
+the *detect* probe, the *installer* invoked, and the *verify* probe:
+
+| State | Nix realizer | Homebrew driver | Behavior |
+|---|---|---|---|
+| **Detect** | working `nix` (daemon + store) | working `brew` (on `PATH` / at prefix) | present+working → **no-op, no prompt** |
+| **Consent** | "Endstate needs to set up its installer; macOS will ask for your password" | same plain-language ask | **one** prompt; the *concept* is hidden, the consent is not |
+| **Install** | **Determinate Nix installer** | upstream Homebrew `install.sh` | the **official** installer, orchestrated (not vendored), inspectable |
+| **Verify** | a Nix eval / `nix --version` + store reachable | `brew --version` | must pass **before** any package work; fail → backend unavailable |
+| **Decline / fail** | skip the realizer lane | skip the brew lane | clear message; **the rest of the run continues**; never half-done |
+
+The load-bearing rules:
+
+1. **Present → silent no-op.** A working backend never prompts and never re-installs.
+2. **Absent → exactly one consent, then the official installer.** Never silent. The prompt is plain
+   language and names no backend product.
+3. **Verify gates use.** A backend that installs but fails its verify probe is treated as
+   **unavailable**, not used half-configured. (Mirrors the engine's verification-first invariant:
+   observable working state is success, not "the installer exited 0".)
+4. **Decline/failure is graceful, not fatal.** The affected lane is skipped with a clear message; other
+   lanes (and config) still run. A failed bootstrap surfaces a clear error and never proceeds "as if"
+   the backend were present.
+
+## 2. Where it runs in the pipeline
+
+`apply`/`capture`/`verify`/`plan` call `newRealizerFn()` (and, per the brew design, a brew-driver
+factory) and treat "absent" as a hard error. The bootstrap is a **pre-step in front of that gate**: for
+each backend a lane needs, *detect → (consent → install → verify)* runs **before** the factory would
+hard-fail. A present backend makes the pre-step a no-op (today's fast path, unchanged). A declined or
+failed bootstrap removes that lane and the run continues with whatever lanes remain — so a Mac with no
+Nix but consented Homebrew still installs the brew apps, and a user who declines everything gets a
+clear "nothing to do, these lanes were skipped" rather than a crash.
+
+This composes with the brew two-lane design: the brew lane's bootstrap and the realizer lane's
+bootstrap are independent pre-steps, each gating only its own lane.
+
+## 3. The Nix half — why it is heavier than brew
+
+The brew §8 sketch is correct but light because Homebrew's install is comparatively contained (a
+user-owned prefix, `install.sh`, the unavoidable Xcode-CLT + sudo prompts). **Nix is a bigger system
+change**, and that is the substance this capability adds:
+
+- **Multi-user / daemon.** The standard (and Determinate) Nix install is a **multi-user** install:
+  it creates the `/nix` store, a build-user group, and a **daemon** (launchd on macOS, systemd on
+  Linux). This is root-level and persistent — heavier than a per-user `~/.brew`.
+- **macOS APFS Nix Store volume.** On modern macOS the installer creates a **dedicated APFS volume**
+  for `/nix` (because the root filesystem is read-only/sealed). That is a real disk-level artifact a
+  user should be told about in plain language, and it bears on the uninstall question.
+- **Root + the unsuppressable prompts.** Like brew's sudo/Xcode-CLT prompts, the Nix install needs
+  elevated privilege; the engine surfaces one plain-language consent and lets the OS own the
+  credential prompt.
+- **The uninstall-the-backend question.** Because the Nix install is a persistent, root-level, possibly
+  volume-creating change, "Endstate installed Nix for me — does Endstate remove it?" is a real
+  question. **Recommendation:** the engine does **not** silently uninstall a backend it installed.
+  Uninstalling a backend is a **separate, explicit, user-owned action** (the Determinate installer ships
+  its own uninstaller; the engine may at most *point at it*), consistent with non-destructive defaults
+  and no-silent-deletion. Whether the engine offers an *assisted* uninstall at all is an Open Question.
+- **Determinate installer as the vehicle.** The repo already standardizes on the **Determinate Nix
+  installer** in CI (`nix-integration.yml`). Reusing it for the user-facing bootstrap means the same,
+  well-supported, flake-enabled install path the engine is already validated against — not a bespoke
+  install script.
+
+## 4. The brew half — owned by `macos-brew-driver`, referenced here
+
+The Homebrew-specific bootstrap requirement ("absent → consent → official `install.sh` → verify →
+graceful decline; present → no-op") is already sketched in `macos-brew-driver` §8. This capability does
+**not** restate it as a brew-specific requirement; instead its backend-agnostic requirements (§1) are
+written so the brew bootstrap is one **instance** of the contract. On graduation, the brew-specific
+requirement graduates from `macos-brew-driver`; the shared contract graduates from here. This keeps the
+two changes composable under `openspec validate --all --strict` (distinct capabilities, distinct
+requirement names) without forking the brew story.
+
+## 5. Consent UX and the CLI-source-of-truth boundary
+
+The **CLI is the source of truth**; the **GUI is the presentation layer**, and the primary audience
+runs the GUI. So the bootstrap's consent should be an **engine-emitted, streamed consent request** that
+the GUI renders as a plain-language dialog ("Endstate needs to set up its installer — this is safe;
+your Mac will ask for your password"), with the engine proceeding only on an explicit affirmative. For
+the CLI, the same consent is an interactive prompt (or an explicit `--bootstrap-backends` /
+`--no-bootstrap` flag for non-interactive/CI use). The exact UX (one combined consent vs per-backend,
+flag names, default in non-interactive mode) is an Open Question; the **invariant** this capability
+fixes is only that consent is explicit, plain-language, and names no backend product.
+
+## 6. The CI-test wrinkle (recorded, not solved here)
+
+The eventual implementation cannot fully validate the **install** path on the existing macOS CI runner:
+the GH `macos-latest` runner has **Homebrew preinstalled** and (via the Determinate action) **Nix
+preinstalled** in the smoke job. So in CI the bootstrap can only exercise **detect → present → no-op**.
+The *absent → consent → install → verify* path must be validated on a **clean real machine** (or a
+throwaway VM image without the backend), out of band from the path-filtered macOS smoke. This is a
+known limitation of the existing CI vehicle, recorded so the implementation does not over-claim CI
+coverage of the install path (the winget/real-output lesson, applied to installers).
+
+## Open Questions (for the human)
+
+1. **Phase / sequencing.** Does the bootstrap land **with** the brew increment (so "rebuild my Mac with
+   zero prerequisites" is true on day one) or as a **fast-follow** after the brew install/capture lanes
+   are proven? (The brew design's Open Question 7 asks the same for the brew half.)
+2. **One consent or per-backend.** On a Mac needing **both** Nix (for config) and Homebrew (for apps),
+   is it **one** combined consent ("set up Endstate's installers") or **two** (one per backend)? One is
+   gentler for the audience; two is more honest about two distinct system changes.
+3. **Non-interactive default.** In a non-interactive/CI context with no TTY, is the default to **skip**
+   the bootstrap (and the lane) or to **fail loudly**? Recommend: skip-with-clear-message by default,
+   `--bootstrap-backends` to opt in, `--no-bootstrap` to force skip.
+4. **Assisted uninstall.** Should the engine ever offer to **uninstall** a backend it installed (via the
+   official uninstaller), or only ever *point at* the uninstaller? Recommend: never silently uninstall;
+   at most surface the official uninstaller. Confirm.
+5. **Nix install flavor.** Confirm the **Determinate** installer (matches CI, flake-enabled,
+   well-supported) over upstream `nix-installer` / a single-user install. Multi-user is heavier but is
+   the supported default; is a single-user/no-daemon option ever wanted (e.g. locked-down corp Macs)?
+6. **macOS volume disclosure.** How much of the APFS Nix Store volume / daemon footprint must the
+   plain-language consent disclose to stay honest without overwhelming a non-technical user?
+
+## Risks / Verification (of the eventual feature)
+
+- **Unsuppressable, environment-specific prompts** — Xcode-CLT, sudo, macOS volume creation, MDM/corp
+  policy blocks. The bootstrap must surface these as plain-language states, never reason them away;
+  failure is a clear error, not a half-done apply.
+- **Install-path is under-covered by CI** (§6) — the macOS runner has the backends preinstalled, so the
+  install path is validated only on clean real machines. Mitigation: hermetic tests of the
+  detect/consent/verify orchestration (fake `ExecCommand`), plus a manual/real-machine install run
+  before any claim of correctness.
+- **Privileged, persistent system change** — a multi-user Nix daemon + APFS volume is not trivially
+  reversible. Mitigation: explicit consent, official installer only, no silent uninstall, and clear
+  disclosure of what is being changed.
+- **Partial-bootstrap leaving a confusing state** — installer exits non-zero midway. Mitigation: the
+  verify gate (§1 rule 3) — a backend that does not pass verify is treated as unavailable, and the lane
+  is skipped with a clear error rather than used half-configured.
+- These are verification *targets for the future implementation*, recorded so the eventual proposal
+  inherits them. **No code is verified by this design-only change.**

--- a/openspec/changes/engine-backend-bootstrap/proposal.md
+++ b/openspec/changes/engine-backend-bootstrap/proposal.md
@@ -1,0 +1,105 @@
+## Why
+
+Endstate's promise to a non-technical user is "rebuild my machine without learning anything." On
+Windows that already holds: `winget` ships with the OS, so the package backend is just *there*. On
+**macOS and Linux it does not hold**, because Endstate's backends — the **Nix realizer** and (per the
+`macos-brew-driver` design) the **Homebrew driver** — are not preinstalled. Today a missing backend is
+a hard stop: the realizer returns `REALIZER_UNAVAILABLE` when Nix is absent, and a brew driver would
+fail the same way when `brew` is not on `PATH`. For the audience Endstate is *for*, "go install Nix /
+Homebrew first" is exactly the wall this product exists to remove.
+
+The governing principle is **invisible but inspectable**: the user should never have to learn the
+words "Nix" or "Homebrew," yet every privileged, system-modifying step must stay explicit, consented,
+and auditable. "Invisible" means the *concepts* are hidden — **not** that consent is hidden. On macOS
+in particular the backend installers force prompts that cannot (and must not) be suppressed: the
+Homebrew installer triggers an Xcode Command Line Tools install and a sudo password prompt; the
+Determinate Nix installer is a privileged, multi-user, daemon-and-volume system change. So the honest
+shape is **one plain-language consent**, then the **official** upstream installer, then a **verify**,
+then proceed — or **decline gracefully** and continue the rest of the run without that backend.
+
+The `macos-brew-driver` design already sketched the **Homebrew half** of this (its §8 / Requirement
+"Homebrew is bootstrapped when absent, with consent"). But that is only half the story: the engine has
+**two** backends to bootstrap on Unix, and the **Nix half is heavier and broader** (root/daemon,
+multi-user, a dedicated macOS APFS volume, and the thorny "do we ever uninstall a backend we
+installed?" question). This change scopes — **design only, no implementation** — the **unified
+"engine installs its own backends" capability**: the backend-agnostic consent/verify/decline contract
+that both bootstraps share, plus the Nix-specific concerns the brew §8 sketch does not cover.
+
+## What Changes
+
+This is a **design-only** OpenSpec change. It produces the comparison, the recommendation, and a
+delta-spec **sketch**; it changes **no Go code, no engine behavior, and no installer is run**.
+
+The direction it proposes (for the human to ratify):
+
+- **ADOPT a single, backend-agnostic bootstrap contract** — *detect → consent → official install →
+  verify → proceed-or-decline-gracefully* — that the Nix realizer and the Homebrew driver both satisfy.
+  A backend that is present and working is a silent no-op (no prompt). A backend that is absent is
+  installed **only after one explicit, plain-language consent**, **never silently**. A declined consent
+  **skips that backend's lane** with a clear message and **continues the rest of the run**. A bootstrap
+  that fails surfaces a clear error and is treated as **unavailable**, never as silently half-done.
+- **Orchestrate the OFFICIAL upstream installer, never a vendored fork.** Nix → the **Determinate Nix
+  installer** (the same one `.github/workflows/nix-integration.yml` already uses in CI). Homebrew → the
+  upstream `install.sh`. The engine *drives* the installer; it does not embed, fork, or re-implement it.
+  The step is inspectable (the user can see exactly what will run), consistent with Endstate's
+  non-destructive / no-silent-mutation posture.
+- **Scope the Nix-specific footprint** the brew §8 sketch does not: Nix's bootstrap is a privileged
+  multi-user install (root, a launchd/systemd daemon, and on macOS a dedicated APFS **Nix Store
+  volume**). The engine treats **uninstalling a backend it installed as a separate, explicit,
+  user-owned action** — it does **not** silently remove a backend, consistent with non-destructive
+  defaults.
+- **Record the platform asymmetry.** Windows needs **no** backend bootstrap (winget ships with the OS).
+  This capability is a **macOS + Linux** concern.
+
+No backend, installer flag, or final consent-UX is *selected* by this change. The recommendation (see
+`design.md`) is a starting position; the open decisions are left explicit for review. The
+**Homebrew-specific** bootstrap requirement remains owned by `macos-brew-driver` §8 and graduates from
+there; this capability does **not** duplicate it — it provides the shared contract the brew bootstrap
+is one instance of, plus the Nix instance.
+
+## Capabilities
+
+### New Capabilities
+
+- `engine-backend-bootstrap`: A capability, specified here at requirement level only (no
+  implementation), under which Endstate installs **its own** package backend when it is absent —
+  consented, via the official installer, verified before use, and gracefully skippable. The
+  load-bearing requirements (sketched in `specs/engine-backend-bootstrap/spec.md`):
+  - **A missing backend is bootstrapped only with explicit consent** — present → no-op; absent → one
+    plain-language consent before any install; declined → that backend's lane is skipped and the run
+    continues; never silent.
+  - **A bootstrapped backend is verified working before use** — post-install the engine confirms the
+    backend works (e.g. `brew --version`, a Nix eval) before provisioning through it; a backend that
+    installs but fails verification is treated as unavailable, not half-used.
+  - **The engine orchestrates the official installer, never a vendored fork** — Determinate (Nix) /
+    upstream `install.sh` (Homebrew); the privileged step is explicit and inspectable.
+  - **Nix backend bootstrap accounts for its heavier footprint** — multi-user daemon + macOS APFS
+    volume + root; the engine does **not** silently uninstall a backend it installed; Windows is
+    exempt (winget ships with the OS).
+
+### Modified Capabilities
+
+- None. This change is additive and design-only. It **composes with** `macos-brew-driver` (whose §8
+  sketches the Homebrew-specific bootstrap requirement) by providing the backend-agnostic contract that
+  requirement is one instance of; it does not modify or duplicate it.
+
+## Impact
+
+**This change is design-only. It modifies no Go code and ships no behavior.** The list below is the
+surface a *future* implementation would touch, recorded here so the eventual proposal is pre-scoped:
+
+- `go-engine/internal/commands/select.go` / the backend factories — a bootstrap pre-step would run
+  *before* `newRealizerFn()` / a brew-driver factory hard-fails on an absent backend, turning today's
+  `REALIZER_UNAVAILABLE` hard stop into detect → consent → install → verify (or graceful decline).
+- `go-engine/internal/commands/apply.go` — the bootstrap gate runs ahead of the realizer/brew lanes;
+  a declined or failed bootstrap removes that lane and continues, rather than aborting `apply`.
+- A new `go-engine/internal/bootstrap/` (or equivalent) package — the detect/consent/install/verify
+  orchestration, one strategy per backend (Determinate Nix, Homebrew), each shelling the **official**
+  installer behind the `ExecCommand` seam so it is hermetically testable.
+- The consent surface — a plain-language prompt the **GUI** renders (CLI source of truth), since the
+  primary audience runs the GUI; the engine emits the consent request as a streamed event.
+- `.github/workflows/nix-integration.yml` — note the **CI-test wrinkle** (design.md): the GH
+  `macos-latest` runner has **Homebrew preinstalled**, so the *install* path cannot be exercised there
+  (detect → present → no-op only). The bootstrap's install path is validated by manual/real-machine
+  runs, not the existing macOS CI smoke.
+- `openspec/specs/engine-backend-bootstrap/` — the spec this sketch graduates into on adoption.

--- a/openspec/changes/engine-backend-bootstrap/specs/engine-backend-bootstrap/spec.md
+++ b/openspec/changes/engine-backend-bootstrap/specs/engine-backend-bootstrap/spec.md
@@ -1,0 +1,113 @@
+## ADDED Requirements
+
+> SKETCH — this delta-spec is part of a DESIGN-ONLY change. The requirements below define the behavior
+> the eventual implementation MUST satisfy; no engine code implements them yet. They are stated
+> behavior-level and backend-agnostic so they survive the human's decisions on phasing, consent UX, and
+> installer flavor (see `design.md` Open Questions). The **Homebrew-specific** bootstrap requirement is
+> owned by `macos-brew-driver` §8; the requirements here are the shared contract that requirement is one
+> instance of, plus the Nix-specific footprint.
+
+### Requirement: A missing backend is bootstrapped only with explicit consent
+
+The engine SHALL bootstrap a backend a run needs (the Nix realizer or the Homebrew driver) when it is
+absent on macOS or Linux only after explicit, plain-language user consent, offering to install it and
+proceeding only once the user agrees. The consent prompt SHALL describe the action in plain language
+without requiring the user to know the backend's product name. The engine SHALL NOT install a backend
+silently or without consent. When the backend is already present and working, the engine SHALL use it
+directly without prompting or re-installing. When the user declines, the engine SHALL skip that
+backend's lane with a clear message and SHALL still run the rest of the apply.
+
+#### Scenario: Backend already present — no prompt, no install
+
+- **WHEN** a run needs a backend that is already installed and working
+- **THEN** the engine SHALL use it directly
+- **AND** it SHALL NOT prompt for consent or attempt a bootstrap
+
+#### Scenario: Backend absent — one plain-language consent before any install
+
+- **WHEN** a run needs a backend that is not installed
+- **THEN** the engine SHALL request consent in plain language describing the action without requiring
+  knowledge of the backend's product name
+- **AND** it SHALL install the backend only after the user explicitly consents
+- **AND** it SHALL NOT install the backend silently
+
+#### Scenario: Consent declined — lane skipped, run continues
+
+- **WHEN** the user declines the bootstrap for a backend
+- **THEN** the engine SHALL NOT install that backend
+- **AND** it SHALL skip that backend's lane with a clear message
+- **AND** it SHALL still run the remaining lanes and configuration of the apply
+
+### Requirement: A bootstrapped backend is verified working before use
+
+After installing a backend, the engine SHALL verify the backend actually works before provisioning any
+package or configuration through it. A backend whose installer completes but whose verification probe
+fails SHALL be treated as unavailable, and the engine SHALL surface a clear error rather than proceeding
+as if the backend were present. A bootstrap that fails SHALL NOT leave the run silently half-completed.
+
+#### Scenario: Post-install verification gates use
+
+- **WHEN** the engine has just installed a backend
+- **THEN** it SHALL run a verification probe (for example, the backend's version command or an
+  evaluation) confirming the backend works
+- **AND** it SHALL provision through the backend only after that probe passes
+
+#### Scenario: Verification failure is surfaced, not silent
+
+- **WHEN** a backend installs but its verification probe fails
+- **THEN** the engine SHALL treat the backend as unavailable
+- **AND** it SHALL report a clear error
+- **AND** it SHALL NOT proceed as if the backend were available
+
+### Requirement: The engine orchestrates the official installer, never a vendored fork
+
+When bootstrapping a backend, the engine SHALL run the backend's official upstream installer — the
+Determinate installer for Nix and the upstream installer script for Homebrew — orchestrating it rather
+than vendoring, forking, or re-implementing it. The privileged, system-modifying step SHALL be explicit
+and inspectable, consistent with the engine's non-destructive, no-silent-mutation posture. The engine
+SHALL NOT suppress operating-system credential or component prompts (such as the macOS administrator
+password or Xcode Command Line Tools install) that the official installer requires.
+
+#### Scenario: Nix bootstrap runs the official installer
+
+- **WHEN** the engine bootstraps the Nix backend
+- **THEN** it SHALL run the official Determinate Nix installer
+- **AND** it SHALL NOT use a vendored or re-implemented installer
+
+#### Scenario: Homebrew bootstrap runs the official installer
+
+- **WHEN** the engine bootstraps the Homebrew backend
+- **THEN** it SHALL run the official upstream Homebrew installer
+- **AND** it SHALL NOT use a vendored or re-implemented installer
+
+#### Scenario: Operating-system prompts are not suppressed
+
+- **WHEN** the official installer triggers an operating-system credential or component prompt
+- **THEN** the engine SHALL let that prompt proceed
+- **AND** it SHALL NOT attempt to suppress or bypass it
+
+### Requirement: Nix backend bootstrap accounts for its heavier footprint
+
+The engine SHALL treat bootstrapping the Nix backend as a heavier, privileged system change than the
+Homebrew bootstrap: a multi-user installation with a background daemon and, on macOS, a dedicated store
+volume. The engine SHALL NOT silently uninstall a backend it installed; removing a backend SHALL be a
+separate, explicit, user-owned action. On Windows the engine SHALL NOT attempt a backend bootstrap,
+because the platform package backend ships with the operating system.
+
+#### Scenario: Nix is bootstrapped as a multi-user system change
+
+- **WHEN** the engine bootstraps Nix on macOS or Linux after consent
+- **THEN** it SHALL use the multi-user installation (background daemon, and on macOS the dedicated store
+  volume) provided by the official installer
+
+#### Scenario: The engine does not silently remove a backend it installed
+
+- **WHEN** a backend was bootstrapped by the engine
+- **THEN** the engine SHALL NOT silently uninstall it as part of any later run
+- **AND** removing the backend SHALL require a separate, explicit, user-owned action
+
+#### Scenario: Windows needs no backend bootstrap
+
+- **WHEN** a run executes on Windows
+- **THEN** the engine SHALL NOT attempt to bootstrap a package backend
+- **AND** it SHALL use the operating-system-provided backend directly

--- a/openspec/changes/engine-backend-bootstrap/tasks.md
+++ b/openspec/changes/engine-backend-bootstrap/tasks.md
@@ -1,0 +1,73 @@
+> DESIGN-ONLY change. These are decision/scoping tasks, not code tasks. No Go is written, no engine
+> behavior ships, no installer is run. "Done" items are the comparison/scoping work completed in
+> `design.md`; "open" items are the decisions the human makes on review before any implementation
+> proposal is opened.
+
+## 1. Scoping & comparison (done — captured in design.md)
+
+- [x] 1.1 Frame the problem: Windows gets its backend (winget) for free; macOS/Linux do not, and a
+      missing backend is a hard stop today (`REALIZER_UNAVAILABLE` / brew-absent). For a non-technical
+      audience, "install the package manager first" is the wall this capability removes.
+- [x] 1.2 Establish the **invisible-but-inspectable** consent model: hide the *concepts* (never the
+      words "Nix"/"Homebrew"), never the *consent*; macOS forces unsuppressable Xcode-CLT/sudo/volume
+      prompts, so the only honest shape is one plain-language consent → official installer → verify.
+- [x] 1.3 Define the **unified backend-agnostic contract** (detect → consent → official install →
+      verify → proceed-or-decline-gracefully) that both the Nix realizer and the Homebrew driver satisfy.
+- [x] 1.4 Place the bootstrap as a **pre-step in front of the backend factory gate** in
+      apply/capture/verify/plan; present → no-op; declined/failed → skip that lane, continue the run.
+- [x] 1.5 Scope the **Nix-specific footprint** the brew §8 sketch does not cover: multi-user daemon,
+      macOS APFS Nix Store volume, root, the Determinate installer as the vehicle, and the
+      uninstall-the-backend question (recommend: never silently uninstall).
+- [x] 1.6 Establish the boundary with `macos-brew-driver`: the Homebrew-specific bootstrap requirement
+      stays in brew §8 and graduates from there; this capability owns the **shared contract** + the
+      **Nix** instance, without duplicating the brew requirement.
+- [x] 1.7 Record the **CI-test wrinkle**: the GH macOS runner has Homebrew (and CI-Nix) preinstalled, so
+      the *install* path cannot be exercised in the existing macOS smoke (detect → present → no-op only);
+      the install path needs a clean real machine.
+- [x] 1.8 Record the consent-UX boundary (CLI source of truth; the GUI renders an engine-emitted consent
+      request for the primary audience) and the verify-first gate.
+- [x] 1.9 Sketch the delta-spec requirements in `specs/engine-backend-bootstrap/spec.md`.
+
+## 2. Decisions (open — the human ratifies)
+
+- [ ] 2.1 **Decide phase/sequencing.** Bootstrap ships **with** the brew increment (true "zero
+      prerequisites" on day one) or as a **fast-follow** once the brew lanes are proven (§ Open Q1; mirrors
+      brew Open Q7).
+- [ ] 2.2 **Decide one-consent vs per-backend** on a Mac needing both Nix (config) and Homebrew (apps)
+      (§ Open Q2).
+- [ ] 2.3 **Decide the non-interactive default** (no TTY): skip-the-lane-with-message vs fail-loudly;
+      confirm `--bootstrap-backends` / `--no-bootstrap` flag shape (§ Open Q3).
+- [ ] 2.4 **Decide the uninstall posture.** Never silently uninstall a backend the engine installed;
+      confirm whether the engine ever offers an *assisted* uninstall (pointing at the official
+      uninstaller) or stays entirely hands-off (§ Open Q4).
+- [ ] 2.5 **Decide the Nix install flavor.** Confirm the **Determinate** multi-user installer (matches
+      CI, flake-enabled) over upstream/single-user; decide whether a single-user/no-daemon option is ever
+      offered (§ Open Q5).
+- [ ] 2.6 **Decide consent disclosure depth** — how much of the daemon/APFS-volume footprint the
+      plain-language consent must disclose to stay honest without overwhelming the audience (§ Open Q6).
+
+## 3. Spec hardening (open — before implementation)
+
+- [ ] 3.1 **Spec the consent contract** as testable requirements (present → no-op/no-prompt; absent →
+      one consent before install; declined → skip lane + continue; never silent).
+- [ ] 3.2 **Spec the verify gate** (post-install verification probe gates use; verify-fail → backend
+      unavailable, not half-used).
+- [ ] 3.3 **Spec official-installer-only** (Determinate / upstream `install.sh`; orchestrated, not
+      vendored; inspectable privileged step).
+- [ ] 3.4 **Spec the Nix footprint + no-silent-uninstall** (multi-user daemon + macOS volume; the engine
+      does not silently remove a backend it installed; Windows exempt).
+- [ ] 3.5 Graduate the ratified subset of `specs/engine-backend-bootstrap/spec.md` into an
+      implementation proposal (separate, non-design-only change), coordinated with the brew §8 graduation.
+
+## 4. Non-tasks (explicitly out of scope here)
+
+- [ ] 4.1 (NOT in this change) Any Go / engine implementation — no `internal/bootstrap/` package, no
+      `select.go`/`apply.go` pre-step wiring, no consent-event emission.
+- [ ] 4.2 (NOT in this change) Running, vendoring, or forking any installer (Determinate / Homebrew
+      `install.sh`).
+- [ ] 4.3 (NOT in this change) Re-specifying the **Homebrew-specific** bootstrap requirement — it stays
+      in `macos-brew-driver` §8; this change provides the shared contract it is one instance of.
+- [ ] 4.4 (NOT in this change) A Windows bootstrap — winget ships with the OS; the only Windows angle is
+      asserting "no backend bootstrap needed."
+- [ ] 4.5 (NOT in this change) An assisted backend **uninstall** flow — recorded as an open decision, not
+      scoped here.


### PR DESCRIPTION
## Scope engine-installed backends — invisible Nix/Homebrew bootstrap (design only)

**Design-only OpenSpec change. No Go code, no engine behavior, no installer is run.**

On Windows the package backend (winget) ships with the OS. On macOS/Linux Endstate's backends — the Nix realizer and (per `macos-brew-driver`) the Homebrew driver — are **not** preinstalled, and a missing backend is a hard stop today. For the non-technical audience, "go install a package manager first" is the wall this capability removes.

### What this scopes
A new `engine-backend-bootstrap` capability: the backend-agnostic **detect → consent → official install → verify → proceed-or-decline-gracefully** contract that both backends satisfy.
- **Invisible ≠ unconsented**: hide the *concepts* (the user never learns "Nix"/"Homebrew"), never the *consent*. macOS forces unsuppressable Xcode-CLT/sudo prompts, so the honest model is one plain-language consent → the **official** upstream installer (Determinate for Nix, `install.sh` for Homebrew — orchestrated, not vendored) → verify before use → graceful decline (skip that lane, continue the run).
- **The Nix-specific footprint** the brew §8 sketch didn't cover: multi-user daemon, the macOS APFS Nix-Store volume, root, the Determinate installer, and the uninstall-the-backend question (recommendation: the engine **never silently uninstalls** a backend it installed).
- **Composes with `macos-brew-driver` §8** (which keeps the Homebrew-specific bootstrap requirement) without duplicating it — the requirements here are the shared contract that requirement is one instance of.

### Notes for review
- The delta spec is a SKETCH (design-only); requirement names are distinct, validated `--all --strict` (69/0).
- **CI wrinkle recorded**: the GH macOS runner has Homebrew and Nix preinstalled, so the *install* path can't be exercised in CI (detect → present → no-op only); it needs a clean real machine.
- Open questions for the maintainer: phasing (with brew increment vs fast-follow), one-consent vs per-backend, non-interactive default, assisted-uninstall posture, Nix install flavor, consent-disclosure depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
