### PR TITLE
feat(engine): best-effort brew rollback composed with the native rollback

### DIFF
--- a/go-engine/internal/commands/apply_brew_test.go
+++ b/go-engine/internal/commands/apply_brew_test.go
@@ -31,6 +31,11 @@ type fakeBrewDriver struct {
 	installFails map[string]bool   // ref -> Install reports StatusFailed
 	installCalls []string          // refs passed to Install, in order
 	detectCalls  int               // DetectBatch call count
+
+	// --- uninstall (rollback lane) ---
+	uninstallResults map[string]*driver.UninstallResult // ref -> outcome (default: uninstalled)
+	uninstallErr     error                              // infrastructure error (e.g. brew missing)
+	uninstallCalls   []string                           // refs passed to Uninstall, in order
 }
 
 func (f *fakeBrewDriver) Name() string { return "brew" }
@@ -64,6 +69,23 @@ func (f *fakeBrewDriver) Install(ref string) (*driver.InstallResult, error) {
 	}
 	f.installed[ref] = true
 	return &driver.InstallResult{Status: driver.StatusInstalled, Message: "Installed successfully"}, nil
+}
+
+// Uninstall satisfies driver.Uninstaller, recording each ref and returning the
+// scripted per-ref outcome (default: uninstalled). It makes *fakeBrewDriver an
+// Uninstaller so the best-effort brew rollback lane is exercised host-independently.
+func (f *fakeBrewDriver) Uninstall(ref string) (*driver.UninstallResult, error) {
+	f.uninstallCalls = append(f.uninstallCalls, ref)
+	if f.uninstallErr != nil {
+		return nil, f.uninstallErr
+	}
+	if r, ok := f.uninstallResults[ref]; ok {
+		return r, nil
+	}
+	if f.installed != nil {
+		delete(f.installed, ref)
+	}
+	return &driver.UninstallResult{Status: driver.StatusUninstalled}, nil
 }
 
 // panicBrewDriverFn is a newBrewDriverFn that fails the test if it is ever

--- a/go-engine/internal/commands/rollback.go
+++ b/go-engine/internal/commands/rollback.go
@@ -166,11 +166,23 @@ func runRealizerRollback(flags RollbackFlags, r realizer.Realizer) (interface{},
 		}
 	}
 
-	// Nothing to roll back: a target generation with no native anchor AND no
-	// eligible config rollback. Preserves the package-only "no native anchor"
-	// rejection while letting a config-only generation be reverted under
-	// --enable-restore.
-	if !hasPackageTarget && homeRef == nil {
+	// Brew best-effort lane (composed with the native rollback): when an explicit
+	// --to target is given, uninstall the brew apps installed AFTER it — recorded in
+	// their own backend:"brew" generations, which the native nix rollback never
+	// touches. Bare rollback (no --to) stays native-package-only: the nix "previous"
+	// anchor is generation-relative and cannot be reconciled with interleaved brew
+	// generations without an explicit boundary. Computed read-only here so it informs
+	// the dry-run preview, the nothing-to-roll-back check, and the uninstall below.
+	var brewRemoveRefs []string
+	if strings.TrimSpace(flags.To) != "" {
+		brewRemoveRefs = brewRollbackRefs(targetGen)
+	}
+
+	// Nothing to roll back: a target generation with no native anchor, no eligible
+	// config rollback, AND no brew refs to uninstall. Preserves the package-only "no
+	// native anchor" rejection while letting a config-only generation be reverted
+	// under --enable-restore and a brew-only target uninstall its later brew refs.
+	if !hasPackageTarget && homeRef == nil && len(brewRemoveRefs) == 0 {
 		return nil, envelope.NewError(envelope.ErrGenerationNotFound,
 			fmt.Sprintf("Generation %d has no native rollback anchor.", targetGen)).
 			WithRemediation("Only generations committed by a native-rollback backend can be rolled back to.")
@@ -204,6 +216,10 @@ func runRealizerRollback(flags RollbackFlags, r realizer.Realizer) (interface{},
 				Flake:            homeRef.Flake,
 				Config:           homeRef.Config,
 			}
+		}
+		if len(brewRemoveRefs) > 0 {
+			res.RemovedRefs = brewRemoveRefs // would-uninstall preview
+			res.Warning = untrackedDepsWarning
 		}
 		return res, nil
 	}
