### PR TITLE
feat(backup): mutable labels (rename) + device-label create default

### DIFF
--- a/docs/contracts/hosted-backup-contract.md
+++ b/docs/contracts/hosted-backup-contract.md
@@ -343,6 +343,7 @@ All endpoints rate-limited at the substrate edge. Rate limits documented per-end
 
 - `GET /api/backups` → list user's backups: `{ backups: [{ id, name, latestVersionId, versionCount, totalSize, updatedAt }] }`
 - `POST /api/backups` → create a new backup: `{ name }` → `{ backupId }`
+- `PATCH /api/backups/:backupId` → update a backup's mutable metadata (partial body; today `{ name }`) → `{ id, name, updatedAt }`. The id is immutable identity; only the label changes. Future metadata fields extend the body additively. Same read-access gating as DELETE (see below).
 - `DELETE /api/backups/:backupId` → permanently delete a backup and all its versions
 - `GET /api/backups/:backupId/versions` → list versions: `{ versions: [{ versionId, createdAt, size, manifestSha256 }] }`
 - `POST /api/backups/:backupId/versions` → create a new version: `{ encryptedManifest, chunkMetadata: [{ index, encryptedSize, sha256 }] }` → `{ versionId, uploadUrls: [{ chunkIndex, presignedUrl, expiresAt }] }`
