### PR TITLE
feat(backup): push --name creates a distinct backup when no --backup-id

### DIFF
--- a/go-engine/internal/backup/upload/resolve_backup_id_test.go
+++ b/go-engine/internal/backup/upload/resolve_backup_id_test.go
@@ -1,0 +1,109 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package upload
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/backup/storage"
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// fakeResolverStore is a minimal in-memory backupResolverStore for unit-testing
+// resolveBackupID without a live backend.
+type fakeResolverStore struct {
+	backups      []storage.Backup
+	createCalls  int
+	lastCreated  string
+	listCalls    int
+	newID        string
+}
+
+func (f *fakeResolverStore) ListBackups(ctx context.Context) ([]storage.Backup, *envelope.Error) {
+	f.listCalls++
+	return f.backups, nil
+}
+
+func (f *fakeResolverStore) CreateBackup(ctx context.Context, name string) (string, *envelope.Error) {
+	f.createCalls++
+	f.lastCreated = name
+	id := f.newID
+	if id == "" {
+		id = "new-backup-id"
+	}
+	return id, nil
+}
+
+// A named push with no --backup-id must CREATE a distinct backup, even when the
+// account already has backups. Previously the engine returned backups[0] and
+// silently ignored --name, so per-profile hosting was impossible.
+func TestResolveBackupID_NamedPushWithExistingBackupsCreatesNew(t *testing.T) {
+	store := &fakeResolverStore{
+		backups: []storage.Backup{{ID: "existing-1", Name: "This computer"}},
+		newID:   "created-gaming",
+	}
+
+	id, err := resolveBackupID(context.Background(), store, "", "gaming-rig")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "created-gaming" {
+		t.Fatalf("expected a newly created backup id, got %q (did it append to backups[0]?)", id)
+	}
+	if store.createCalls != 1 {
+		t.Fatalf("expected CreateBackup called once, got %d", store.createCalls)
+	}
+	if store.lastCreated != "gaming-rig" {
+		t.Fatalf("expected new backup labeled %q, got %q", "gaming-rig", store.lastCreated)
+	}
+}
+
+// An explicit --backup-id is honored verbatim, without touching storage.
+func TestResolveBackupID_ExplicitIDUsedVerbatim(t *testing.T) {
+	store := &fakeResolverStore{backups: []storage.Backup{{ID: "existing-1"}}}
+
+	id, err := resolveBackupID(context.Background(), store, "b-123", "ignored-name")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "b-123" {
+		t.Fatalf("expected explicit id b-123, got %q", id)
+	}
+	if store.createCalls != 0 || store.listCalls != 0 {
+		t.Fatalf("explicit id must not call storage; create=%d list=%d", store.createCalls, store.listCalls)
+	}
+}
+
+// No id and no name: legacy convenience — append to the first existing backup.
+func TestResolveBackupID_NoNameNoIDAppendsToFirst(t *testing.T) {
+	store := &fakeResolverStore{backups: []storage.Backup{{ID: "first"}, {ID: "second"}}}
+
+	id, err := resolveBackupID(context.Background(), store, "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "first" {
+		t.Fatalf("expected first backup id, got %q", id)
+	}
+	if store.createCalls != 0 {
+		t.Fatalf("expected no CreateBackup, got %d", store.createCalls)
+	}
+}
+
+// No id, no name, no existing backups: create a "default" backup.
+func TestResolveBackupID_NoNameNoIDNoBackupsCreatesDefault(t *testing.T) {
+	store := &fakeResolverStore{backups: nil, newID: "created-default"}
+
+	id, err := resolveBackupID(context.Background(), store, "", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if id != "created-default" {
+		t.Fatalf("expected created default id, got %q", id)
+	}
+	if store.lastCreated != "default" {
+		t.Fatalf("expected default label, got %q", store.lastCreated)
+	}
+}

--- a/go-engine/internal/backup/upload/upload.go
+++ b/go-engine/internal/backup/upload/upload.go
@@ -77,9 +77,10 @@ type Dependencies struct {
 
 // PushVersion executes the upload pipeline. Inputs:
 //   - profilePath: a file or directory on disk to back up
-//   - backupID: existing backup id; if empty, the engine looks up the user's
-//     first backup and creates a new one named `name` if none exists
-//   - name: human-readable label used iff a fresh backup is created
+//   - backupID: existing backup id to add a version to; used verbatim when set
+//   - name: when backupID is empty, a non-empty name CREATES a new backup with
+//     that label (one backup per profile). Empty backupID + empty name keeps the
+//     legacy convenience: append to the first existing backup, else create "default".
 //
 // Returns the new versionId on success. Streaming progress is emitted on
 // deps.Events when --events jsonl is active.
@@ -96,7 +97,7 @@ func PushVersion(ctx context.Context, deps Dependencies, backupID, profilePath, 
 	}
 	defer wipe(dek)
 
-	resolvedBackupID, envErr := resolveBackupID(ctx, deps, backupID, name)
+	resolvedBackupID, envErr := resolveBackupID(ctx, deps.Storage, backupID, name)
 	if envErr != nil {
 		return nil, envErr
 	}
@@ -310,26 +311,41 @@ func EstimateSize(deps Dependencies, profilePath string) (*SizeEstimate, *envelo
 	}, nil
 }
 
-// resolveBackupID picks a backup id to write a version against. If the
-// caller specified one, it is used verbatim. Otherwise the user's
-// existing backups are listed: if there's at least one, the first is
-// used; otherwise a new backup is created with `name` (default: "default").
-func resolveBackupID(ctx context.Context, deps Dependencies, backupID, name string) (string, *envelope.Error) {
+// backupResolverStore is the minimal storage surface resolveBackupID needs.
+// Satisfied by *storage.Client; lets the resolution logic be unit-tested with
+// a fake instead of a live backend.
+type backupResolverStore interface {
+	ListBackups(ctx context.Context) ([]storage.Backup, *envelope.Error)
+	CreateBackup(ctx context.Context, name string) (string, *envelope.Error)
+}
+
+// resolveBackupID picks a backup id to write a version against:
+//   - an explicit backupID is used verbatim;
+//   - otherwise a non-empty name creates a NEW backup labeled `name` — so the
+//     GUI's per-profile model gets one backup per profile, addressed by id on
+//     later pushes. (Previously a named push fell through to "append to the
+//     first existing backup", silently ignoring --name once any backup existed.)
+//   - a push with neither id nor name keeps the legacy convenience: append to
+//     the user's first backup, or create a "default" backup if they have none.
+func resolveBackupID(ctx context.Context, store backupResolverStore, backupID, name string) (string, *envelope.Error) {
 	if strings.TrimSpace(backupID) != "" {
 		return backupID, nil
 	}
-	backups, err := deps.Storage.ListBackups(ctx)
+	if createName := strings.TrimSpace(name); createName != "" {
+		id, cerr := store.CreateBackup(ctx, createName)
+		if cerr != nil {
+			return "", cerr
+		}
+		return id, nil
+	}
+	backups, err := store.ListBackups(ctx)
 	if err != nil {
 		return "", err
 	}
 	if len(backups) > 0 {
 		return backups[0].ID, nil
 	}
-	createName := strings.TrimSpace(name)
-	if createName == "" {
-		createName = "default"
-	}
-	id, cerr := deps.Storage.CreateBackup(ctx, createName)
+	id, cerr := store.CreateBackup(ctx, "default")
 	if cerr != nil {
 		return "", cerr
 	}

--- a/openspec/changes/backup-push-name-creates-backup/.openspec.yaml
+++ b/openspec/changes/backup-push-name-creates-backup/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-04

--- a/openspec/changes/backup-push-name-creates-backup/design.md
+++ b/openspec/changes/backup-push-name-creates-backup/design.md
@@ -1,0 +1,30 @@
+## Context
+
+`resolveBackupID(ctx, store, backupID, name)` in `go-engine/internal/backup/upload/upload.go` chooses the backup a push writes a version to. Prior logic: explicit id → use it; else if any backup exists → `backups[0]`; else create `name` (default `"default"`). The `backups[0]` branch ran before the name was ever consulted, so `--name` only mattered on a brand-new account. The GUI relies on a named push creating a distinct backup.
+
+## Goals / Non-Goals
+
+**Goals:**
+- A named push with no id creates a new, distinctly-labeled backup.
+- Explicit-id and the bare no-id/no-name convenience paths are preserved.
+- The resolution logic is unit-testable without a live backend.
+
+**Non-Goals:**
+- Enforcing global name uniqueness (names remain labels; id is the key).
+- Any change to the chunked upload pipeline, crypto, or version semantics.
+- Renaming/merging existing backups.
+
+## Decisions
+
+**Order the checks id → name → list.** Move the `--name` create ahead of the `backups[0]` fallback so a named push always creates. Rationale: matches the documented `[--name <label>]` intent and unblocks per-profile hosting. Alternative (a new `--create` flag) rejected as extra surface; `--name` already signals intent and callers wanting to target an existing backup pass `--backup-id`.
+
+**Extract `backupResolverStore` interface.** `resolveBackupID` takes a 2-method interface (`ListBackups`, `CreateBackup`) instead of the concrete `Dependencies`/`*storage.Client`, satisfied by `*storage.Client` and faked in tests. Pure testability refactor, no behavior change.
+
+## Risks / Trade-offs
+
+- [A user scripting `backup push --name X` repeatedly now gets many backups instead of versions] → Mitigation: documented; to add a version, pass `--backup-id`. The GUI records and reuses ids, so it versions correctly.
+- [Consumer skew: GUI shipping before this lands] → Mitigation: GUI gates on the engine pin; engine ships first.
+
+## Migration Plan
+
+Backward-compatible. No data migration. Release normally; the GUI pin auto-bumps via `engine-drift-check`. Rollback = revert; only the no-id+named path reverts to the old (buggy) behavior.

--- a/openspec/changes/backup-push-name-creates-backup/proposal.md
+++ b/openspec/changes/backup-push-name-creates-backup/proposal.md
@@ -1,0 +1,25 @@
+## Why
+
+`backup push` with `--name` but no `--backup-id` does not create a backup with that name once the account already has one — `resolveBackupID` returns `backups[0]` and silently ignores `--name`. This makes per-profile hosting impossible: every push collapses into the first backup. The GUI's unified per-profile model (one backup per profile, addressed by id) depends on a named push creating a distinct backup.
+
+## What Changes
+
+- **`backup push` resolution**: when `--backup-id` is absent and `--name` is non-empty, the engine **creates a new backup** labeled `--name` instead of appending to the first existing backup.
+- Explicit `--backup-id` is unchanged (used verbatim → new version of that backup).
+- Empty `--backup-id` **and** empty `--name` keeps the legacy convenience: append to the first existing backup, else create `"default"`.
+- `resolveBackupID` is refactored to depend on a minimal `backupResolverStore` interface so the resolution logic is unit-tested with a fake (no behavior change from the refactor itself).
+
+## Capabilities
+
+### New Capabilities
+- `backup-push-resolution`: how `backup push` chooses or creates the target backup from `--backup-id` / `--name`.
+
+### Modified Capabilities
+<!-- None: no existing spec covers push target resolution. -->
+
+## Impact
+
+- `go-engine/internal/backup/upload/upload.go` (`resolveBackupID`, `PushVersion` doc).
+- `go-engine/internal/backup/upload/resolve_backup_id_test.go` (new unit tests).
+- Consumer: the GUI `unified-per-profile-backups` change (separate `endstate-gui` repo) depends on this contract.
+- Backward-compatible: only the previously-misbehaving "no id + named" path changes; auto-backup (which records and passes an id after first push) is unaffected.

--- a/openspec/changes/backup-push-name-creates-backup/specs/backup-push-resolution/spec.md
+++ b/openspec/changes/backup-push-name-creates-backup/specs/backup-push-resolution/spec.md
@@ -1,0 +1,26 @@
+## ADDED Requirements
+
+### Requirement: backup push target resolution
+
+`backup push` SHALL resolve the backup it writes a version to as follows: an explicit `--backup-id` is used verbatim; otherwise a non-empty `--name` SHALL create a new backup labeled with that name; otherwise (no id and no name) it SHALL append to the user's first existing backup, or create a backup named `default` if the user has none. A non-empty `--name` with no `--backup-id` SHALL NOT append to a pre-existing backup.
+
+#### Scenario: Explicit backup id is used verbatim
+- **WHEN** `backup push --backup-id <id>` is invoked
+- **THEN** the version is written to backup `<id>` without listing or creating backups
+
+#### Scenario: Named push with existing backups creates a new backup
+- **WHEN** `backup push --name <label>` (no `--backup-id`) is invoked and the account already has one or more backups
+- **THEN** a new backup labeled `<label>` is created and its id returned
+- **AND** no existing backup receives the version
+
+#### Scenario: Named push on an empty account creates the named backup
+- **WHEN** `backup push --name <label>` is invoked and the account has no backups
+- **THEN** a new backup labeled `<label>` is created
+
+#### Scenario: No id and no name appends to the first backup
+- **WHEN** `backup push` is invoked with neither `--backup-id` nor `--name` and at least one backup exists
+- **THEN** the version is appended to the first backup
+
+#### Scenario: No id, no name, no backups creates a default
+- **WHEN** `backup push` is invoked with neither `--backup-id` nor `--name` and the account has no backups
+- **THEN** a new backup labeled `default` is created

--- a/openspec/changes/backup-push-name-creates-backup/tasks.md
+++ b/openspec/changes/backup-push-name-creates-backup/tasks.md
@@ -1,0 +1,15 @@
+## 1. Resolution change
+
+- [x] 1.1 Extract `backupResolverStore` interface (`ListBackups`, `CreateBackup`); change `resolveBackupID` to take it; pass `deps.Storage` at the call site
+- [x] 1.2 Reorder resolution: id → named-create → list/first-or-default, so a named push with no id creates a new backup
+- [x] 1.3 Update the `PushVersion` doc comment to match the new contract
+
+## 2. Tests
+
+- [x] 2.1 Unit tests with a fake store: named+existing → create new; explicit id → verbatim (no storage calls); no-name/no-id → first; no-name/no-id/empty → default
+- [x] 2.2 `go test ./internal/backup/... ./internal/commands/...` green; `go vet` clean
+
+## 3. Release / consumer
+
+- [ ] 3.1 Merge → release-please cuts the engine release; GUI pin auto-bumps via `engine-drift-check`
+- [ ] 3.2 GUI `unified-per-profile-backups` change implements the per-profile hosting on top of this contract


### PR DESCRIPTION
## Why
`resolveBackupID` returned `backups[0]` whenever the account had any backup, **silently ignoring `--name`**. So `backup push --name X` (no `--backup-id`) could never create a new named backup once one existed — every push collapsed into the first backup. This makes the GUI's per-profile hosting model impossible (found via live debugging: clicking "Back up to cloud" kept appending versions to "This computer" and the per-profile badge never flipped).

## What changes
Reorder resolution to **id → named-create → first-or-default**:
- explicit `--backup-id` → used verbatim (new version of that backup);
- no id + non-empty `--name` → **create a new backup labeled `<name>`** (the fix);
- no id + no name → legacy convenience: append to the first backup, else create `default`.

`resolveBackupID` is refactored onto a tiny `backupResolverStore` interface (satisfied by `*storage.Client`) so the logic is unit-testable with a fake — no behavior change from the refactor itself.

## Tests (TDD)
New `resolve_backup_id_test.go` — wrote the failing test first (named+existing → got `existing-1`, RED), then implemented (GREEN). 4 cases: named+existing → create new; explicit id → verbatim (no storage calls); no-name/no-id → first; no-name/no-id/empty → `default`.
- `go test ./internal/backup/... ./internal/commands/...` green (commands suite incl. orchestration/if-changed/storage — nothing relied on the old behavior)
- `go vet` clean

## Compatibility
Backward-compatible: only the previously-misbehaving no-id+named path changes. Auto-backup (records + passes an id after first push) is unaffected.

## Consumer
Unblocks the GUI **`unified-per-profile-backups`** change (separate `endstate-gui` repo / OpenSpec change). Sequencing: merge → engine release → GUI pin auto-bumps via `engine-drift-check` → GUI implements per-profile hosting. OpenSpec change `backup-push-name-creates-backup` included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)