@@ -251,9 +267,20 @@ func runRealizerRollback(flags RollbackFlags, r realizer.Realizer) (interface{},
 	if hasPackageTarget {
 		native = strconv.Itoa(cur.Generation)
 	}
-	newGen := appendRollbackGeneration(buildRunID("rollback"), r.Name(), cur, native, newHomeRef)
+	// Append the native rollback generation only when the native lane actually
+	// rolled back packages or re-activated config. A brew-only rollback (no native
+	// anchor, no config) records ONLY its backend:"brew" generation below, never an
+	// empty backend:"nix" one.
+	newGen := 0
+	if hasPackageTarget || newHomeRef != nil {
+		newGen = appendRollbackGeneration(buildRunID("rollback"), r.Name(), cur, native, newHomeRef)
+	}
 
-	return &RollbackResult{
+	// Brew best-effort uninstall lane, composed with the native rollback. Runs AFTER
+	// the native package + config rollback; per-package and failure-tolerant — a brew
+	// failure never unwinds the (already committed) native rollback. Records a
+	// separate backend:"brew" rollback generation.
+	res := &RollbackResult{
 		DryRun:           false,
 		Backend:          r.Name(),
 		TargetGeneration: targetGen,
@@ -261,7 +288,78 @@ func runRealizerRollback(flags RollbackFlags, r realizer.Realizer) (interface{},
 		ToNative:         native,
 		NewGeneration:    newGen,
 		HomeManager:      homeResult,
-	}, nil
+	}
+	if len(brewRemoveRefs) > 0 {
+		removed, failed := runBrewRollbackLane(brewRemoveRefs)
+		res.RemovedRefs = removed
+		res.FailedRefs = failed
+		res.Partial = len(failed) > 0
+		res.Warning = untrackedDepsWarning
+	}
+	return res, nil
+}
+
+// brewRollbackRefs returns the de-duplicated union of the AddedRefs of every
+// backend:"brew" Provisioning Generation numbered greater than targetGen — the
+// brew packages a best-effort rollback to targetGen must uninstall. nix and winget
+// generations are ignored (the native lane owns those). Order follows provision.List.
+func brewRollbackRefs(targetGen int) []string {
+	gens, err := provision.List()
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var refs []string
+	for _, g := range gens {
+		if g.Backend != "brew" || g.Number <= targetGen {
+			continue
+		}
+		for _, ref := range g.AddedRefs {
+			if ref != "" && !seen[ref] {
+				seen[ref] = true
+				refs = append(refs, ref)
+			}
+		}
+	}
+	return refs
+}
+
+// runBrewRollbackLane uninstalls the given brew refs best-effort via the host's
+// brew driver and records a backend:"brew" rollback generation. It mirrors
+// runDriverRollback's per-ref, failure-tolerant loop, scoped to brew and composed
+// into the native rollback. Because the native rollback has ALREADY committed when
+// this runs, an unavailable brew driver or a per-ref infrastructure error is
+// tolerated (the refs are reported failed) rather than aborting — the native
+// rollback cannot be unwound. Cask uninstalls are non-destructive (the brew driver
+// never passes --zap). A generation is recorded only when at least one ref was
+// actually removed (an all-failed lane records none, matching the winget path's
+// "nothing removed → no generation").
+func runBrewRollbackLane(refs []string) (removed, failed []string) {
+	d, derr := newBrewDriverFn()
+	if derr != nil {
+		return nil, refs
+	}
+	un, ok := d.(driver.Uninstaller)
+	if !ok {
+		return nil, refs
+	}
+	for _, ref := range refs {
+		res, uerr := un.Uninstall(ref)
+		if uerr != nil || res == nil {
+			failed = append(failed, ref)
+			continue
+		}
+		switch res.Status {
+		case driver.StatusUninstalled, driver.StatusAbsent:
+			removed = append(removed, ref)
+		default:
+			failed = append(failed, ref)
+		}
+	}
+	if len(removed) > 0 {
+		appendRollbackGenerationRemoved(buildRunID("rollback"), "brew", removed, len(failed) > 0)
+	}
+	return removed, failed
 }
 
 // rollbackHomeConfig re-activates the home-manager config recorded by the target

--- a/go-engine/internal/commands/rollback_brew_test.go
+++ b/go-engine/internal/commands/rollback_brew_test.go
@@ -1,0 +1,295 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/driver"
+	"github.com/Artexis10/endstate/go-engine/internal/provision"
+)
+
+// ---------------------------------------------------------------------------
+// Best-effort brew rollback composed with the native (Nix) realizer rollback.
+//
+// On darwin RunRollback short-circuits to the realizer; these tests prove the
+// brew uninstall lane runs ALONGSIDE the native rollback when an explicit
+// --to target is given. Both seams are overridden (newRealizerFn via the
+// capable fakeRealizer, newBrewDriverFn via withRealizerAndBrew) so the path is
+// host-independent — overriding only one would run the wrong backend on a given
+// OS (the recurring two-seam gotcha).
+// ---------------------------------------------------------------------------
+
+// brewRollbackGen returns the (single) Backend:"brew", Rollback-marked generation
+// in the recorded history, or nil if none was appended.
+func brewRollbackGen(t *testing.T) *provision.Generation {
+	t.Helper()
+	gens, err := provision.List()
+	if err != nil {
+		t.Fatalf("provision.List: %v", err)
+	}
+	var found *provision.Generation
+	for _, g := range gens {
+		if g.Backend == "brew" && g.Rollback {
+			found = g
+		}
+	}
+	return found
+}
+
+// TestRollback_Realizer_BrewLane_UninstallsAfterTarget: `rollback --to N --confirm`
+// performs the native rollback AND uninstalls the brew refs added after N,
+// recording a separate Backend:"brew" rollback generation.
+func TestRollback_Realizer_BrewLane_UninstallsAfterTarget(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	if err := provision.Write(&provision.Generation{Backend: "nix", Native: "4", AddedRefs: []string{"nixpkgs#jq"}}); err != nil {
+		t.Fatalf("seed nix gen: %v", err) // gen 1
+	}
+	if err := provision.Write(&provision.Generation{Backend: "brew", AddedRefs: []string{"hello", "cask:firefox"}}); err != nil {
+		t.Fatalf("seed brew gen: %v", err) // gen 2
+	}
+
+	fr := capableRealizer(setOf(4, "jq"))
+	fb := &fakeBrewDriver{installed: map[string]bool{"hello": true, "cask:firefox": true}}
+	var result *RollbackResult
+	withRealizerAndBrew(fr, func() (driver.Driver, error) { return fb, nil }, func() {
+		raw, env := RunRollback(RollbackFlags{To: "1", Confirm: true})
+		if env != nil {
+			t.Fatalf("unexpected envelope error: %+v", env)
+		}
+		result = raw.(*RollbackResult)
+	})
+
+	if fr.rollbackCalls != 1 || fr.lastRollbackArg != 4 {
+		t.Errorf("want native Rollback(4) once, got calls=%d arg=%d", fr.rollbackCalls, fr.lastRollbackArg)
+	}
+	if !sameSet(fb.uninstallCalls, []string{"hello", "cask:firefox"}) {
+		t.Errorf("brew uninstall calls = %v, want the set {hello, cask:firefox}", fb.uninstallCalls)
+	}
+	if !sameSet(result.RemovedRefs, []string{"hello", "cask:firefox"}) || result.Partial {
+		t.Errorf("RemovedRefs=%v partial=%v, want both removed, not partial", result.RemovedRefs, result.Partial)
+	}
+	if result.Warning == "" {
+		t.Error("expected the untracked-dependencies warning on a brew rollback")
+	}
+	g := brewRollbackGen(t)
+	if g == nil {
+		t.Fatal("expected a Backend:brew rollback-marked generation")
+	}
+	if !sameSet(g.RemovedRefs, []string{"hello", "cask:firefox"}) || len(g.AddedRefs) != 0 {
+		t.Errorf("brew rollback gen wrong: removed=%v added=%v", g.RemovedRefs, g.AddedRefs)
+	}
+}
+
+// TestRollback_Realizer_BrewLane_PartialFailure: a per-ref brew uninstall failure
+// is tolerated — reported partial, native rollback stands, run does not error.
+func TestRollback_Realizer_BrewLane_PartialFailure(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	if err := provision.Write(&provision.Generation{Backend: "nix", Native: "4", AddedRefs: []string{"nixpkgs#jq"}}); err != nil {
+		t.Fatalf("seed nix gen: %v", err) // gen 1
+	}
+	if err := provision.Write(&provision.Generation{Backend: "brew", AddedRefs: []string{"a", "b"}}); err != nil {
+		t.Fatalf("seed brew gen: %v", err) // gen 2
+	}
+
+	fr := capableRealizer(setOf(4, "jq"))
+	fb := &fakeBrewDriver{
+		installed: map[string]bool{"a": true, "b": true},
+		uninstallResults: map[string]*driver.UninstallResult{
+			"b": {Status: driver.StatusFailed, Message: "in use by another package"},
+		},
+	}
+	var result *RollbackResult
+	withRealizerAndBrew(fr, func() (driver.Driver, error) { return fb, nil }, func() {
+		raw, env := RunRollback(RollbackFlags{To: "1", Confirm: true})
+		if env != nil {
+			t.Fatalf("a per-item brew failure must not top-level error: %+v", env)
+		}
+		result = raw.(*RollbackResult)
+	})
+
+	if fr.rollbackCalls != 1 {
+		t.Errorf("native Rollback called %d times, want 1 (must still run)", fr.rollbackCalls)
+	}
+	if !result.Partial || len(result.FailedRefs) != 1 || result.FailedRefs[0] != "b" {
+		t.Errorf("want partial with FailedRefs=[b], got partial=%v failed=%v", result.Partial, result.FailedRefs)
+	}
+	if len(result.RemovedRefs) != 1 || result.RemovedRefs[0] != "a" {
+		t.Errorf("want RemovedRefs=[a], got %v", result.RemovedRefs)
+	}
+	if g := brewRollbackGen(t); g == nil || !g.Partial {
+		t.Errorf("expected a partial Backend:brew rollback generation, got %+v", g)
+	}
+}
+
+// TestRollback_Realizer_BrewLane_DryRun: --dry-run previews the brew removals
+// without uninstalling, without the native rollback, and without a new generation.
+func TestRollback_Realizer_BrewLane_DryRun(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	if err := provision.Write(&provision.Generation{Backend: "nix", Native: "4", AddedRefs: []string{"nixpkgs#jq"}}); err != nil {
+		t.Fatalf("seed nix gen: %v", err) // gen 1
+	}
+	if err := provision.Write(&provision.Generation{Backend: "brew", AddedRefs: []string{"hello"}}); err != nil {
+		t.Fatalf("seed brew gen: %v", err) // gen 2
+	}
+
+	fr := capableRealizer(setOf(4, "jq"))
+	fb := &fakeBrewDriver{installed: map[string]bool{"hello": true}}
+	var result *RollbackResult
+	withRealizerAndBrew(fr, func() (driver.Driver, error) { return fb, nil }, func() {
+		raw, env := RunRollback(RollbackFlags{To: "1", DryRun: true}) // no confirm
+		if env != nil {
+			t.Fatalf("unexpected envelope error: %+v", env)
+		}
+		result = raw.(*RollbackResult)
+	})
+
+	if !result.DryRun {
+		t.Error("result.DryRun = false, want true")
+	}
+	if len(result.RemovedRefs) != 1 || result.RemovedRefs[0] != "hello" {
+		t.Errorf("dry-run preview RemovedRefs=%v, want [hello]", result.RemovedRefs)
+	}
+	if len(fb.uninstallCalls) != 0 {
+		t.Errorf("dry-run must not uninstall; calls=%v", fb.uninstallCalls)
+	}
+	if fr.rollbackCalls != 0 {
+		t.Errorf("dry-run must not native-rollback; calls=%d", fr.rollbackCalls)
+	}
+	if gens, _ := provision.List(); len(gens) != 2 {
+		t.Errorf("dry-run must not append a generation; want 2 (seed), got %d", len(gens))
+	}
+}
+
+// TestRollback_Realizer_BrewLane_RequiresConfirm: --to N without --confirm refuses,
+// uninstalls nothing, native-rolls-back nothing, and appends no generation.
+func TestRollback_Realizer_BrewLane_RequiresConfirm(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	if err := provision.Write(&provision.Generation{Backend: "nix", Native: "4", AddedRefs: []string{"nixpkgs#jq"}}); err != nil {
+		t.Fatalf("seed nix gen: %v", err) // gen 1
+	}
+	if err := provision.Write(&provision.Generation{Backend: "brew", AddedRefs: []string{"hello"}}); err != nil {
+		t.Fatalf("seed brew gen: %v", err) // gen 2
+	}
+
+	fr := capableRealizer(setOf(4, "jq"))
+	fb := &fakeBrewDriver{installed: map[string]bool{"hello": true}}
+	withRealizerAndBrew(fr, func() (driver.Driver, error) { return fb, nil }, func() {
+		_, env := RunRollback(RollbackFlags{To: "1"}) // no confirm, no dry-run
+		if env == nil {
+			t.Fatal("expected refusal, got nil error")
+		}
+	})
+	if len(fb.uninstallCalls) != 0 {
+		t.Errorf("refusal must not uninstall; calls=%v", fb.uninstallCalls)
+	}
+	if fr.rollbackCalls != 0 {
+		t.Errorf("refusal must not native-rollback; calls=%d", fr.rollbackCalls)
+	}
+	if gens, _ := provision.List(); len(gens) != 2 {
+		t.Errorf("refusal must not append a generation; want 2 (seed), got %d", len(gens))
+	}
+}
+
+// TestRollback_Realizer_BrewOnlyTarget: a brew-only target generation (no native
+// anchor) with a later brew generation is valid — the brew lane runs, the native
+// package rollback is skipped (there is no anchor).
+func TestRollback_Realizer_BrewOnlyTarget(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	if err := provision.Write(&provision.Generation{Backend: "brew", AddedRefs: []string{"old"}}); err != nil {
+		t.Fatalf("seed brew gen: %v", err) // gen 1 (the target; no native anchor)
+	}
+	if err := provision.Write(&provision.Generation{Backend: "brew", AddedRefs: []string{"new"}}); err != nil {
+		t.Fatalf("seed brew gen: %v", err) // gen 2
+	}
+
+	fr := capableRealizer(setOf(0))
+	fb := &fakeBrewDriver{installed: map[string]bool{"old": true, "new": true}}
+	var result *RollbackResult
+	withRealizerAndBrew(fr, func() (driver.Driver, error) { return fb, nil }, func() {
+		raw, env := RunRollback(RollbackFlags{To: "1", Confirm: true})
+		if env != nil {
+			t.Fatalf("a brew-only target must be valid, got: %+v", env)
+		}
+		result = raw.(*RollbackResult)
+	})
+
+	if fr.rollbackCalls != 0 {
+		t.Errorf("native Rollback called %d times for a brew-only target, want 0", fr.rollbackCalls)
+	}
+	if !sameSet(fb.uninstallCalls, []string{"new"}) {
+		t.Errorf("brew uninstall calls = %v, want [new]", fb.uninstallCalls)
+	}
+	if !sameSet(result.RemovedRefs, []string{"new"}) {
+		t.Errorf("RemovedRefs=%v, want [new]", result.RemovedRefs)
+	}
+}
+
+// TestRollback_Realizer_NoBrewGens_NonRegression: a no-brew history with --to N
+// never resolves the brew driver and yields the native-only result. The
+// panicBrewDriverFn fails the test if newBrewDriverFn is ever called.
+func TestRollback_Realizer_NoBrewGens_NonRegression(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	if err := provision.Write(&provision.Generation{Backend: "nix", Native: "4", AddedRefs: []string{"nixpkgs#jq"}}); err != nil {
+		t.Fatalf("seed nix gen: %v", err) // gen 1
+	}
+
+	fr := capableRealizer(setOf(4, "jq"))
+	var result *RollbackResult
+	withRealizerAndBrew(fr, panicBrewDriverFn(t), func() {
+		raw, env := RunRollback(RollbackFlags{To: "1", Confirm: true})
+		if env != nil {
+			t.Fatalf("unexpected envelope error: %+v", env)
+		}
+		result = raw.(*RollbackResult)
+	})
+
+	if fr.rollbackCalls != 1 || fr.lastRollbackArg != 4 {
+		t.Errorf("want native Rollback(4) once, got calls=%d arg=%d", fr.rollbackCalls, fr.lastRollbackArg)
+	}
+	if len(result.RemovedRefs) != 0 {
+		t.Errorf("a no-brew history must remove nothing; RemovedRefs=%v", result.RemovedRefs)
+	}
+	// seed nix gen (1) + native rollback append (2) — no brew generation.
+	gens, _ := provision.List()
+	if len(gens) != 2 {
+		t.Fatalf("want 2 generations (seed + native rollback), got %d: %+v", len(gens), gens)
+	}
+	for _, g := range gens {
+		if g.Backend == "brew" {
+			t.Errorf("a no-brew history must append no brew generation, got %+v", g)
+		}
+	}
+}
+
+// TestRollback_Realizer_Bare_BrewUntouched: bare rollback (no --to) stays
+// native-package-only and never engages the brew lane (the nix "previous" anchor
+// cannot be reconciled with interleaved brew generations without a boundary).
+func TestRollback_Realizer_Bare_BrewUntouched(t *testing.T) {
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+	if err := provision.Write(&provision.Generation{Backend: "nix", Native: "4", AddedRefs: []string{"nixpkgs#jq"}}); err != nil {
+		t.Fatalf("seed nix gen: %v", err) // gen 1
+	}
+	if err := provision.Write(&provision.Generation{Backend: "brew", AddedRefs: []string{"hello"}}); err != nil {
+		t.Fatalf("seed brew gen: %v", err) // gen 2
+	}
+
+	fr := capableRealizer(setOf(4, "jq"))
+	var result *RollbackResult
+	// panicBrewDriverFn proves the bare path never resolves the brew driver.
+	withRealizerAndBrew(fr, panicBrewDriverFn(t), func() {
+		raw, env := RunRollback(RollbackFlags{Confirm: true}) // no --to
+		if env != nil {
+			t.Fatalf("unexpected envelope error: %+v", env)
+		}
+		result = raw.(*RollbackResult)
+	})
+
+	if fr.rollbackCalls != 1 || fr.lastRollbackArg != -1 {
+		t.Errorf("want native Rollback(-1) once, got calls=%d arg=%d", fr.rollbackCalls, fr.lastRollbackArg)
+	}
+	if len(result.RemovedRefs) != 0 {
+		t.Errorf("bare rollback must not touch brew; RemovedRefs=%v", result.RemovedRefs)
+	}
+}