@@ -500,7 +501,7 @@ Subscription state is authoritative on the substrate backend. The JWT carries `s
 
 ### Delete operations are NOT subscription-gated
 
-`DELETE /api/backups/:backupId` and `DELETE /api/backups/:backupId/versions/:versionId` are exempt from the write-block rule above. A signed-in user may delete their own backups in any non-`none` state.
+`DELETE /api/backups/:backupId` and `DELETE /api/backups/:backupId/versions/:versionId` are exempt from the write-block rule above. A signed-in user may delete their own backups in any non-`none` state. `PATCH /api/backups/:backupId` (rename) is exempt on the same basis — managing an existing backup's label is allowed in any non-`none` state, and rename is strictly less destructive than delete.
 
 This is a deliberate kindness exception. Three reasons:
 

--- a/go-engine/internal/backup/storage/storage.go
+++ b/go-engine/internal/backup/storage/storage.go
@@ -121,6 +121,32 @@ func (c *Client) DeleteBackup(ctx context.Context, backupID string) *envelope.Er
 	}, nil)
 }
 
+// UpdatedBackup is the response of PATCH /api/backups/:id.
+type UpdatedBackup struct {
+	ID        string `json:"id"`
+	Name      string `json:"name"`
+	UpdatedAt string `json:"updatedAt"`
+}
+
+// UpdateBackup changes a backup's mutable metadata (today only its display
+// name) via PATCH. The backend id is the durable identity and is unchanged;
+// only the label moves.
+func (c *Client) UpdateBackup(ctx context.Context, backupID, name string) (UpdatedBackup, *envelope.Error) {
+	type req struct {
+		Name string `json:"name"`
+	}
+	var out UpdatedBackup
+	if err := c.httpc.Do(ctx, client.Request{
+		Method:   "PATCH",
+		URL:      c.url(ctx, "/" + backupID),
+		Body:     req{Name: name},
+		ReadOnly: false,
+	}, &out); err != nil {
+		return UpdatedBackup{}, err
+	}
+	return out, nil
+}
+
 // VersionInfo is one row of GET /api/backups/:id/versions.
 type VersionInfo struct {
 	VersionID      string `json:"versionId"`

--- a/go-engine/internal/backup/upload/resolve_backup_id_test.go
+++ b/go-engine/internal/backup/upload/resolve_backup_id_test.go
@@ -5,6 +5,7 @@ package upload
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/Artexis10/endstate/go-engine/internal/backup/storage"
@@ -45,7 +46,7 @@ func TestResolveBackupID_NamedPushWithExistingBackupsCreatesNew(t *testing.T) {
 		newID:   "created-gaming",
 	}
 
-	id, err := resolveBackupID(context.Background(), store, "", "gaming-rig")
+	id, err := resolveBackupID(context.Background(), store, "", "gaming-rig", "MACHINE-X")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -64,7 +65,7 @@ func TestResolveBackupID_NamedPushWithExistingBackupsCreatesNew(t *testing.T) {
 func TestResolveBackupID_ExplicitIDUsedVerbatim(t *testing.T) {
 	store := &fakeResolverStore{backups: []storage.Backup{{ID: "existing-1"}}}
 
-	id, err := resolveBackupID(context.Background(), store, "b-123", "ignored-name")
+	id, err := resolveBackupID(context.Background(), store, "b-123", "ignored-name", "MACHINE-X")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -80,7 +81,7 @@ func TestResolveBackupID_ExplicitIDUsedVerbatim(t *testing.T) {
 func TestResolveBackupID_NoNameNoIDAppendsToFirst(t *testing.T) {
 	store := &fakeResolverStore{backups: []storage.Backup{{ID: "first"}, {ID: "second"}}}
 
-	id, err := resolveBackupID(context.Background(), store, "", "")
+	id, err := resolveBackupID(context.Background(), store, "", "", "MACHINE-X")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -92,18 +93,40 @@ func TestResolveBackupID_NoNameNoIDAppendsToFirst(t *testing.T) {
 	}
 }
 
-// No id, no name, no existing backups: create a "default" backup.
-func TestResolveBackupID_NoNameNoIDNoBackupsCreatesDefault(t *testing.T) {
+// No id, no name, no existing backups: create a backup labeled with the
+// injected default (the device label), not the literal "default".
+func TestResolveBackupID_NoNameNoIDNoBackupsCreatesDeviceLabeled(t *testing.T) {
 	store := &fakeResolverStore{backups: nil, newID: "created-default"}
 
-	id, err := resolveBackupID(context.Background(), store, "", "")
+	id, err := resolveBackupID(context.Background(), store, "", "", "DESKTOP-HUGO")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if id != "created-default" {
 		t.Fatalf("expected created default id, got %q", id)
 	}
-	if store.lastCreated != "default" {
-		t.Fatalf("expected default label, got %q", store.lastCreated)
+	if store.lastCreated != "DESKTOP-HUGO" {
+		t.Fatalf("expected the device label as the create name, got %q", store.lastCreated)
+	}
+}
+
+// deviceLabelFrom trims a present host name and falls back to "default" on
+// empty/error — so a missing host name never fails a push.
+func TestDeviceLabelFrom(t *testing.T) {
+	cases := []struct {
+		host string
+		err  error
+		want string
+	}{
+		{"HUGO-DESKTOP", nil, "HUGO-DESKTOP"},
+		{"  Work-Laptop  ", nil, "Work-Laptop"},
+		{"", nil, "default"},
+		{"   ", nil, "default"},
+		{"ignored", errors.New("hostname unavailable"), "default"},
+	}
+	for _, c := range cases {
+		if got := deviceLabelFrom(c.host, c.err); got != c.want {
+			t.Fatalf("deviceLabelFrom(%q, %v) = %q, want %q", c.host, c.err, got, c.want)
+		}
 	}
 }

--- a/go-engine/internal/backup/upload/upload.go
+++ b/go-engine/internal/backup/upload/upload.go
@@ -97,7 +97,7 @@ func PushVersion(ctx context.Context, deps Dependencies, backupID, profilePath, 
 	}
 	defer wipe(dek)
 
-	resolvedBackupID, envErr := resolveBackupID(ctx, deps.Storage, backupID, name)
+	resolvedBackupID, envErr := resolveBackupID(ctx, deps.Storage, backupID, name, deviceLabel())
 	if envErr != nil {
 		return nil, envErr
 	}
@@ -326,8 +326,9 @@ type backupResolverStore interface {
 //     later pushes. (Previously a named push fell through to "append to the
 //     first existing backup", silently ignoring --name once any backup existed.)
 //   - a push with neither id nor name keeps the legacy convenience: append to
-//     the user's first backup, or create a "default" backup if they have none.
-func resolveBackupID(ctx context.Context, store backupResolverStore, backupID, name string) (string, *envelope.Error) {
+//     the user's first backup, or create a backup labeled defaultName (the
+//     device label — see deviceLabel) if they have none.
+func resolveBackupID(ctx context.Context, store backupResolverStore, backupID, name, defaultName string) (string, *envelope.Error) {
 	if strings.TrimSpace(backupID) != "" {
 		return backupID, nil
 	}
@@ -345,11 +346,33 @@ func resolveBackupID(ctx context.Context, store backupResolverStore, backupID, n
 	if len(backups) > 0 {
 		return backups[0].ID, nil
 	}
-	id, cerr := store.CreateBackup(ctx, "default")
+	id, cerr := store.CreateBackup(ctx, defaultName)
 	if cerr != nil {
 		return "", cerr
 	}
 	return id, nil
+}
+
+// deviceLabel returns a human label for this machine's default backup — the
+// OS host name (COMPUTERNAME on Windows), trimmed. Falls back to "default"
+// when the host name is empty or unavailable. The backup's identity is its
+// backend id; this is only the display label, so a missing name is non-fatal
+// and must never fail a push.
+func deviceLabel() string {
+	host, err := os.Hostname()
+	return deviceLabelFrom(host, err)
+}
+
+// deviceLabelFrom is the pure core of deviceLabel, split out so the
+// trim/fallback logic is unit-testable without depending on the host's name.
+func deviceLabelFrom(host string, err error) string {
+	if err != nil {
+		return "default"
+	}
+	if h := strings.TrimSpace(host); h != "" {
+		return h
+	}
+	return "default"
 }
 
 // tarProfile returns the tar archive of the profile's contents. If

--- a/go-engine/internal/commands/backup.go
+++ b/go-engine/internal/commands/backup.go
@@ -99,11 +99,13 @@ func RunBackup(flags BackupFlags) (interface{}, *envelope.Error) {
 		return runBackupEstimate(flags)
 	case "":
 		return nil, envelope.NewError(envelope.ErrInternalError,
-			"backup requires a subcommand (signup, claim, login, logout, status, subscribe, browser-session, push, estimate, pull, list, versions, delete, delete-version, recover)")
+			"backup requires a subcommand (signup, claim, login, logout, status, subscribe, browser-session, push, estimate, pull, list, versions, rename, delete, delete-version, recover)")
 	case "list":
 		return runBackupList(flags)
 	case "versions":
 		return runBackupVersions(flags)
+	case "rename":
+		return runBackupRename(flags)
 	case "delete":
 		return runBackupDelete(flags)
 	case "delete-version":

--- a/go-engine/internal/commands/backup_rename.go
+++ b/go-engine/internal/commands/backup_rename.go
@@ -1,0 +1,45 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"context"
+	"strings"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// RenameResult is the data payload for `backup rename`. It echoes the backup's
+// id (the durable identity, unchanged) and its new label.
+type RenameResult struct {
+	BackupID  string `json:"backupId"`
+	Name      string `json:"name"`
+	UpdatedAt string `json:"updatedAt,omitempty"`
+}
+
+// runBackupRename changes a backup's display label by id. Identity is the
+// backend id; only the human label moves. Today it sets `name`; it is the
+// GUI's entry point for editing backup metadata.
+func runBackupRename(flags BackupFlags) (interface{}, *envelope.Error) {
+	if strings.TrimSpace(flags.BackupID) == "" {
+		return nil, envelope.NewError(envelope.ErrInternalError,
+			"backup rename requires --backup-id <id>")
+	}
+	name := strings.TrimSpace(flags.Name)
+	if name == "" {
+		return nil, envelope.NewError(envelope.ErrInternalError,
+			"backup rename requires a non-empty --name <label>")
+	}
+	st := newBackupStack()
+	updated, err := st.Storage.UpdateBackup(context.Background(), flags.BackupID, name)
+	if err != nil {
+		return nil, err
+	}
+	// The backend echoes the persisted row; report it verbatim (source of truth).
+	return &RenameResult{
+		BackupID:  updated.ID,
+		Name:      updated.Name,
+		UpdatedAt: updated.UpdatedAt,
+	}, nil
+}

--- a/go-engine/internal/commands/backup_rename_test.go
+++ b/go-engine/internal/commands/backup_rename_test.go
@@ -1,0 +1,33 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands_test
+
+import (
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/commands"
+)
+
+// `backup rename` requires both an id (which backup) and a non-empty name
+// (the new label). Both guards fire before any backend call, so they need no
+// stack. The happy path (PATCH round-trip) is covered by the substrate route
+// tests and the GUI live verification.
+func TestBackupRename_RequiresBackupID(t *testing.T) {
+	if _, err := commands.RunBackup(commands.BackupFlags{
+		Subcommand: "rename",
+		Name:       "Gaming Rig",
+	}); err == nil {
+		t.Fatal("expected an error when --backup-id is missing")
+	}
+}
+
+func TestBackupRename_RequiresName(t *testing.T) {
+	if _, err := commands.RunBackup(commands.BackupFlags{
+		Subcommand: "rename",
+		BackupID:   "b-123",
+		Name:       "   ",
+	}); err == nil {
+		t.Fatal("expected an error when --name is blank")
+	}
+}

--- a/go-engine/internal/commands/capabilities.go
+++ b/go-engine/internal/commands/capabilities.go
@@ -58,6 +58,10 @@ type HostedBackupFeature struct {
 	MinSchemaVersion string `json:"minSchemaVersion"`
 	IssuerURL        string `json:"issuerUrl"`
 	Audience         string `json:"audience"`
+	// Rename advertises that the engine supports `backup rename` (mutable
+	// backup labels via PATCH). The GUI gates its rename affordance on this
+	// so it stays hidden against an older engine.
+	Rename bool `json:"rename"`
 }
 
 // PlatformInfo describes the host operating system and available package manager
@@ -149,6 +153,7 @@ func RunCapabilities() (interface{}, *envelope.Error) {
 				MinSchemaVersion: "1.0",
 				IssuerURL:        backup.IssuerURL(),
 				Audience:         backup.Audience(),
+				Rename:           true,
 			},
 		},
 		Platform:           platformInfoFor(runtime.GOOS),

--- a/openspec/changes/backup-rename-and-device-label/design.md
+++ b/openspec/changes/backup-rename-and-device-label/design.md
@@ -1,0 +1,48 @@
+## Context
+
+A backup's identity is its backend-assigned **id** (a UUID returned by `CreateBackup` → substrate). Its `name` is a display label set once at create and never changed — `--name` is only consulted on creation (see `resolveBackupID`), and there is no rename in the storage client or backend. So the GUI's machine auto-backup is stuck at `"This computer"`, and there's no way to relabel.
+
+The GUI must not derive or fabricate a label (thin-presentation-layer contract). So the engine + backend own the label, and the label must be mutable.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Make a backup's label mutable: `backup rename --backup-id <id> --name <label>` → `PATCH /api/backups/:id`.
+- Replace the meaningless `"default"` create label with the device (host) name.
+- Keep the change a reusable foundation: the backend route is a partial-metadata update, so future fields are additive.
+- Keep `resolveBackupID` deterministically unit-testable (inject the default name).
+
+**Non-Goals:**
+- Per-profile auto-backup *unification* (silent + explicit host converging on one backup) — still deferred; it needs a stable manifest-embedded machine/profile id, not just a mutable label.
+- Renaming versions, or any non-`name` metadata field today (the shape allows it; no field is added now — YAGNI).
+- Changing the push-resolution order or the append-to-first convenience.
+- Global name uniqueness (names stay labels; id is the key).
+
+## Decisions
+
+**D1 — Mutable label via a partial-metadata PATCH, exposed as `backup rename`.**
+The backend endpoint is `PATCH /api/backups/:id` taking a partial body (today `{ name }`); the engine wraps it as `Client.UpdateBackup(ctx, id, name)` and the CLI surfaces it as `backup rename`. Rationale: a partial PATCH is the general "update backup metadata" primitive, so adding `description`/`tags`/… later is a column + a field, no new route/command/wrapper. Alternative (a one-off `/rename` route) rejected as narrow.
+
+**D2 — Inject the create-default name into `resolveBackupID`.**
+`resolveBackupID(ctx, store, backupID, name, defaultName)` — the caller passes `deviceLabel()`; tests pass a fixed value. Rationale: calling `os.Hostname()` inside the resolver would make the "create default" unit test machine-dependent. The pure `deviceLabelFrom(host, err)` is unit-tested for the trim/fallback logic.
+
+**D3 — Advertise rename as a capability flag, not a probe.**
+Rename reuses `--backup-id`/`--name`, so the GUI cannot detect it by flag. Add `features.hostedBackup.rename = true`; the GUI gates its rename UI on it.
+
+**D4 — Rename access mirrors delete (backend).**
+The substrate route uses read-access (allowed in any non-`none` subscription state), matching DELETE — rename is strictly less destructive than delete, so gating it harder would be inconsistent. (Specced in the substrate change.)
+
+## Risks / Trade-offs
+
+- **Ugly host names** (`DESKTOP-7F3K2P1`) become the create-default label verbatim. Mitigation: identity is the id; and now that labels are mutable, the user/GUI can rename. (Whether to prettify the Windows auto-generated pattern is deferred — verbatim is simplest and accurate.)
+- **Consumer/backend skew**: the engine emits `PATCH` before substrate deploys it → 405. Mitigation: ship substrate first; the GUI gates on `hostedBackup.rename` + the engine pin. The device-label default is engine-internal and safe regardless.
+- **`os.Hostname()` error** → falls back to `"default"`; never fails a push.
+
+## Migration Plan
+
+Backward-compatible. No data migration: existing backups keep their labels (including legacy `"This computer"`/`"default"`). Only newly-created default-named backups get the device label; rename is opt-in. Order: substrate `PATCH` deploys → engine releases (GUI pin auto-bumps via `engine-drift-check`) → GUI adds the rename affordance. Rollback = revert; the create-default reverts to `"default"` and rename calls 405 (or are hidden by the capability gate).
+
+## Open Questions
+
+- Prettify ugly host names now, or rely on user rename? (Recommend: rely on rename.)
+- Eventually attach a stable machine **id** to the backup (for the deferred unification)? Out of scope here.

--- a/openspec/changes/backup-rename-and-device-label/proposal.md
+++ b/openspec/changes/backup-rename-and-device-label/proposal.md
@@ -1,0 +1,34 @@
+## Why
+
+A hosted backup's **label is write-once**: `name` is set at create (`CreateBackup`) and there is no way to change it afterward — no rename/relabel anywhere in the engine, storage client, or backend. Two consequences:
+
+- The GUI's automatic per-machine backup is stuck showing the misleading `"This computer"` (on a *new* machine, restoring "This computer" is actually your *old* machine), and users cannot name a backup `"Gaming Rig"`.
+- Any baked-in default (e.g. the OS hostname) would be permanent.
+
+The clean fix is to make the label **mutable metadata** decoupled from the immutable backend **id** (a UUID). Identity stays the id; the label becomes editable. With that foundation, a better *default* label (the device/host name) is just the initial value, and future per-backup metadata (description, tags, …) is additive.
+
+## What Changes
+
+- **Mutable metadata via rename** — a new `backup rename --backup-id <id> --name <label>` command, backed by `storage.Client.UpdateBackup` → `PATCH /api/backups/:id` (substrate, separate change). The backend route is a **partial-metadata update**, so future fields extend it without a new endpoint/command.
+- **Device-label create default** — when `backup push` creates a backup with neither `--backup-id` nor `--name` (the path that hardcoded `"default"`), it labels the new backup with the host name (`os.Hostname()`, trimmed), falling back to `"default"` when unavailable. The default-name is injected into `resolveBackupID` so the resolution logic stays unit-testable.
+- **Capability advert** — `capabilities.features.hostedBackup.rename = true`, so the GUI gates its rename affordance on engine support (rename adds no new flag — it reuses `--backup-id`/`--name` — so a flag-based probe wouldn't detect it).
+
+## Capabilities
+
+### New Capabilities
+- `backup-metadata`: a backup's mutable metadata (today: the display label) — how it is changed (`backup rename` → `PATCH`), the device-label create-default, and the capability advert. Identity remains the backend id; only the label moves.
+
+### Modified Capabilities
+<!-- None: backup-push-resolution (from the in-flight backup-push-name-creates-backup change) is not yet in the specs baseline, so the create-default label change is specced here under backup-metadata. The resolution ORDER is unchanged — only the create-default label. -->
+
+## Impact
+
+- `go-engine/internal/backup/storage/storage.go` — `UpdateBackup(ctx, id, name)` + `UpdatedBackup` (PATCH).
+- `go-engine/internal/commands/backup_rename.go` (new) + dispatch/help in `backup.go`.
+- `go-engine/internal/commands/capabilities.go` — `HostedBackupFeature.Rename`.
+- `go-engine/internal/backup/upload/upload.go` — `deviceLabel()` + inject the default into `resolveBackupID`.
+- Tests: `resolve_backup_id_test.go` (device-label default + `deviceLabelFrom`), `backup_rename_test.go` (validation).
+- **Backend dependency (separate `substrate` change, PR open):** `PATCH /api/backups/:id` (`updateBackupOwned` + route). The engine emits `PATCH`; until substrate deploys it the backend returns 405.
+- **Consumer (separate `endstate-gui` change):** a rename affordance gated on `hostedBackup.rename`; auto-backup keeps `"This computer"` until this ships, then relies on the device-label default / lets users rename.
+- Cross-repo contract coupling (engine ↔ substrate ↔ GUI), per `CLAUDE.md`.
+- Backward-compatible: existing backups (incl. legacy `"This computer"`, `"default"`) keep their labels; only newly-created default-named backups get the device label, and rename is opt-in.

--- a/openspec/changes/backup-rename-and-device-label/specs/backup-metadata/spec.md
+++ b/openspec/changes/backup-rename-and-device-label/specs/backup-metadata/spec.md
@@ -1,0 +1,42 @@
+## ADDED Requirements
+
+### Requirement: A backup's label is mutable via rename
+
+The engine SHALL support changing a backup's display label by its id, without affecting the backup's identity (its backend id) or its versions. `backup rename --backup-id <id> --name <label>` SHALL issue `PATCH /api/backups/:id` with the new name and report the persisted result. A missing `--backup-id` or a blank `--name` SHALL be rejected before any backend call.
+
+#### Scenario: Rename changes the label, not the identity
+- **WHEN** `backup rename --backup-id <id> --name "Gaming Rig"` is invoked
+- **THEN** the engine issues `PATCH /api/backups/<id>` with `{ name: "Gaming Rig" }`
+- **AND** returns the backup's unchanged id and its new label
+
+#### Scenario: Rename requires an id
+- **WHEN** `backup rename` is invoked without `--backup-id`
+- **THEN** it fails with a validation error and makes no backend call
+
+#### Scenario: Rename requires a non-empty name
+- **WHEN** `backup rename --backup-id <id> --name "   "` is invoked
+- **THEN** it fails with a validation error and makes no backend call
+
+### Requirement: backup push default name uses the device label
+
+When `backup push` creates a backup because neither `--backup-id` nor `--name` was supplied AND the account has no existing backups, the engine SHALL label the new backup with a device label derived from the OS host name (trimmed), instead of the literal `default`. When the host name is empty or unavailable, it SHALL fall back to `default`; computing the label SHALL NOT fail the push. The push-resolution order is unchanged: explicit `--backup-id` verbatim; non-empty `--name` creates a backup with that name; no-id/no-name with existing backups appends to the first backup.
+
+#### Scenario: Create on an empty account uses the device label
+- **WHEN** `backup push` is invoked with neither `--backup-id` nor `--name`, the account has no backups, and the host name is `HUGO-DESKTOP`
+- **THEN** a new backup labeled `HUGO-DESKTOP` is created, not `default`
+
+#### Scenario: Host name unavailable falls back to default
+- **WHEN** the same create path runs but the host name is empty or errors
+- **THEN** the new backup is labeled `default` and the push still succeeds
+
+#### Scenario: Explicit name is still honored verbatim
+- **WHEN** `backup push --name <label>` is invoked
+- **THEN** the new backup is labeled `<label>` (the device label is not substituted)
+
+### Requirement: Rename support is advertised as a capability
+
+The capabilities envelope SHALL advertise rename support so a client can gate its rename affordance against engine support. Rename reuses existing flags (`--backup-id`, `--name`), so it SHALL be advertised as an explicit feature flag rather than relied upon to be probed via the flag list.
+
+#### Scenario: Capabilities advertises rename
+- **WHEN** a client invokes `capabilities --json`
+- **THEN** `features.hostedBackup.rename` is `true`

--- a/openspec/changes/backup-rename-and-device-label/tasks.md
+++ b/openspec/changes/backup-rename-and-device-label/tasks.md
@@ -1,0 +1,30 @@
+## 1. Rename: storage client + command
+
+- [x] 1.1 `storage.Client.UpdateBackup(ctx, backupID, name)` + `UpdatedBackup{id,name,updatedAt}` → `PATCH /api/backups/:id` with `{name}`
+- [x] 1.2 `backup rename` command (`backup_rename.go`): validate `--backup-id` + non-empty `--name`, delegate to `UpdateBackup`, report the server-echoed row
+- [x] 1.3 Dispatch + help: add `rename` to `RunBackup`'s switch and the subcommand list in `backup.go`
+- [x] 1.4 Validation tests (`backup_rename_test.go`): missing id, blank name (no backend call)
+
+## 2. Device-label create default
+
+- [x] 2.1 `deviceLabel()` (`upload.go`) = trimmed `os.Hostname()`, fallback `"default"`, never errors; pure `deviceLabelFrom(host, err)` split out for tests
+- [x] 2.2 Inject the default into `resolveBackupID(ctx, store, backupID, name, defaultName)`; call site passes `deviceLabel()`; resolution order unchanged
+- [x] 2.3 Tests: create-default uses the injected label (not `"default"`); `deviceLabelFrom` trim/fallback table
+
+## 3. Capability advert
+
+- [x] 3.1 `HostedBackupFeature.Rename bool` (`capabilities.go`), set `true`; GUI gates its rename UI on it
+
+## 4. Verify & release
+
+- [x] 4.1 `go build ./...`, `go vet ./internal/backup/... ./internal/commands/...`, `go test ./internal/backup/... ./internal/commands/...` green
+- [x] 4.2 CLI smoke: `backup rename` (no args) → validation error; with `--backup-id`+`--name` → reaches backend (405 until substrate deploys), proving dispatch + flag parsing
+- [x] 4.3 `openspec validate backup-rename-and-device-label --strict`
+- [ ] 4.4 Merge → release-please cuts the engine release; GUI `ENGINE_VERSION` pin auto-bumps via `engine-drift-check`
+
+## 5. Cross-repo
+
+- [x] 5.1 Backend: `PATCH /api/backups/:id` (substrate change — PR open; deploy before the engine release is consumed)
+- [x] 5.2 Update the hosted-backup contract doc with the PATCH endpoint + read-access gating note
+- [ ] 5.3 GUI follow-up (separate `endstate-gui` change): `backupRename` bridge + rename affordance gated on `hostedBackup.rename`; auto-backup relies on the device-label default
+- [ ] 5.4 (Deferred) per-profile auto-backup unification — needs a stable machine/profile id (engine), tracked separately


### PR DESCRIPTION
## Why

A backup's label was **write-once**: `name` is set at create and there was no way to change it (no rename in the engine, storage client, or backend). So the GUI's automatic per-machine backup is stuck showing the misleading `"This computer"` (on a *new* machine that's actually your *old* machine), and users can't name a backup `"Gaming Rig"`. This makes the label **mutable metadata**, decoupled from the immutable backend **id** (a UUID).

Stage 2 of 3 (substrate → **engine** → GUI). Depends on the substrate `PATCH /api/backups/:id` endpoint (separate PR) — the engine emits `PATCH` and gets **405** until substrate deploys.

## What changes

- **`storage.Client.UpdateBackup(ctx, id, name)`** → `PATCH /api/backups/:id`; `UpdatedBackup{id,name,updatedAt}`. The id is identity; only the label moves.
- **`backup rename --backup-id <id> --name <label>`** command — validates id + non-empty name, reports the server-echoed row.
- **`features.hostedBackup.rename = true`** so the GUI can gate its rename affordance (rename reuses `--backup-id`/`--name`, so a flag probe can't detect it).
- **Device-label create default**: the no-id/no-name `backup push` create path now labels the new backup with the trimmed `os.Hostname()` (fallback `"default"`) instead of the literal `"default"`. The default-name is **injected** into `resolveBackupID` so the resolver stays deterministically testable; pure `deviceLabelFrom(host, err)` is unit-tested for trim/fallback.

## Foundation, not a one-off

The backend route is a **partial-metadata PATCH**, so future fields (`description`, `tags`, …) are additive — no new route, command, or client wrapper.

## Verification

`go build ./...`, `go vet`, `go test ./internal/backup/... ./internal/commands/...` green (updated resolve test + new `deviceLabelFrom` + rename validation tests). CLI smoke: `backup rename` with no args → validation error (dispatch works); with `--backup-id`+`--name` → reaches the backend and gets 405 (production substrate lacks PATCH until its PR deploys), confirming flag parsing + dispatch. OpenSpec `backup-rename-and-device-label` validates `--strict`. Hosted-backup contract doc updated (PATCH endpoint + read-access gating).

🤖 Generated with [Claude Code](https://claude.com/claude-code)