--- a/go-engine/internal/provision/provision.go
+++ b/go-engine/internal/provision/provision.go
@@ -37,13 +37,13 @@ type Generation struct {
 	Number        int        `json:"number"`
 	RunID         string     `json:"runId"`
 	Timestamp     string     `json:"timestamp,omitempty"`
-	Backend       string     `json:"backend"` // "nix" | "winget"
+	Backend       string     `json:"backend"` // "nix" | "winget" | "brew"
 	Items         []ProvItem `json:"items"`
 	AddedRefs     []string   `json:"addedRefs"`
 	Native        string     `json:"native,omitempty"`      // backend-native anchor (nix generation number); "" if none
 	Partial       bool       `json:"partial"`               // true when a non-atomic backend committed a partial set
 	Rollback      bool       `json:"rollback,omitempty"`    // true when this generation was produced by a rollback (AddedRefs is empty)
-	RemovedRefs   []string   `json:"removedRefs,omitempty"` // refs uninstalled by a best-effort (winget) rollback; empty for native/apply generations
+	RemovedRefs   []string   `json:"removedRefs,omitempty"` // refs uninstalled by a best-effort (winget/brew) rollback; empty for native/apply generations
 
 	// HomeManager records a home-manager configuration activated by this apply's
 	// config stage (realizer-only, opt-in via --enable-restore). nil when no

--- a/openspec/changes/macos-brew-best-effort-rollback/design.md
+++ b/openspec/changes/macos-brew-best-effort-rollback/design.md
@@ -1,0 +1,83 @@
+# Design — best-effort brew rollback (two-lane, composed with native rollback)
+
+## Context
+
+`apply` on darwin already runs two lanes: the Nix realizer (default) commits an atomic generation, and a
+best-effort brew lane installs `driver: "brew"` apps and records them in a SEPARATE `backend: "brew"`
+provisioning generation (`apply_realizer.go`). `rollback`, by contrast, short-circuits: `RunRollback`
+calls `newRealizerFn()` first and `runRealizerRollback` owns the whole operation — the brew driver
+(`newBrewDriverFn`) is never consulted. So a darwin machine's brew apps are recorded but never rolled
+back. This change makes `rollback` symmetric with `apply`: a brew uninstall lane composed into the
+realizer rollback path.
+
+The brew driver already implements `driver.Uninstaller` (`brew uninstall [--cask]`, never `--zap`,
+already-absent → `StatusAbsent`). The winget best-effort rollback (`runDriverRollback`) already
+implements the "uninstall the union of added refs of generations after the target" pattern. This change
+reuses both — it adds wiring, not new driver or pattern code.
+
+## Locked decisions
+
+1. **The brew lane requires an explicit `--to N`.** Bare rollback (no `--to`) stays native-package-only
+   and byte-identical to today. Rationale: the native "previous" anchor (`Rollback(-1)`) is
+   nix-generation-relative and cannot be reconciled with interleaved `backend: "brew"` generations
+   without an explicit engine-generation boundary. Composing brew into bare rollback would be ambiguous
+   and host-state-dependent. This mirrors `--enable-restore` config rollback, which already requires
+   `--to`. Bare-rollback brew support is a possible later increment.
+
+2. **Composed into `runRealizerRollback`, not a separate dispatch.** Because the realizer path
+   short-circuits `RunRollback`, the only way to reach brew is to compose the lane inside
+   `runRealizerRollback` (a single merged `RollbackResult`). The brew set is computed from the resolved
+   `targetGen` (engine generation number), the same boundary the native lane uses.
+
+3. **Native first, then brew; brew never unwinds the native rollback.** The native package rollback (and
+   opt-in config rollback) runs and is recorded first. The brew uninstall lane runs after. A brew
+   per-package failure is partial (reported, run continues). A brew driver infrastructure error (e.g. no
+   brew on a host that somehow recorded brew generations) is tolerated as failed refs rather than
+   aborting — unlike `runDriverRollback`, which aborts, because here the native rollback has ALREADY
+   committed and cannot be unwound. Best-effort posture, non-destructive.
+
+4. **Brew-only target is valid.** A `--to N` whose generation has no native anchor (a brew generation) is
+   accepted when `brewRemoveRefs` is non-empty; the native package rollback is skipped (no anchor) and
+   only the brew lane runs. The "nothing to roll back" rejection (`!hasPackageTarget && homeRef == nil`)
+   gains `&& len(brewRemoveRefs) == 0`.
+
+5. **Reuse the existing `RollbackResult` best-effort fields.** Brew removals populate `RemovedRefs` /
+   `FailedRefs` / `Partial` / `Warning` (today only the winget driver path uses them; the native path
+   leaves them empty). This keeps the struct unchanged and the `omitempty` JSON clean when no brew lane
+   ran — preserving the no-brew byte-identical guarantee. Brew uninstalls are recorded in a separate
+   `backend: "brew"` rollback generation via the existing `appendRollbackGenerationRemoved`.
+
+6. **The native rollback generation is only appended when the native lane did something.** Guarded to
+   `hasPackageTarget || newHomeRef != nil`, so a brew-only rollback does not append an empty `backend:
+   "nix"` generation (it appends only the `backend: "brew"` one). All pre-existing paths satisfy the
+   guard, so their behavior is unchanged.
+
+## Implementation sketch
+
+- `brewRollbackRefs(targetGen int) []string` — union of `AddedRefs` of `Backend == "brew"` generations
+  with `Number > targetGen`, de-duplicated, deterministic order (reuses `provision.List()`). Mirrors the
+  `runDriverRollback` union, filtered to brew.
+- `runBrewRollbackLane(refs []string) (removed, failed []string)` — resolves `newBrewDriverFn()`,
+  type-asserts `driver.Uninstaller`, uninstalls each ref (per-package, failure-tolerant), and appends a
+  `backend: "brew"` rollback generation. A missing/incapable brew driver reports all refs failed without
+  aborting.
+- `runRealizerRollback` changes: compute `brewRemoveRefs` (only when `flags.To != ""`); relax the
+  nothing-to-rollback guard; include brew refs in the dry-run preview; after the native rollback + config
+  + native generation append, run `runBrewRollbackLane` and fold its result into `RollbackResult`.
+
+## Testing
+
+Hermetic (the dev box is Linux; no real brew). Override BOTH seams — `newRealizerFn` (a capable
+`fakeRealizer`) AND `newBrewDriverFn` (a `fakeBrewDriver` extended with `Uninstall`) — via the existing
+`withRealizerAndBrew` helper; the seam gotcha is that overriding only one runs the wrong backend on a
+given OS. Cases: brew refs uninstalled alongside native rollback; partial failure tolerated; dry-run
+preview; confirm gate; brew-only target; **non-regression** — a no-brew history never resolves the brew
+driver (`panicBrewDriverFn`) and the result is the native-only one; bare rollback leaves brew untouched.
+
+## CI smoke wrinkle
+
+The macOS runner has Homebrew preinstalled, so `scripts/smoke/brew-realbrew-smoke.sh` can apply a brew
+formula, then `rollback --to N --confirm`, and assert the formula is uninstalled — the real uninstall
+anchor. The script's `command -v brew` guard keeps the linux leg a no-op. The script path is already in
+the `nix-integration.yml` path filter, so editing the script triggers the macOS smoke without touching
+the workflow.

--- a/openspec/changes/macos-brew-best-effort-rollback/proposal.md
+++ b/openspec/changes/macos-brew-best-effort-rollback/proposal.md
@@ -1,0 +1,62 @@
+## Why
+
+The design-only change `macos-brew-driver` scoped a macOS Homebrew driver, and `macos-brew-apply-wiring`
+graduated its **install / capture / verify / plan** lanes — a `driver: "brew"` app is now installed on
+darwin alongside the Nix realizer and recorded in its own `backend: "brew"` provisioning generation. The
+brew **driver package** has implemented `Uninstall` (non-`--zap`, already-absent tolerant) since it
+shipped. What is still missing is the **command wiring**: `rollback` short-circuits to the native (Nix)
+realizer on darwin (`RunRollback` calls `newRealizerFn()` first; `runRealizerRollback` owns the whole
+operation), so a machine's brew-installed apps — recorded in `backend: "brew"` generations the native
+rollback never touches — are **never uninstalled**. Rolling back a darwin machine silently leaves its
+brew apps behind.
+
+This change **wires best-effort brew rollback into the realizer rollback path** so that rolling back to
+an explicit target generation also uninstalls the brew apps installed after it — the same two-lane
+composition `apply` already uses, now for `rollback`. It graduates the **best-effort rollback** subset of
+the `macos-brew-driver` design into implemented behavior, reusing the existing winget best-effort
+pattern (uninstall the union of added refs of generations after the target, tolerate per-package failure,
+require `--confirm`, append a rollback-marked generation).
+
+Deferred (left in the design change, not graduated here): precise version pinning (brew's pin is weak and
+already surfaced as advisory drift by verify), and the invisible Homebrew bootstrap.
+
+## What Changes
+
+- **Two-lane rollback at the realizer path.** When `rollback --to N` runs on a host whose realizer owns
+  the native (Nix) rollback, the engine ALSO uninstalls, best-effort, the union of brew references added
+  by every `backend: "brew"` provisioning generation numbered greater than `N`. The native package
+  rollback runs first; the brew uninstall lane runs second and never unwinds or aborts it. A per-package
+  brew failure is reported (partial) but does not fail the run while any brew uninstall succeeded.
+- **Explicit target required for the brew lane.** The brew uninstall lane engages only with an explicit
+  `--to N` (symmetric with `--enable-restore` config rollback). **Bare rollback** (no `--to`) stays
+  native-package-only and byte-identical to today: the native "previous" anchor is generation-relative
+  and cannot be reconciled with interleaved brew generations without an explicit boundary.
+- **Brew-only target is valid.** A target generation that recorded no native package anchor (a
+  `backend: "brew"` generation) is accepted when there are later brew refs to uninstall — the brew
+  packages roll back with no native package change. This relaxes the prior "no native anchor → not found"
+  rejection only for the brew-composed case.
+- **Confirmation, dry-run, non-destructive.** The brew uninstalls require `--confirm` (the native
+  rollback's existing gate) and are previewed under `--dry-run` without mutating. Cask uninstalls are
+  non-destructive (never `--zap`). The untracked-transitive-dependency caveat is surfaced (brew's
+  auto-installed dependencies are exactly such a caveat).
+- **Separate brew rollback generation.** Brew uninstalls are recorded in their own `backend: "brew"`
+  rollback-marked provisioning generation (RemovedRefs populated, AddedRefs empty), mirroring the apply
+  path's separate brew generation and the winget best-effort rollback record.
+- **Real-macOS smoke** (`scripts/smoke/brew-realbrew-smoke.sh`) is extended to apply a brew formula, then
+  `rollback --to N --confirm`, and assert the formula is uninstalled — confirming brew's real uninstall
+  anchors (the hermetic tests only lock the assumed shapes).
+
+## Capabilities
+
+- `macos-brew-best-effort-rollback` (new): two-lane rollback composing best-effort brew uninstall with
+  the native realizer rollback, its confirmation/dry-run/non-destructive guarantees, and the brew-only
+  target relaxation. Stated under requirement names distinct from the still-active `macos-brew-driver`
+  design change and the archived `macos-brew-apply-wiring` so `openspec validate --all --strict` does not
+  collide.
+
+## Out of Scope (deferred to the design change)
+
+- Precise brew version pinning (brew's pin model is weak; declared versions stay advisory, and verify
+  already reports drift).
+- The invisible Homebrew bootstrap (detect → consent → install → verify).
+- Bare-rollback brew support (the brew lane requires an explicit `--to N` this change).

--- a/openspec/changes/macos-brew-best-effort-rollback/specs/macos-brew-best-effort-rollback/spec.md
+++ b/openspec/changes/macos-brew-best-effort-rollback/specs/macos-brew-best-effort-rollback/spec.md
@@ -1,0 +1,59 @@
+## ADDED Requirements
+
+### Requirement: Best-effort brew rollback composes with the native rollback on darwin
+
+When `rollback` runs to an explicit target generation on a host whose realizer owns the native package rollback (Nix on macOS), the engine SHALL also uninstall the union of the brew references added by every provisioning generation whose backend is `brew` and whose number is greater than the target. The native package rollback SHALL run first; the brew uninstall lane SHALL run second and SHALL NOT unwind or abort the native rollback. Each brew uninstall SHALL be best-effort and per package: a per-package failure SHALL be reported and the run SHALL be marked partial, but it SHALL NOT fail while at least one brew uninstall succeeded. The engine SHALL record the brew uninstalls in a separate rollback-marked provisioning generation whose backend is `brew`, and SHALL surface that package-manager-pulled transitive dependencies may remain installed.
+
+#### Scenario: A brew app installed after the target is uninstalled alongside the native rollback
+
+- **WHEN** `rollback --to N --confirm` runs on macOS and a `backend: "brew"` generation numbered greater than N recorded a brew install
+- **THEN** the engine SHALL perform the native package rollback to generation N
+- **AND** it SHALL uninstall that brew reference through the Homebrew driver
+- **AND** it SHALL record the brew uninstall in a separate rollback-marked generation whose backend is `brew`
+
+#### Scenario: A brew uninstall failure does not abort the native rollback
+
+- **WHEN** one brew reference fails to uninstall during a `rollback --to N --confirm` whose native lane already rolled back
+- **THEN** the engine SHALL report that reference as failed and mark the run partial
+- **AND** the native rollback SHALL stand
+- **AND** the run SHALL NOT return a top-level error while another brew uninstall succeeded
+
+#### Scenario: A no-brew history is unchanged from the native-only rollback
+
+- **WHEN** `rollback --to N --confirm` runs and no `backend: "brew"` generation was recorded after N
+- **THEN** the engine SHALL produce the same result as the native-only rollback path
+- **AND** it SHALL NOT resolve or invoke the Homebrew driver
+
+#### Scenario: Bare rollback leaves brew apps untouched
+
+- **WHEN** `rollback --confirm` runs with no explicit target on a host that has recorded brew generations
+- **THEN** the engine SHALL roll back only the native package set, exactly as before this change
+- **AND** it SHALL NOT uninstall any brew app
+
+### Requirement: A brew-only rollback target is valid
+
+The engine SHALL accept an explicit `rollback --to N` whose target generation recorded no native package anchor (a `backend: "brew"` generation) when there are brew references to uninstall after it, rolling back the brew packages with no native package rollback. This relaxes the "no native anchor → generation not found" rejection only for the brew-composed case; a target with neither a native anchor, an eligible config rollback, nor brew references to remove SHALL still be rejected.
+
+#### Scenario: A brew-only target rolls back brew packages without a native change
+
+- **WHEN** `rollback --to N --confirm` targets a `backend: "brew"` generation and a later brew generation added references
+- **THEN** the engine SHALL uninstall the later brew references
+- **AND** it SHALL NOT attempt a native package rollback for that target
+
+### Requirement: Brew rollback requires confirmation, previews under dry-run, and is non-destructive
+
+The engine SHALL require `--confirm` to perform a brew rollback's uninstalls and SHALL refuse without it (the native rollback's existing gate), uninstalling nothing and recording no generation. Under `--dry-run` the engine SHALL report the brew references it would uninstall without uninstalling anything or recording a generation. Cask uninstalls performed by a brew rollback SHALL be non-destructive (never `--zap`), consistent with the backup-before-overwrite and no-silent-deletion posture.
+
+#### Scenario: Dry-run previews brew removals without mutating
+
+- **WHEN** `rollback --to N --dry-run` runs on macOS with brew generations recorded after N
+- **THEN** the engine SHALL report the brew references that would be uninstalled
+- **AND** it SHALL NOT uninstall any brew app
+- **AND** it SHALL NOT record a new provisioning generation
+
+#### Scenario: Without confirmation the brew rollback refuses
+
+- **WHEN** `rollback --to N` runs without `--confirm` and not in dry-run
+- **THEN** the engine SHALL refuse with a message naming `--confirm`
+- **AND** it SHALL NOT uninstall any brew app
+- **AND** it SHALL NOT record a new provisioning generation

--- a/openspec/changes/macos-brew-best-effort-rollback/tasks.md
+++ b/openspec/changes/macos-brew-best-effort-rollback/tasks.md
@@ -1,0 +1,57 @@
+> TDD: each Go piece is written RED first, then implemented to green. All CI tests are hermetic (no real
+> `brew`); brew's real uninstall anchor is confirmed ONLY by the macOS smoke (a CI leg, not a local gate
+> on this Linux box).
+
+## 1. Brew rollback set helper
+
+- [ ] 1.1 RED: `brewRollbackRefs(targetGen)` returns the de-duplicated union of `AddedRefs` of every
+      `Backend == "brew"` generation numbered greater than `targetGen`; ignores nix/winget generations
+      and generations at or below the target.
+- [ ] 1.2 Implement `brewRollbackRefs` in `rollback.go` (reuses `provision.List()`).
+
+## 2. Two-lane rollback composition
+
+- [ ] 2.1 RED: `rollback --to N --confirm` on a capable realizer with a later `backend: "brew"`
+      generation performs the native `Rollback` AND uninstalls the brew refs; result carries
+      `RemovedRefs`; a separate `backend: "brew"` rollback-marked generation is appended.
+- [ ] 2.2 RED: a brew uninstall failure → `Partial` with the failed ref reported; the native rollback
+      still stands; no top-level error while another succeeded.
+- [ ] 2.3 RED: a brew-only target generation (no native anchor) with later brew refs is valid — the brew
+      lane runs, the native `Rollback` is NOT called.
+- [ ] 2.4 RED (non-regression): a no-brew history with `--to N` never resolves `newBrewDriverFn`
+      (`panicBrewDriverFn`) and yields the native-only result; bare rollback (no `--to`) leaves brew
+      untouched (brew driver never resolved).
+- [ ] 2.5 Implement: `runBrewRollbackLane` (best-effort uninstall + `appendRollbackGenerationRemoved`
+      with backend `brew`); compute `brewRemoveRefs` in `runRealizerRollback` only when `--to` is given;
+      relax the nothing-to-rollback guard with `len(brewRemoveRefs) == 0`; guard the native generation
+      append to `hasPackageTarget || newHomeRef != nil`; fold brew removed/failed/partial/warning into
+      `RollbackResult`.
+
+## 3. Confirm gate + dry-run
+
+- [ ] 3.1 RED: `rollback --to N --dry-run` previews the brew `RemovedRefs` without uninstalling or
+      appending a generation; `rollback --to N` without `--confirm` refuses, uninstalls nothing, appends
+      nothing (the existing native gate already covers this — assert the brew lane respects it).
+- [ ] 3.2 Implement the dry-run brew preview branch.
+
+## 4. Test double
+
+- [ ] 4.1 Extend `fakeBrewDriver` (in `apply_brew_test.go`) with `Uninstall` (records refs, scriptable
+      per-ref outcome + infra error) so it satisfies `driver.Uninstaller`.
+
+## 5. macOS smoke + CI
+
+- [ ] 5.1 Extend `scripts/smoke/brew-realbrew-smoke.sh`: after apply+capture, apply a second tiny formula
+      (best-effort), then `rollback --to <gen> --confirm`, then assert the later formula is uninstalled
+      (`brew list` fails) while the first remains, and the rollback output reports the removed ref.
+- [ ] 5.2 No workflow change needed — the script path is already in the `nix-integration.yml` path
+      filter, so editing it triggers the macOS smoke leg (the `command -v brew` guard no-ops on linux).
+
+## 6. OpenSpec + verification
+
+- [ ] 6.1 This change (`macos-brew-best-effort-rollback`) with distinct requirement names; `openspec
+      validate --all --strict` green.
+- [ ] 6.2 `go test ./...`, `go vet ./...`, `GOOS=windows go build ./...` green.
+- [ ] 6.3 Existing nix home-manager smoke confirms the realizer rollback lane is unbroken (non-regression
+      on the high-blast-radius change).
+- [ ] 6.4 macOS brew rollback smoke confirmed green (CI-only; cannot run on the Linux dev box).

--- a/scripts/smoke/brew-realbrew-smoke.sh
+++ b/scripts/smoke/brew-realbrew-smoke.sh
@@ -43,6 +43,10 @@ fi
 # privileges / network that a runner may lack; the formula leg is STRICT.
 FORMULA="hello"
 CASK="cask:gnu-typist" # tiny; cask leg is warn-only regardless of outcome
+# A second tiny formula, installed in a LATER generation, so the rollback phase
+# (below) has a generation to roll back PAST. Its install is best-effort: if it
+# does not take, the rollback phase is skipped with a warning.
+FORMULA2="tree"
 
 # ---------------------------------------------------------------------------
 # Temp dirs — isolated HOME and ENDSTATE_ROOT; cleaned on exit.
@@ -59,14 +63,16 @@ mkdir -p "${SMOKE_HOME}" "${SMOKE_STATE}" "${SMOKE_BIN}"
 
 cleanup() {
   echo
-  echo "==> [brew-smoke] cleanup: uninstalling ${FORMULA} and removing ${TMP_ROOT}"
+  echo "==> [brew-smoke] cleanup: uninstalling ${FORMULA}/${FORMULA2} and removing ${TMP_ROOT}"
   brew uninstall --formula "${FORMULA}" >/dev/null 2>&1 || true
+  brew uninstall --formula "${FORMULA2}" >/dev/null 2>&1 || true
   rm -rf "${TMP_ROOT}"
 }
 trap cleanup EXIT
 
-# Ensure a clean starting point (the formula must not be pre-installed).
+# Ensure a clean starting point (neither formula may be pre-installed).
 brew uninstall --formula "${FORMULA}" >/dev/null 2>&1 || true
+brew uninstall --formula "${FORMULA2}" >/dev/null 2>&1 || true
 
 # ---------------------------------------------------------------------------
 # Phase 1: Build the engine binary
@@ -163,6 +169,68 @@ if grep -q '"driver": *"brew"' "${CAPTURE_OUT}" && grep -q "\"darwin\": *\"${FOR
   echo "    PASS: captured manifest round-trips ${FORMULA} as a driver:brew app"
 else
   fail "Captured manifest does not contain the brew-driver ${FORMULA} app — capture round-trip failed."
+fi
+
+# ---------------------------------------------------------------------------
+# Phase 5: best-effort brew rollback composed with the native (Nix) rollback.
+#
+# The macOS runner has BOTH brew and Nix, so RunRollback takes the realizer path
+# and the brew uninstall lane runs alongside it. Generations (fresh
+# ENDSTATE_ROOT): apply (Phase 3) wrote brew generation 1 (${FORMULA}); this
+# apply writes brew generation 2 (${FORMULA2}). `rollback --to 1 --confirm`
+# uninstalls generation 2's additions (${FORMULA2}) and leaves generation 1
+# (${FORMULA}) intact.
+#
+# The second install is BEST-EFFORT: if ${FORMULA2} does not install, the
+# rollback assertion is skipped with a warning rather than failing the smoke.
+# ---------------------------------------------------------------------------
+
+phase "Installing a second formula (${FORMULA2}) in a later generation"
+
+ROLLBACK_MANIFEST="${TMP_ROOT}/manifest-rollback.jsonc"
+cat > "${ROLLBACK_MANIFEST}" << MANIFEST2
+{
+  "version": 1,
+  "name": "brew-smoke-rollback",
+  "apps": [
+    { "id": "${FORMULA}", "displayName": "${FORMULA}", "driver": "brew", "refs": { "darwin": "${FORMULA}" } },
+    { "id": "${FORMULA2}", "displayName": "${FORMULA2}", "driver": "brew", "refs": { "darwin": "${FORMULA2}" } }
+  ]
+}
+MANIFEST2
+
+"${ENGINE_BIN}" apply --manifest "${ROLLBACK_MANIFEST}" --json >/dev/null 2>&1 || true
+
+if ! brew list --formula "${FORMULA2}" >/dev/null 2>&1; then
+  echo "    WARN: ${FORMULA2} did not install; skipping the rollback assertion (best-effort)."
+else
+  phase "Running: endstate rollback --to 1 --confirm --json (brew lane composed with native)"
+
+  ROLLBACK_OUT="${TMP_ROOT}/rollback-out.json"
+  "${ENGINE_BIN}" rollback --to 1 --confirm --json 2>&1 | tee "${ROLLBACK_OUT}" || {
+    echo "    --- rollback output ---"; cat "${ROLLBACK_OUT}"; echo "    --- end ---"
+    fail "endstate rollback exited non-zero."
+  }
+
+  # STRICT: the later formula must be uninstalled; the target-generation formula must remain.
+  if brew list --formula "${FORMULA2}" >/dev/null 2>&1; then
+    fail "${FORMULA2} is still installed after 'rollback --to 1' — the brew rollback lane did not uninstall it."
+  fi
+  echo "    PASS: ${FORMULA2} was uninstalled by rollback"
+
+  if brew list --formula "${FORMULA}" >/dev/null 2>&1; then
+    echo "    PASS: ${FORMULA} (generation 1) survived the rollback"
+  else
+    fail "${FORMULA} was uninstalled by 'rollback --to 1' — generation 1 should have survived."
+  fi
+
+  # The rollback envelope should report the removed ref.
+  if grep -q "\"${FORMULA2}\"" "${ROLLBACK_OUT}"; then
+    echo "    PASS: rollback output reports ${FORMULA2} among the removed refs"
+  else
+    echo "    --- rollback output ---"; cat "${ROLLBACK_OUT}"; echo "    --- end ---"
+    fail "rollback output does not report ${FORMULA2} as a removed ref."
+  fi
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Why

`rollback` short-circuits to the Nix realizer on darwin (`RunRollback` calls `newRealizerFn()` first), so a machine's brew apps — recorded in their own `backend:"brew"` provisioning generation since #117 — were **never uninstalled**. The brew driver has implemented `Uninstall` (non-`--zap`) since it shipped; this PR adds the missing **command wiring**.

Graduates the **best-effort rollback** subset of the still-active `macos-brew-driver` design (the same two-lane composition `apply` already uses, now for `rollback`).

## What changes

- **Two-lane rollback.** `rollback --to N` on a realizer host now also uninstalls, best-effort, the union of brew refs added by every `backend:"brew"` generation numbered greater than N — alongside the native rollback, which runs first. A per-package brew failure is reported (partial) and never unwinds/aborts the native rollback. Brew uninstalls are recorded in a separate `backend:"brew"` rollback generation.
- **Explicit `--to` required for the brew lane** (symmetric with `--enable-restore`). **Bare rollback stays byte-identical to today** — the nix "previous" anchor is generation-relative and can't be reconciled with interleaved brew generations without an explicit boundary.
- **Brew-only target is valid** (relaxes "no native anchor → not found" only for the brew-composed case).
- **Confirm-gated, dry-run previewable, non-destructive** (no `--zap`); surfaces the untracked-transitive-deps caveat.
- New OpenSpec change `macos-brew-best-effort-rollback` (distinct capability id).
- Extends `scripts/smoke/brew-realbrew-smoke.sh` with a rollback phase (real-brew validation runs in the macOS CI leg).

## Verification

- `go test ./...`, `go vet ./...`, `GOOS=windows go build ./...` — green
- `openspec validate --all --strict` — 72/72
- hm-realnix non-regression smoke — pass
- 7 hermetic tests in `rollback_brew_test.go` (both backend seams overridden), incl. non-regression: a no-brew history never resolves the brew driver.
- Real-brew rollback path is CI-only (the macOS smoke); it can't run on a Linux dev box.

## Out of scope (deferred)

Precise version pinning (brew's pin is weak; verify already reports advisory drift), the invisible Homebrew bootstrap, and bare-rollback brew support.

🤖 Generated with [Claude Code](https://claude.com/claude-code)