### PR TITLE
feat(bootstrap): engine-installed backend bootstrap (Nix/Homebrew) — the zero-prerequisites keystone

### DIFF
--- a/go-engine/cmd/endstate/main.go
+++ b/go-engine/cmd/endstate/main.go
@@ -124,17 +124,19 @@ type parsedArgs struct {
 	runID  string
 
 	// Backup / account flags
-	email          string
-	token          string
-	backupID       string
-	versionID      string
-	to             string
-	confirm        bool
-	prune          bool // apply --prune: converge to the exact declared set
-	repin          bool // apply --repin: reinstall a drifted declared App.Version
-	saveRecoveryTo string
-	overwrite      bool
-	ifChanged      bool
+	email             string
+	token             string
+	backupID          string
+	versionID         string
+	to                string
+	confirm           bool
+	prune             bool // apply --prune: converge to the exact declared set
+	repin             bool // apply --repin: reinstall a drifted declared App.Version
+	bootstrapBackends bool // apply --bootstrap-backends: install an absent backend (consented)
+	noBootstrap       bool // apply --no-bootstrap: skip an absent backend rather than install
+	saveRecoveryTo    string
+	overwrite         bool
+	ifChanged         bool
 
 	// Positional args after command (used by profile / backup / account subcommands)
 	positionalArgs []string
@@ -188,6 +190,10 @@ func parseArgs(args []string) parsedArgs {
 			p.prune = true
 		case "--repin":
 			p.repin = true
+		case "--bootstrap-backends":
+			p.bootstrapBackends = true
+		case "--no-bootstrap":
+			p.noBootstrap = true
 		case "--overwrite":
 			p.overwrite = true
 		case "--if-changed":
@@ -304,7 +310,7 @@ func commandUsage(cmd string) string {
 	case "capabilities":
 		return "Usage: endstate capabilities [--json]\n\nReport CLI capabilities for GUI handshake.\n"
 	case "apply":
-		return "Usage: endstate apply [--manifest <path>] [--dry-run] [--enable-restore] [--prune] [--repin] [--confirm] [--json] [--events jsonl]\n\nExecute provisioning plan. With --prune, converge the engine-managed set to exactly the manifest by removing installed-but-undeclared packages (realizer backends only, e.g. Nix on Linux/macOS). With --repin, reinstall a declared app version when the installed version has drifted from it (winget only). --prune and --repin both require --confirm to execute; use --dry-run to preview what would change.\n"
+		return "Usage: endstate apply [--manifest <path>] [--dry-run] [--enable-restore] [--prune] [--repin] [--confirm] [--bootstrap-backends] [--no-bootstrap] [--json] [--events jsonl]\n\nExecute provisioning plan. With --prune, converge the engine-managed set to exactly the manifest by removing installed-but-undeclared packages (realizer backends only, e.g. Nix on Linux/macOS). With --repin, reinstall a declared app version when the installed version has drifted from it (winget only). --prune and --repin both require --confirm to execute; use --dry-run to preview what would change. On macOS/Linux, when a needed package backend is absent, --bootstrap-backends authorizes the engine to install it via its official installer; --no-bootstrap forces skipping it. Without either flag the engine skips the lane and requests consent.\n"
 	case "verify":
 		return "Usage: endstate verify [--manifest <path>] [--json] [--events jsonl]\n\nVerify machine state against manifest.\n"
 	case "capture":
@@ -415,15 +421,17 @@ func dispatch(p parsedArgs) (interface{}, *envelope.Error) {
 
 	case "apply":
 		return commands.RunApply(commands.ApplyFlags{
-			Manifest:      p.manifest,
-			DryRun:        p.dryRun,
-			EnableRestore: p.enableRestore,
-			Events:        p.events,
-			Export:        p.export,
-			RestoreFilter: p.restoreFilter,
-			Prune:         p.prune,
-			Confirm:       p.confirm,
-			Repin:         p.repin,
+			Manifest:          p.manifest,
+			DryRun:            p.dryRun,
+			EnableRestore:     p.enableRestore,
+			Events:            p.events,
+			Export:            p.export,
+			RestoreFilter:     p.restoreFilter,
+			Prune:             p.prune,
+			Confirm:           p.confirm,
+			Repin:             p.repin,
+			BootstrapBackends: p.bootstrapBackends,
+			NoBootstrap:       p.noBootstrap,
 		})
 
 	case "verify":

--- a/go-engine/internal/bootstrap/bootstrap.go
+++ b/go-engine/internal/bootstrap/bootstrap.go
@@ -1,0 +1,231 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+// Package bootstrap implements the backend-agnostic "the engine installs its own
+// package backend when it is absent" contract: detect → consent → official
+// install → verify → proceed-or-decline. It is the mechanism layer; the consent
+// decision (flags + the streamed consent-request event) is orchestrated by the
+// commands package. The detect/install/verify steps are injectable seams so the
+// contract is hermetically testable — NO real installer ever runs in `go test`
+// (the install path can only be validated on a real clean machine, not reasoned
+// about in CI; the same lesson the winget driver learned for real command output).
+package bootstrap
+
+import (
+	"os"
+	"os/exec"
+)
+
+// Backend identifies a package backend the engine can bootstrap on macOS/Linux.
+// Windows is never bootstrapped (winget ships with the OS).
+type Backend string
+
+const (
+	// BackendBrew is the Homebrew driver (darwin `driver: "brew"` lane).
+	BackendBrew Backend = "brew"
+	// BackendNix is the Nix realizer (the cross-OS default lane).
+	BackendNix Backend = "nix"
+)
+
+// Outcome is the per-backend result of Provision (install + verify).
+type Outcome int
+
+const (
+	// OutcomeInstalled means the official installer ran and the verify probe
+	// passed: the backend is available for use.
+	OutcomeInstalled Outcome = iota
+	// OutcomeInstallFailed means the official installer returned an error; verify
+	// was not attempted. The backend is unavailable.
+	OutcomeInstallFailed
+	// OutcomeVerifyFailed means the installer completed but the verify probe did
+	// not confirm a working backend. The backend is treated as unavailable rather
+	// than used half-configured (verification-first: "exit 0" is not success).
+	OutcomeVerifyFailed
+)
+
+// Available reports whether a Provision outcome leaves the backend usable. Only a
+// freshly-installed-and-verified backend is available; an install or verify
+// failure is not.
+func (o Outcome) Available() bool { return o == OutcomeInstalled }
+
+// Bootstrapper runs the detect/install/verify contract for a set of backends
+// behind injectable seams. New() wires the real seams; tests construct a
+// Bootstrapper with fakes and never touch a real installer.
+type Bootstrapper struct {
+	// Detect reports whether a backend is already present and working.
+	Detect func(b Backend) (present bool, err error)
+	// Install shells the backend's OFFICIAL upstream installer. It is the only
+	// place a privileged installer is run, and it is never called under `go test`.
+	Install func(b Backend) error
+	// Verify runs the backend's post-install probe (e.g. `<backend> --version`).
+	Verify func(b Backend) (ok bool, err error)
+}
+
+// New returns a Bootstrapper wired to the real detect/install/verify seams.
+func New() *Bootstrapper {
+	return &Bootstrapper{
+		Detect:  realDetect,
+		Install: realInstall,
+		Verify:  realVerify,
+	}
+}
+
+// Probe detects each needed backend and partitions the set into absent (needs
+// install) and present (already working), preserving input order. A detect error
+// is treated as absent: the engine would rather offer to install than wrongly
+// assume a backend is present and then hard-fail mid-run.
+func (bs *Bootstrapper) Probe(needed []Backend) (absent, present []Backend) {
+	for _, b := range needed {
+		ok, err := bs.Detect(b)
+		if err == nil && ok {
+			present = append(present, b)
+		} else {
+			absent = append(absent, b)
+		}
+	}
+	return absent, present
+}
+
+// Provision installs and verifies each given backend, returning a per-backend
+// Outcome. It is called ONLY after consent has been granted for the combined set.
+// Each backend is independent: install error → OutcomeInstallFailed (verify
+// skipped); installer ok but verify not-working/error → OutcomeVerifyFailed;
+// install ok and verify ok → OutcomeInstalled.
+func (bs *Bootstrapper) Provision(absent []Backend) map[Backend]Outcome {
+	out := make(map[Backend]Outcome, len(absent))
+	for _, b := range absent {
+		if err := bs.Install(b); err != nil {
+			out[b] = OutcomeInstallFailed
+			continue
+		}
+		ok, err := bs.Verify(b)
+		if err != nil || !ok {
+			out[b] = OutcomeVerifyFailed
+			continue
+		}
+		out[b] = OutcomeInstalled
+	}
+	return out
+}
+
+// ConsentMessage returns the plain-language, product-neutral consent ask for a
+// combined set of absent backends. It deliberately names NO backend product
+// ("Nix"/"Homebrew") — the concepts stay invisible — while staying honest about
+// the privileged footprint (an administrator password, a background helper, a
+// dedicated storage area) and pointing at the inspectable details for the exact
+// commands. The product names live only in the Details (InstallerCommand).
+func ConsentMessage(absent []Backend) string {
+	noun := "the tool it uses"
+	if len(absent) > 1 {
+		noun = "the tools it uses"
+	}
+	return "Endstate needs to set up " + noun + " to install and configure your software. " +
+		"You may be asked for your administrator password, and a background helper and a dedicated " +
+		"storage area may be created. See the details for the exact commands that will run."
+}
+
+// InstallerCommand returns the exact, inspectable command the engine would run to
+// install the given backend via its OFFICIAL upstream installer. It is surfaced
+// in the consent-request event's details so a user who looks can see precisely
+// what the privileged step does. The engine orchestrates these — it never
+// vendors, forks, or re-implements them.
+func InstallerCommand(b Backend) string {
+	switch b {
+	case BackendBrew:
+		// The official Homebrew installer (https://brew.sh).
+		return `/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`
+	case BackendNix:
+		// The official Determinate Nix installer, multi-user (matches CI's
+		// DeterminateSystems/nix-installer-action). --no-confirm because the
+		// engine owns the single up-front consent.
+		return `curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm`
+	default:
+		return ""
+	}
+}
+
+// --- Real seams (never exercised under `go test`; validated on a real machine) ---
+
+// realDetect reports whether a backend's binary is present and runnable. It
+// checks PATH first, then the backend's well-known default install locations
+// (so a backend installed this session but not yet on the shell PATH still reads
+// as present).
+func realDetect(b Backend) (bool, error) {
+	bin := string(b) // "brew" / "nix"
+	if _, err := exec.LookPath(bin); err == nil {
+		return true, nil
+	}
+	for _, p := range knownBinPaths(b) {
+		if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// knownBinPaths returns the well-known absolute binary locations for a backend,
+// covering the case where the backend is installed but not yet on PATH.
+func knownBinPaths(b Backend) []string {
+	switch b {
+	case BackendBrew:
+		return []string{
+			"/opt/homebrew/bin/brew",              // Apple Silicon macOS
+			"/usr/local/bin/brew",                 // Intel macOS
+			"/home/linuxbrew/.linuxbrew/bin/brew", // Linuxbrew
+		}
+	case BackendNix:
+		return []string{"/nix/var/nix/profiles/default/bin/nix"} // Determinate default
+	default:
+		return nil
+	}
+}
+
+// realInstall shells the backend's official installer, wiring the process stdio
+// through so the OS credential / Xcode-CLT prompts the installer forces are NOT
+// suppressed (the user answers them directly). It is the only privileged step
+// and is never called in tests.
+func realInstall(b Backend) error {
+	var cmd *exec.Cmd
+	switch b {
+	case BackendBrew:
+		cmd = exec.Command("/bin/bash", "-c",
+			`/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"`)
+	case BackendNix:
+		cmd = exec.Command("/bin/sh", "-c",
+			`curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm`)
+	default:
+		return os.ErrInvalid
+	}
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stderr // installer chatter is diagnostics, not the JSON envelope on stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// realVerify confirms a freshly-installed backend actually works by running its
+// version command. "Installer exited 0" is not success — the probe is.
+func realVerify(b Backend) (bool, error) {
+	bin := resolveBin(b)
+	if bin == "" {
+		return false, nil
+	}
+	if err := exec.Command(bin, "--version").Run(); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+// resolveBin returns a runnable path for a backend's binary: PATH first, then the
+// known default locations (a just-installed backend may not be on PATH yet).
+func resolveBin(b Backend) string {
+	bin := string(b)
+	if p, err := exec.LookPath(bin); err == nil {
+		return p
+	}
+	for _, p := range knownBinPaths(b) {
+		if fi, err := os.Stat(p); err == nil && !fi.IsDir() {
+			return p
+		}
+	}
+	return ""
+}

--- a/go-engine/internal/bootstrap/bootstrap_test.go
+++ b/go-engine/internal/bootstrap/bootstrap_test.go
@@ -1,0 +1,167 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package bootstrap
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// Probe partitions a needed set into present (detected working) and absent
+// (needs install), preserving input order.
+func TestProbe_PartitionsPresentAndAbsent(t *testing.T) {
+	bs := &Bootstrapper{
+		Detect: func(b Backend) (bool, error) { return b == BackendBrew, nil }, // brew present, nix absent
+	}
+	absent, present := bs.Probe([]Backend{BackendBrew, BackendNix})
+	if len(present) != 1 || present[0] != BackendBrew {
+		t.Fatalf("present = %v, want [brew]", present)
+	}
+	if len(absent) != 1 || absent[0] != BackendNix {
+		t.Fatalf("absent = %v, want [nix]", absent)
+	}
+}
+
+// A detect error is treated as absent: we would rather offer to install than
+// wrongly assume a backend is present and then hard-fail mid-run.
+func TestProbe_DetectErrorTreatedAsAbsent(t *testing.T) {
+	bs := &Bootstrapper{
+		Detect: func(b Backend) (bool, error) { return false, errors.New("boom") },
+	}
+	absent, present := bs.Probe([]Backend{BackendBrew})
+	if len(present) != 0 {
+		t.Fatalf("present = %v, want []", present)
+	}
+	if len(absent) != 1 || absent[0] != BackendBrew {
+		t.Fatalf("absent = %v, want [brew]", absent)
+	}
+}
+
+// Install then a passing verify yields OutcomeInstalled, and verify runs only
+// after install.
+func TestProvision_InstallThenVerifySucceeds(t *testing.T) {
+	var calls []string
+	bs := &Bootstrapper{
+		Install: func(b Backend) error { calls = append(calls, "install:"+string(b)); return nil },
+		Verify:  func(b Backend) (bool, error) { calls = append(calls, "verify:"+string(b)); return true, nil },
+	}
+	out := bs.Provision([]Backend{BackendBrew})
+	if out[BackendBrew] != OutcomeInstalled {
+		t.Fatalf("outcome = %v, want Installed", out[BackendBrew])
+	}
+	if strings.Join(calls, ",") != "install:brew,verify:brew" {
+		t.Fatalf("calls = %v, want [install:brew verify:brew]", calls)
+	}
+}
+
+// An install error is OutcomeInstallFailed and verify is never attempted.
+func TestProvision_InstallErrorSkipsVerify(t *testing.T) {
+	verifyCalled := false
+	bs := &Bootstrapper{
+		Install: func(b Backend) error { return errors.New("install failed") },
+		Verify:  func(b Backend) (bool, error) { verifyCalled = true; return true, nil },
+	}
+	out := bs.Provision([]Backend{BackendBrew})
+	if out[BackendBrew] != OutcomeInstallFailed {
+		t.Fatalf("outcome = %v, want InstallFailed", out[BackendBrew])
+	}
+	if verifyCalled {
+		t.Fatal("verify must not be called after an install error")
+	}
+}
+
+// Installer exits 0 but the verify probe reports not-working → VerifyFailed
+// (the backend is unavailable, never used half-configured).
+func TestProvision_VerifyFalseIsVerifyFailed(t *testing.T) {
+	bs := &Bootstrapper{
+		Install: func(b Backend) error { return nil },
+		Verify:  func(b Backend) (bool, error) { return false, nil },
+	}
+	out := bs.Provision([]Backend{BackendBrew})
+	if out[BackendBrew] != OutcomeVerifyFailed {
+		t.Fatalf("outcome = %v, want VerifyFailed", out[BackendBrew])
+	}
+}
+
+// A verify probe error is also VerifyFailed (unavailable).
+func TestProvision_VerifyErrorIsVerifyFailed(t *testing.T) {
+	bs := &Bootstrapper{
+		Install: func(b Backend) error { return nil },
+		Verify:  func(b Backend) (bool, error) { return false, errors.New("probe error") },
+	}
+	out := bs.Provision([]Backend{BackendBrew})
+	if out[BackendBrew] != OutcomeVerifyFailed {
+		t.Fatalf("outcome = %v, want VerifyFailed", out[BackendBrew])
+	}
+}
+
+// Each backend in a combined set gets its own independent outcome.
+func TestProvision_MultipleBackendsIndependentOutcomes(t *testing.T) {
+	bs := &Bootstrapper{
+		Install: func(b Backend) error {
+			if b == BackendNix {
+				return errors.New("nix install failed")
+			}
+			return nil
+		},
+		Verify: func(b Backend) (bool, error) { return true, nil },
+	}
+	out := bs.Provision([]Backend{BackendBrew, BackendNix})
+	if out[BackendBrew] != OutcomeInstalled {
+		t.Fatalf("brew outcome = %v, want Installed", out[BackendBrew])
+	}
+	if out[BackendNix] != OutcomeInstallFailed {
+		t.Fatalf("nix outcome = %v, want InstallFailed", out[BackendNix])
+	}
+}
+
+// Only a freshly-installed-and-verified backend is "available".
+func TestOutcome_AvailableOnlyWhenInstalled(t *testing.T) {
+	if !OutcomeInstalled.Available() {
+		t.Fatal("Installed must be available")
+	}
+	if OutcomeInstallFailed.Available() || OutcomeVerifyFailed.Available() {
+		t.Fatal("failed outcomes must not be available")
+	}
+}
+
+// The inspectable details for the consent event come from InstallerCommand:
+// they must name the OFFICIAL installer for each backend.
+func TestInstallerCommand_NamesOfficialInstaller(t *testing.T) {
+	brewCmd := InstallerCommand(BackendBrew)
+	if !strings.Contains(brewCmd, "install.sh") || !strings.Contains(strings.ToLower(brewCmd), "homebrew") {
+		t.Fatalf("brew installer command %q must reference the official Homebrew install.sh", brewCmd)
+	}
+	nixCmd := InstallerCommand(BackendNix)
+	if !strings.Contains(strings.ToLower(nixCmd), "determinate") {
+		t.Fatalf("nix installer command %q must reference the Determinate installer", nixCmd)
+	}
+}
+
+// The plain-language consent message must NOT name any backend product — the
+// concepts stay invisible. (Product names live only in the inspectable Details.)
+func TestConsentMessage_NamesNoBackendProduct(t *testing.T) {
+	for _, set := range [][]Backend{{BackendBrew}, {BackendNix}, {BackendBrew, BackendNix}} {
+		msg := strings.ToLower(ConsentMessage(set))
+		for _, banned := range []string{"nix", "homebrew", "brew", "determinate"} {
+			if strings.Contains(msg, banned) {
+				t.Fatalf("consent message for %v must not name product %q: %q", set, banned, msg)
+			}
+		}
+		if msg == "" {
+			t.Fatalf("consent message for %v is empty", set)
+		}
+	}
+}
+
+// New wires the real seams (so production uses real detect/install/verify), but
+// no test ever calls Provision on it — the real installer must never run in
+// `go test`.
+func TestNew_WiresRealSeams(t *testing.T) {
+	bs := New()
+	if bs.Detect == nil || bs.Install == nil || bs.Verify == nil {
+		t.Fatal("New must wire all three real seams")
+	}
+}

--- a/go-engine/internal/commands/apply.go
+++ b/go-engine/internal/commands/apply.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/Artexis10/endstate/go-engine/internal/bootstrap"
 	"github.com/Artexis10/endstate/go-engine/internal/config"
 	"github.com/Artexis10/endstate/go-engine/internal/driver"
 	"github.com/Artexis10/endstate/go-engine/internal/envelope"
@@ -71,6 +72,14 @@ type ApplyFlags struct {
 	// already-installed drifted version. Winget-only; requires --confirm (unless
 	// --dry-run). The realizer path ignores it (Nix pins via its ref).
 	Repin bool
+	// BootstrapBackends (--bootstrap-backends) authorizes the engine to install an
+	// absent package backend (the Nix realizer / Homebrew driver) on macOS/Linux
+	// via its official installer. Consent for the backend-bootstrap pre-step.
+	BootstrapBackends bool
+	// NoBootstrap (--no-bootstrap) forces the backend-bootstrap pre-step to skip an
+	// absent backend's lane rather than install it. Takes precedence over
+	// BootstrapBackends.
+	NoBootstrap bool
 }
 
 // RestoreModuleRef identifies a config module available for restore, including
@@ -227,8 +236,20 @@ func RunApply(flags ApplyFlags) (interface{}, *envelope.Error) {
 		// ErrNoBrewDriver, leaving brewDrv nil → the lane visibly skips brew apps.
 		var brewDrv driver.Driver
 		if len(brewApps) > 0 {
-			if d, berr := newBrewDriverFn(); berr == nil {
-				brewDrv = d
+			// Backend-bootstrap pre-step IN FRONT of the brew factory gate: apply is
+			// mutating, so an absent+consented brew backend is installed via its
+			// official installer and verified before use. Absent+declined (or a
+			// non-darwin host) leaves brewDrv nil → the existing visible-skip path
+			// (apply_brew.go), so a present brew backend or a no-brew manifest stays
+			// byte-identical to today.
+			avail, berr := bootstrapBackendsFn([]bootstrap.Backend{bootstrap.BackendBrew}, true, bootstrapConsent(flags), emitter)
+			if berr != nil {
+				return nil, berr
+			}
+			if avail[bootstrap.BackendBrew] {
+				if d, derr := newBrewDriverFn(); derr == nil {
+					brewDrv = d
+				}
 			}
 		}
 		rzMf := *mf

--- a/go-engine/internal/commands/apply.go
+++ b/go-engine/internal/commands/apply.go
@@ -227,34 +227,52 @@ func RunApply(flags ApplyFlags) (interface{}, *envelope.Error) {
 		// ErrNoBackend on darwin). Partition AFTER SynthesizeAppsFromModules so
 		// synthesized manual apps land in the realizer (rest) lane. The realizer
 		// receives a shallow manifest copy carrying ONLY restApps — it never sees
-		// a brew/`cask:` ref. The brew driver is resolved additively (nil on a
-		// non-darwin host → the brew lane visibly skips each brew app).
+		// a brew/`cask:` ref.
 		brewApps, restApps := partitionBrewLane(mf.Apps)
-		// Resolve the brew driver ONLY when at least one app routes to brew, so a
-		// no-brew manifest never even touches newBrewDriverFn (the realizer-only
-		// path stays byte-identical to today). A non-darwin host returns
-		// ErrNoBrewDriver, leaving brewDrv nil → the lane visibly skips brew apps.
+
+		// Backend-bootstrap pre-step IN FRONT of the factory gate, with ONE combined
+		// consent over every backend this run needs and lacks. The realizer (Nix) is
+		// needed when there is realizer-lane work (restApps) or a home-manager config
+		// stage; brew is needed when an app routes to the brew lane. apply is mutating,
+		// so an absent+consented backend is installed via its official installer and
+		// verified before use. A backend not bootstrappable on the host (brew off
+		// darwin, anything on Windows) is filtered out by the pre-step and resolves via
+		// the existing factory gate (which no-ops it) unchanged.
+		nixNeeded := len(restApps) > 0 || configStageApplies(flags, mf)
+		brewNeeded := len(brewApps) > 0
+		needed := make([]bootstrap.Backend, 0, 2)
+		if nixNeeded {
+			needed = append(needed, bootstrap.BackendNix)
+		}
+		if brewNeeded {
+			needed = append(needed, bootstrap.BackendBrew)
+		}
+		avail, berr := bootstrapBackendsFn(needed, true, bootstrapConsent(flags), emitter)
+		if berr != nil {
+			return nil, berr
+		}
+
+		// Brew driver resolves only when brew is needed AND available; absent+declined
+		// (or a non-darwin host) leaves brewDrv nil → the existing visible-skip path.
 		var brewDrv driver.Driver
-		if len(brewApps) > 0 {
-			// Backend-bootstrap pre-step IN FRONT of the brew factory gate: apply is
-			// mutating, so an absent+consented brew backend is installed via its
-			// official installer and verified before use. Absent+declined (or a
-			// non-darwin host) leaves brewDrv nil → the existing visible-skip path
-			// (apply_brew.go), so a present brew backend or a no-brew manifest stays
-			// byte-identical to today.
-			avail, berr := bootstrapBackendsFn([]bootstrap.Backend{bootstrap.BackendBrew}, true, bootstrapConsent(flags), emitter)
-			if berr != nil {
-				return nil, berr
-			}
-			if avail[bootstrap.BackendBrew] {
-				if d, derr := newBrewDriverFn(); derr == nil {
-					brewDrv = d
-				}
+		if brewNeeded && avail[bootstrap.BackendBrew] {
+			if d, derr := newBrewDriverFn(); derr == nil {
+				brewDrv = d
 			}
 		}
-		rzMf := *mf
-		rzMf.Apps = restApps
-		return runApplyRealizer(flags, &rzMf, rz, emitter, runID, configModuleMap, restoreModulesAvailable, brewApps, brewDrv)
+
+		// Route on realizer availability. When Nix is needed AND available, the
+		// whole-set realizer path runs (byte-identical to today; brew interleaves).
+		// When Nix is NOT needed, or is needed but unavailable (declined/failed), the
+		// realizer lane is skipped and the brew lane runs standalone — so a declined
+		// Nix with a consented brew still installs the brew apps, and the run never
+		// aborts with a half-done apply.
+		if nixNeeded && avail[bootstrap.BackendNix] {
+			rzMf := *mf
+			rzMf.Apps = restApps
+			return runApplyRealizer(flags, &rzMf, rz, emitter, runID, configModuleMap, restoreModulesAvailable, brewApps, brewDrv)
+		}
+		return runApplyBrewOnly(flags, mf, restApps, brewApps, brewDrv, emitter, runID, configModuleMap, restoreModulesAvailable)
 	}
 
 	// Convergence (--prune) is realizer-only. The driver path (winget) operates on

--- a/go-engine/internal/commands/apply_brew.go
+++ b/go-engine/internal/commands/apply_brew.go
@@ -12,20 +12,31 @@ import (
 	"github.com/Artexis10/endstate/go-engine/internal/manifest"
 )
 
-// partitionBrewLane splits a synthesized app set into the brew lane (apps that
-// declare driver:"brew", case-insensitively) and the rest (everything the Nix
-// realizer owns). Order is preserved within each lane so the event stream and
-// recorded actions stay deterministic. The realizer is always handed restApps —
-// it NEVER sees a brew/`cask:` ref.
+// partitionBrewLane splits a synthesized app set into the brew lane and the rest
+// (everything the Nix realizer owns). An app routes to the brew lane when it
+// declares driver:"brew" (case-insensitively) OR its darwin ref is a Homebrew
+// Cask (cask: prefix) — the cask: prefix is an unambiguous "this is a GUI app"
+// signal, so a Cask routes to brew BY DEFAULT without the user also declaring
+// driver:"brew" (brew-default-for-apps). Order is preserved within each lane so
+// the event stream and recorded actions stay deterministic. The realizer is
+// always handed restApps — it NEVER sees a brew/`cask:` ref; this routing (not a
+// manifest rejection) is what upholds that invariant.
 func partitionBrewLane(apps []manifest.App) (brewApps, restApps []manifest.App) {
 	for _, app := range apps {
-		if strings.EqualFold(app.Driver, "brew") {
+		if strings.EqualFold(app.Driver, "brew") || isCaskRef(app.Refs["darwin"]) {
 			brewApps = append(brewApps, app)
 		} else {
 			restApps = append(restApps, app)
 		}
 	}
 	return brewApps, restApps
+}
+
+// isCaskRef reports whether a darwin ref is a Homebrew Cask (cask: prefix). It
+// mirrors the brew driver's caskPrefix and the manifest validator's
+// brewCaskPrefix; kept local so the routing has no cross-package dependency.
+func isCaskRef(darwinRef string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(darwinRef)), "cask:")
 }
 
 // brewLane is the interleaved, best-effort brew install lane that runs ALONGSIDE

--- a/go-engine/internal/commands/apply_brew_only.go
+++ b/go-engine/internal/commands/apply_brew_only.go
@@ -1,0 +1,173 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/Artexis10/endstate/go-engine/internal/driver"
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/events"
+	"github.com/Artexis10/endstate/go-engine/internal/manifest"
+)
+
+// configStageApplies reports whether the home-manager config stage would run this
+// apply: it is realizer-only and gated by --enable-restore plus a declared
+// home-manager input. It mirrors resolveHomeFlake's guard and is used to decide
+// whether the Nix backend is NEEDED (so an absent Nix is offered for bootstrap).
+func configStageApplies(flags ApplyFlags, mf *manifest.Manifest) bool {
+	return flags.EnableRestore && mf.HomeManager != nil
+}
+
+// runApplyBrewOnly is the apply path taken when the Nix realizer lane is NOT
+// available — either not needed (no realizer-lane apps and no config stage) or
+// needed but unavailable (the user declined the Nix bootstrap, or it failed). It
+// runs the brew lane standalone and surfaces any realizer-lane apps as visible
+// skips, so a declined Nix with a consented brew still installs the brew apps and
+// the run never aborts with a half-done apply.
+//
+// It is deliberately separate from runApplyRealizer (which REQUIRES a working
+// realizer): the present-Nix path stays byte-identical, and this path is purely
+// additive. Manual apps (backend-independent verifyPath checks) are still
+// evaluated; only true Nix-ref apps are skipped as backend-unavailable. The
+// home-manager config stage cannot run without the realizer and is therefore
+// skipped here.
+func runApplyBrewOnly(flags ApplyFlags, mf *manifest.Manifest, restApps, brewApps []manifest.App, brewDrv driver.Driver, emitter *events.Emitter, runID string, configModuleMap map[string]string, restoreModulesAvailable []RestoreModuleRef) (interface{}, *envelope.Error) {
+	brew := newBrewLane(brewDrv, emitter, brewApps)
+
+	// --- Phase 1: Plan ---
+	emitter.EmitPhase("plan")
+
+	type restEntry struct {
+		app      manifest.App
+		isManual bool
+		name     string
+		ref      string
+	}
+	var entries []restEntry
+	for _, app := range restApps {
+		ref := app.Refs[runtime.GOOS]
+		name := realizerItemName(app)
+		switch {
+		case ref != "":
+			entries = append(entries, restEntry{app: app, name: name, ref: ref})
+		case app.Manual != nil && app.Manual.VerifyPath != "":
+			entries = append(entries, restEntry{app: app, isManual: true, name: name})
+		default:
+			// No host ref and not a manual app: nothing to do (matches realizer path).
+		}
+	}
+
+	actions := make([]ApplyAction, 0, len(entries))
+	idx := map[string]int{}
+	presentCount, skippedRealizer := 0, 0
+	for _, e := range entries {
+		if e.isManual {
+			expanded, exists := checkVerifyPath(e.app.Manual.VerifyPath)
+			a := ApplyAction{ID: e.app.ID, Driver: "manual", Name: e.name, Manual: e.app.Manual}
+			if exists {
+				a.Status, a.Reason, a.Message = "present", "already_installed", fmt.Sprintf("Verified at %s", expanded)
+				emitter.EmitItem(e.app.ID, "manual", "present", "already_installed", a.Message, e.name)
+				presentCount++
+			} else {
+				a.Status, a.Reason, a.Message = "to_install", "manual_required", fmt.Sprintf("Not found at %s", expanded)
+				emitter.EmitItem(e.app.ID, "manual", "to_install", "manual_required", a.Message, e.name)
+			}
+			idx[e.app.ID] = len(actions)
+			actions = append(actions, a)
+			continue
+		}
+		// Nix-ref app, but the realizer backend is unavailable → visible skip.
+		msg := "Package backend is not set up; skipped"
+		a := ApplyAction{ID: e.app.ID, Ref: stringPtr(e.ref), Driver: "nix", Name: e.name,
+			Status: "skipped", Reason: "backend_unavailable", Message: msg}
+		emitter.EmitItem(e.ref, "nix", "skipped", "backend_unavailable", msg, e.name)
+		idx[e.app.ID] = len(actions)
+		actions = append(actions, a)
+		skippedRealizer++
+	}
+
+	brewPresent, brewToInstall := brew.planBrew()
+	totalApps := len(actions) + len(brew.brewActions())
+	// Plan-phase convention (mirrors runApplyRealizer): present→success slot,
+	// to_install→failed slot, skipped not counted in the slots (only in total).
+	emitter.EmitSummary("plan", totalApps, presentCount+brewPresent, 0, brewToInstall)
+
+	if flags.DryRun {
+		dryActions := append(append([]ApplyAction{}, actions...), brew.brewActions()...)
+		return &ApplyResult{
+			DryRun:                  true,
+			Manifest:                ApplyManifestRef{Path: flags.Manifest, Name: mf.Name},
+			Summary:                 ApplySummary{Total: totalApps, Skipped: skippedRealizer + presentCount + brewPresent},
+			Actions:                 dryActions,
+			ConfigModuleMap:         configModuleMap,
+			RestoreModulesAvailable: restoreModulesAvailable,
+		}, nil
+	}
+
+	// --- Phase 2: Apply ---
+	emitter.EmitPhase("apply")
+	successCount, skippedCount, failedCount := 0, 0, 0
+
+	// Manual apps: present → success; otherwise skipped (manual_required).
+	for _, e := range entries {
+		if !e.isManual {
+			continue
+		}
+		if actions[idx[e.app.ID]].Status == "present" {
+			successCount++
+		} else {
+			actions[idx[e.app.ID]].Status = "skipped"
+			actions[idx[e.app.ID]].Reason = "manual_required"
+			emitter.EmitItem(e.app.ID, "manual", "skipped", "manual_required", actions[idx[e.app.ID]].Message, e.name)
+			skippedCount++
+		}
+	}
+	// Skipped Nix-ref apps stay skipped through apply.
+	skippedCount += skippedRealizer
+
+	brewInstalled, brewSkipped, brewFailed := brew.applyBrew()
+	successCount += brewInstalled
+	skippedCount += brewSkipped
+	failedCount += brewFailed
+	emitter.EmitSummary("apply", successCount+skippedCount+failedCount, successCount, skippedCount, failedCount)
+
+	// --- Phase 3: Verify ---
+	emitter.EmitPhase("verify")
+	verifyPass, verifyFail := 0, 0
+	for _, e := range entries {
+		if !e.isManual {
+			continue
+		}
+		expanded, exists := checkVerifyPath(e.app.Manual.VerifyPath)
+		if exists {
+			emitter.EmitItem(e.app.ID, "manual", "present", "", fmt.Sprintf("Verified at %s", expanded), e.name)
+			verifyPass++
+		} else {
+			emitter.EmitItem(e.app.ID, "manual", "failed", "missing", fmt.Sprintf("Missing at %s", expanded), e.name)
+			verifyFail++
+		}
+	}
+	brewPass, brewVerifyFail, _ := brew.verifyBrew()
+	verifyPass += brewPass
+	verifyFail += brewVerifyFail
+	emitter.EmitSummary("verify", verifyPass+verifyFail, verifyPass, 0, verifyFail)
+
+	// Record ONLY the brew generation (the realizer lane committed nothing). It is
+	// append-only and no-ops when nothing was installed, so a declined-Nix run with
+	// no brew installs records no generation at all.
+	brewActions := brew.brewActions()
+	writeProvisioningGeneration(runID, "brew", brewActions, nil, "", brewFailed > 0, nil)
+	actions = append(actions, brewActions...)
+
+	return &ApplyResult{
+		DryRun:                  false,
+		Manifest:                ApplyManifestRef{Path: flags.Manifest, Name: mf.Name},
+		Summary:                 ApplySummary{Total: totalApps, Success: successCount, Skipped: skippedCount, Failed: failedCount},
+		Actions:                 actions,
+		ConfigModuleMap:         configModuleMap,
+		RestoreModulesAvailable: restoreModulesAvailable,
+	}, nil
+}

--- a/go-engine/internal/commands/apply_brew_test.go
+++ b/go-engine/internal/commands/apply_brew_test.go
@@ -142,6 +142,24 @@ func TestPartitionBrewLane_SplitsAndPreservesOrder(t *testing.T) {
 	}
 }
 
+func TestPartitionBrewLane_CaskRefAutoRoutesToBrew(t *testing.T) {
+	apps := []manifest.App{
+		{ID: "ripgrep", Refs: map[string]string{"darwin": "nixpkgs#ripgrep"}},
+		// Cask ref, NO driver:"brew" → must still route to the brew lane.
+		{ID: "chrome", Refs: map[string]string{"darwin": "cask:google-chrome"}},
+		// Case-insensitive prefix.
+		{ID: "slack", Refs: map[string]string{"darwin": "Cask:slack"}},
+		{ID: "jq", Refs: map[string]string{"darwin": "jq"}},
+	}
+	brewApps, restApps := partitionBrewLane(apps)
+	if len(brewApps) != 2 || brewApps[0].ID != "chrome" || brewApps[1].ID != "slack" {
+		t.Fatalf("brew lane = %+v, want [chrome slack] (cask: auto-routes)", brewApps)
+	}
+	if len(restApps) != 2 || restApps[0].ID != "ripgrep" || restApps[1].ID != "jq" {
+		t.Fatalf("rest lane = %+v, want [ripgrep jq] (nix refs stay)", restApps)
+	}
+}
+
 func TestPartitionBrewLane_NoBrew(t *testing.T) {
 	apps := []manifest.App{{ID: "ripgrep", Refs: map[string]string{"darwin": "ripgrep"}}}
 	brewApps, restApps := partitionBrewLane(apps)

--- a/go-engine/internal/commands/backend_bootstrap.go
+++ b/go-engine/internal/commands/backend_bootstrap.go
@@ -1,0 +1,147 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"runtime"
+
+	"github.com/Artexis10/endstate/go-engine/internal/bootstrap"
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/events"
+)
+
+// This file wires the engine-installed-backend bootstrap (internal/bootstrap)
+// as a pre-step in front of the backend factory gate. It is unrelated to the
+// `endstate bootstrap` self-install command in bootstrap.go.
+
+// Consent carries the user's backend-bootstrap decision, resolved from the CLI
+// flags. Granted is --bootstrap-backends (authorize installing absent backends);
+// Denied is --no-bootstrap (force skip). Neither set means "not yet answered":
+// the engine emits a consent-request event and defaults to skipping the lane.
+type Consent struct {
+	Granted bool
+	Denied  bool
+}
+
+// bootstrapConsent derives the Consent from apply flags. An explicit --no-bootstrap
+// takes precedence over --bootstrap-backends (a conservative "no wins").
+func bootstrapConsent(flags ApplyFlags) Consent {
+	return Consent{Granted: flags.BootstrapBackends && !flags.NoBootstrap, Denied: flags.NoBootstrap}
+}
+
+// bootstrapBackendsFn is the injectable pre-step seam run in front of the backend
+// factory gate (newRealizerFn / newBrewDriverFn). It detects each needed backend
+// and, on the mutating apply command, drives consent → official install → verify;
+// it returns which backends are available to resolve. The commands package
+// TestMain defaults it to a present/available no-op so existing tests are
+// byte-identical; production wires realEnsureBackends.
+var bootstrapBackendsFn = realEnsureBackends
+
+// newBootstrapperFn constructs the bootstrap mechanism realEnsureBackends drives.
+// It defaults to the real detect/install/verify seams; tests override it with a
+// fake Bootstrapper so the absent → consent → install → verify branches are
+// exercised hermetically (the real installer is never shelled in `go test`).
+var newBootstrapperFn = bootstrap.New
+
+// realEnsureBackends is the production pre-step. For each needed backend that is
+// bootstrappable on the host OS it runs detect → (consent → install → verify):
+//   - present → available (no prompt, no install);
+//   - absent + read-only command (mutating=false) → not available, NO install,
+//     NO consent request (you do not install a package manager to read state);
+//   - absent + apply + consent granted → install via the OFFICIAL installer, then
+//     verify; available only if the verify probe passes;
+//   - absent + apply + no consent → emit ONE combined consent-request event and
+//     default to skipping (not available); explicit --no-bootstrap skips silently.
+//
+// A backend that is not bootstrappable on the host (e.g. brew off darwin, or any
+// backend on Windows) is simply absent from the returned map, so its lane falls
+// back to the existing factory gate (which no-ops it) unchanged.
+func realEnsureBackends(needed []bootstrap.Backend, mutating bool, consent Consent, emitter *events.Emitter) (map[bootstrap.Backend]bool, *envelope.Error) {
+	goos := runtime.GOOS
+	available := map[bootstrap.Backend]bool{}
+
+	relevant := make([]bootstrap.Backend, 0, len(needed))
+	for _, b := range needed {
+		if bootstrappableOn(goos, b) {
+			relevant = append(relevant, b)
+		}
+	}
+	if len(relevant) == 0 {
+		return available, nil
+	}
+
+	bs := newBootstrapperFn()
+	absent, present := bs.Probe(relevant)
+	for _, b := range present {
+		available[b] = true // present and working → use directly, never re-install
+	}
+	if len(absent) == 0 {
+		return available, nil
+	}
+
+	// Read-only commands never install: report the absent backends as unavailable
+	// without prompting. Their lanes fall back to detect/skip in the existing path.
+	if !mutating {
+		for _, b := range absent {
+			available[b] = false
+		}
+		return available, nil
+	}
+
+	switch {
+	case consent.Granted:
+		outcomes := bs.Provision(absent) // install + verify each, independently
+		for b, o := range outcomes {
+			available[b] = o.Available()
+		}
+	case consent.Denied:
+		// Explicit skip: the user declined up front. Lane(s) skipped, run continues.
+		for _, b := range absent {
+			available[b] = false
+		}
+	default:
+		// Not yet answered: emit ONE combined consent-request and default to skip.
+		emitter.EmitConsent(backendStrings(absent), bootstrap.ConsentMessage(absent), installerCommands(absent))
+		for _, b := range absent {
+			available[b] = false
+		}
+	}
+	return available, nil
+}
+
+// bootstrappableOn reports whether a backend can be bootstrapped (and used) on the
+// given host OS. The Homebrew driver is darwin-only; the Nix realizer is
+// linux/darwin; Windows bootstraps nothing (winget ships with the OS).
+func bootstrappableOn(goos string, b bootstrap.Backend) bool {
+	switch b {
+	case bootstrap.BackendBrew:
+		return goos == "darwin"
+	case bootstrap.BackendNix:
+		return goos == "linux" || goos == "darwin"
+	default:
+		return false
+	}
+}
+
+// backendStrings renders backend identifiers for the consent event's structured
+// backends field.
+func backendStrings(bs []bootstrap.Backend) []string {
+	out := make([]string, len(bs))
+	for i, b := range bs {
+		out[i] = string(b)
+	}
+	return out
+}
+
+// installerCommands renders the exact, inspectable installer commands for the
+// consent event's details field (the "what will run" affordance).
+func installerCommands(bs []bootstrap.Backend) []string {
+	out := make([]string, 0, len(bs))
+	for _, b := range bs {
+		if cmd := bootstrap.InstallerCommand(b); cmd != "" {
+			out = append(out, cmd)
+		}
+	}
+	return out
+}

--- a/go-engine/internal/commands/backend_bootstrap.go
+++ b/go-engine/internal/commands/backend_bootstrap.go
@@ -44,6 +44,14 @@ var bootstrapBackendsFn = realEnsureBackends
 // exercised hermetically (the real installer is never shelled in `go test`).
 var newBootstrapperFn = bootstrap.New
 
+// bootstrapGOOSFn reports the host OS used to decide which backends are
+// bootstrappable (brew → darwin, nix → linux/darwin, none on Windows). It
+// defaults to runtime.GOOS and is a test seam (mirroring captureGOOSFn) so the
+// realEnsureBackends branch tests run host-independently on every CI OS — without
+// it, those tests short-circuit on a Windows runner where no backend is
+// bootstrappable.
+var bootstrapGOOSFn = func() string { return runtime.GOOS }
+
 // realEnsureBackends is the production pre-step. For each needed backend that is
 // bootstrappable on the host OS it runs detect → (consent → install → verify):
 //   - present → available (no prompt, no install);
@@ -58,7 +66,7 @@ var newBootstrapperFn = bootstrap.New
 // backend on Windows) is simply absent from the returned map, so its lane falls
 // back to the existing factory gate (which no-ops it) unchanged.
 func realEnsureBackends(needed []bootstrap.Backend, mutating bool, consent Consent, emitter *events.Emitter) (map[bootstrap.Backend]bool, *envelope.Error) {
-	goos := runtime.GOOS
+	goos := bootstrapGOOSFn()
 	available := map[bootstrap.Backend]bool{}
 
 	relevant := make([]bootstrap.Backend, 0, len(needed))

--- a/go-engine/internal/commands/backend_bootstrap_test.go
+++ b/go-engine/internal/commands/backend_bootstrap_test.go
@@ -7,7 +7,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -38,11 +37,25 @@ func fakeBootstrapper(present bool, installErr error, verifyOK bool) (*bootstrap
 	return bs, &calls
 }
 
-// withBootstrapper overrides the newBootstrapperFn seam for the duration of f.
+// withBootstrapper overrides the newBootstrapperFn seam for the duration of f and
+// pins the bootstrap GOOS to a Unix host (linux), so the nix-backend branch tests
+// run identically on every CI OS — including the Windows runner, where nix is not
+// bootstrappable and realEnsureBackends would otherwise short-circuit.
 func withBootstrapper(bs *bootstrap.Bootstrapper, f func()) {
-	orig := newBootstrapperFn
+	withBootstrapperOn("linux", bs, f)
+}
+
+// withBootstrapperOn is withBootstrapper with an explicit pinned host OS (e.g.
+// "darwin" to exercise the brew-bootstrappable path).
+func withBootstrapperOn(goos string, bs *bootstrap.Bootstrapper, f func()) {
+	origBs := newBootstrapperFn
+	origGOOS := bootstrapGOOSFn
 	newBootstrapperFn = func() *bootstrap.Bootstrapper { return bs }
-	defer func() { newBootstrapperFn = orig }()
+	bootstrapGOOSFn = func() string { return goos }
+	defer func() {
+		newBootstrapperFn = origBs
+		bootstrapGOOSFn = origGOOS
+	}()
 	f()
 }
 
@@ -416,19 +429,16 @@ func TestRunApply_CombinedConsent_OneProbeForBothBackends(t *testing.T) {
 }
 
 // TestRealEnsureBackends_CombinedConsentOneEventBothBackends validates the real
-// pre-step emits a SINGLE consent event covering both absent backends. Guarded to
-// darwin because brew is not bootstrappable off darwin (bootstrappableOn filters it).
+// pre-step emits a SINGLE consent event covering both absent backends. It pins the
+// host to darwin (both nix and brew bootstrappable) so it runs on every CI OS.
 func TestRealEnsureBackends_CombinedConsentOneEventBothBackends(t *testing.T) {
-	if runtime.GOOS != "darwin" {
-		t.Skip("brew is bootstrappable only on darwin; combined-set path needs darwin")
-	}
 	bs := &bootstrap.Bootstrapper{
 		Detect:  func(b bootstrap.Backend) (bool, error) { return false, nil }, // both absent
 		Install: func(b bootstrap.Backend) error { return nil },
 		Verify:  func(b bootstrap.Backend) (bool, error) { return true, nil },
 	}
 	em, buf := captureBootstrapEmitter()
-	withBootstrapper(bs, func() {
+	withBootstrapperOn("darwin", bs, func() {
 		_, _ = realEnsureBackends([]bootstrap.Backend{bootstrap.BackendNix, bootstrap.BackendBrew}, true, Consent{}, em)
 	})
 	ev := consentLines(t, buf)

--- a/go-engine/internal/commands/backend_bootstrap_test.go
+++ b/go-engine/internal/commands/backend_bootstrap_test.go
@@ -7,10 +7,12 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/Artexis10/endstate/go-engine/internal/bootstrap"
+	"github.com/Artexis10/endstate/go-engine/internal/driver"
 	"github.com/Artexis10/endstate/go-engine/internal/envelope"
 	"github.com/Artexis10/endstate/go-engine/internal/events"
 	"github.com/Artexis10/endstate/go-engine/internal/provision"
@@ -261,7 +263,8 @@ func TestRunApply_BrewLane_DeclinedBootstrap_SkipsBrewContinuesRun(t *testing.T)
 
 	var result interface{}
 	var eerr *envelope.Error
-	withBootstrapAvail(map[bootstrap.Backend]bool{bootstrap.BackendBrew: false}, func() {
+	// Nix available (realizer lane runs), brew declined (lane skipped).
+	withBootstrapAvail(map[bootstrap.Backend]bool{bootstrap.BackendNix: true, bootstrap.BackendBrew: false}, func() {
 		// panicBrewDriverFn fails the test if the gate resolves the brew factory.
 		withRealizerAndBrew(fr, panicBrewDriverFn(t), func() {
 			r, e := RunApply(ApplyFlags{Manifest: mfPath, Events: "jsonl", NoBootstrap: true})
@@ -281,6 +284,160 @@ func TestRunApply_BrewLane_DeclinedBootstrap_SkipsBrewContinuesRun(t *testing.T)
 	gens, _ := provision.List()
 	if len(gens) != 1 || gens[0].Backend != "nix" {
 		t.Fatalf("declined brew → exactly one nix generation, got %+v", gens)
+	}
+}
+
+// TestRunApply_NixDeclined_BrewOnlyPath proves the PR2 declined-Nix restructuring:
+// when Nix is needed but unavailable and brew is available, the realizer-lane app
+// is a visible skip, the brew app STILL installs via the standalone brew-only path,
+// the run does not error, and exactly ONE (brew) provisioning generation is written
+// (no nix generation).
+func TestRunApply_NixDeclined_BrewOnlyPath(t *testing.T) {
+	manifestJSON := replaceGOOS(`{
+  "version": 1, "name": "nix-declined-brew-ok",
+  "apps": [
+    { "id": "ripgrep", "displayName": "ripgrep", "refs": { "GOOS": "nixpkgs#ripgrep" } },
+    { "id": "hello", "displayName": "hello", "driver": "brew", "refs": { "darwin": "hello" } }
+  ]
+}`)
+	mfPath := writeTempManifest(t, manifestJSON)
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	fr := &fakeRealizer{} // never used: Nix is unavailable, brew-only path runs
+	fb := &fakeBrewDriver{installed: map[string]bool{}}
+
+	var result interface{}
+	var eerr *envelope.Error
+	withBootstrapAvail(map[bootstrap.Backend]bool{bootstrap.BackendNix: false, bootstrap.BackendBrew: true}, func() {
+		withRealizerAndBrew(fr, func() (driver.Driver, error) { return fb, nil }, func() {
+			r, e := RunApply(ApplyFlags{Manifest: mfPath, Events: "jsonl", BootstrapBackends: true})
+			result, eerr = r, e
+		})
+	})
+	if eerr != nil {
+		t.Fatalf("declined Nix must not error the run: %v", eerr)
+	}
+	ar := result.(*ApplyResult)
+	if !hasAction(ar.Actions, "ripgrep", "nix", "skipped") {
+		t.Errorf("Nix-ref app must be a visible skip when Nix is unavailable, got %+v", ar.Actions)
+	}
+	if !hasAction(ar.Actions, "hello", "brew", "installed") {
+		t.Errorf("brew app must still install on the brew-only path, got %+v", ar.Actions)
+	}
+	if len(fb.installCalls) != 1 || fb.installCalls[0] != "hello" {
+		t.Errorf("brew Install calls = %v, want [hello]", fb.installCalls)
+	}
+	gens, _ := provision.List()
+	if len(gens) != 1 || gens[0].Backend != "brew" {
+		t.Fatalf("declined Nix + brew install → exactly one brew generation, got %+v", gens)
+	}
+}
+
+// TestRunApply_NixOnlyDeclined_NoCrashAllSkipped proves a Nix-only manifest with
+// Nix declined does not crash: the app is skipped, no generation is written, and
+// the run returns a (successful) result rather than a top-level error.
+func TestRunApply_NixOnlyDeclined_NoCrashAllSkipped(t *testing.T) {
+	manifestJSON := replaceGOOS(`{
+  "version": 1, "name": "nix-only-declined",
+  "apps": [ { "id": "ripgrep", "displayName": "ripgrep", "refs": { "GOOS": "nixpkgs#ripgrep" } } ]
+}`)
+	mfPath := writeTempManifest(t, manifestJSON)
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	fr := &fakeRealizer{}
+	var result interface{}
+	var eerr *envelope.Error
+	withBootstrapAvail(map[bootstrap.Backend]bool{bootstrap.BackendNix: false}, func() {
+		// No brew app → the brew factory must never resolve.
+		withRealizerAndBrew(fr, panicBrewDriverFn(t), func() {
+			r, e := RunApply(ApplyFlags{Manifest: mfPath, Events: "jsonl", NoBootstrap: true})
+			result, eerr = r, e
+		})
+	})
+	if eerr != nil {
+		t.Fatalf("Nix-only declined must not crash: %v", eerr)
+	}
+	ar := result.(*ApplyResult)
+	if !hasAction(ar.Actions, "ripgrep", "nix", "skipped") {
+		t.Errorf("the only app must be skipped, got %+v", ar.Actions)
+	}
+	gens, _ := provision.List()
+	if len(gens) != 0 {
+		t.Fatalf("nothing installed → no provisioning generation, got %+v", gens)
+	}
+}
+
+// TestRunApply_CombinedConsent_OneProbeForBothBackends proves the apply gate makes
+// a SINGLE bootstrap pre-step call carrying the combined needed set (one consent),
+// not one call per backend.
+func TestRunApply_CombinedConsent_OneProbeForBothBackends(t *testing.T) {
+	manifestJSON := replaceGOOS(`{
+  "version": 1, "name": "combined",
+  "apps": [
+    { "id": "ripgrep", "displayName": "ripgrep", "refs": { "GOOS": "nixpkgs#ripgrep" } },
+    { "id": "hello", "displayName": "hello", "driver": "brew", "refs": { "darwin": "hello" } }
+  ]
+}`)
+	mfPath := writeTempManifest(t, manifestJSON)
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	fr := &fakeRealizer{
+		planDiff:      realizer.Diff{ToAdd: []realizer.Installable{{ID: "ripgrep", Ref: "nixpkgs#ripgrep"}}},
+		realizeResult: realizer.Result{Advanced: true, ToGeneration: 1, After: realizer.Set{Elements: map[string]realizer.Element{}}},
+		currentSet:    realizer.Set{Elements: map[string]realizer.Element{"ripgrep": {Name: "ripgrep"}}},
+	}
+	fb := &fakeBrewDriver{installed: map[string]bool{}}
+
+	var calls int
+	var captured []bootstrap.Backend
+	orig := bootstrapBackendsFn
+	bootstrapBackendsFn = func(needed []bootstrap.Backend, _ bool, _ Consent, _ *events.Emitter) (map[bootstrap.Backend]bool, *envelope.Error) {
+		calls++
+		captured = needed
+		return map[bootstrap.Backend]bool{bootstrap.BackendNix: true, bootstrap.BackendBrew: true}, nil
+	}
+	defer func() { bootstrapBackendsFn = orig }()
+
+	withRealizerAndBrew(fr, func() (driver.Driver, error) { return fb, nil }, func() {
+		if _, e := RunApply(ApplyFlags{Manifest: mfPath, Events: "jsonl", BootstrapBackends: true}); e != nil {
+			t.Fatalf("RunApply error: %v", e)
+		}
+	})
+	if calls != 1 {
+		t.Fatalf("bootstrap pre-step called %d times, want exactly 1 (combined consent)", calls)
+	}
+	has := map[bootstrap.Backend]bool{}
+	for _, b := range captured {
+		has[b] = true
+	}
+	if !has[bootstrap.BackendNix] || !has[bootstrap.BackendBrew] {
+		t.Fatalf("combined needed set = %v, want both nix and brew", captured)
+	}
+}
+
+// TestRealEnsureBackends_CombinedConsentOneEventBothBackends validates the real
+// pre-step emits a SINGLE consent event covering both absent backends. Guarded to
+// darwin because brew is not bootstrappable off darwin (bootstrappableOn filters it).
+func TestRealEnsureBackends_CombinedConsentOneEventBothBackends(t *testing.T) {
+	if runtime.GOOS != "darwin" {
+		t.Skip("brew is bootstrappable only on darwin; combined-set path needs darwin")
+	}
+	bs := &bootstrap.Bootstrapper{
+		Detect:  func(b bootstrap.Backend) (bool, error) { return false, nil }, // both absent
+		Install: func(b bootstrap.Backend) error { return nil },
+		Verify:  func(b bootstrap.Backend) (bool, error) { return true, nil },
+	}
+	em, buf := captureBootstrapEmitter()
+	withBootstrapper(bs, func() {
+		_, _ = realEnsureBackends([]bootstrap.Backend{bootstrap.BackendNix, bootstrap.BackendBrew}, true, Consent{}, em)
+	})
+	ev := consentLines(t, buf)
+	if len(ev) != 1 {
+		t.Fatalf("combined consent must emit exactly one event, got %d", len(ev))
+	}
+	backends, _ := ev[0]["backends"].([]interface{})
+	if len(backends) != 2 {
+		t.Fatalf("combined consent event backends = %v, want both", ev[0]["backends"])
 	}
 }
 

--- a/go-engine/internal/commands/backend_bootstrap_test.go
+++ b/go-engine/internal/commands/backend_bootstrap_test.go
@@ -1,0 +1,301 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+package commands
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/bootstrap"
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/events"
+	"github.com/Artexis10/endstate/go-engine/internal/provision"
+	"github.com/Artexis10/endstate/go-engine/internal/realizer"
+)
+
+// fakeBootstrapper builds a *bootstrap.Bootstrapper with scriptable seams and
+// records install/verify calls, so realEnsureBackends is exercised hermetically
+// (no real installer). present controls the detect probe.
+func fakeBootstrapper(present bool, installErr error, verifyOK bool) (*bootstrap.Bootstrapper, *[]string) {
+	var calls []string
+	bs := &bootstrap.Bootstrapper{
+		Detect: func(b bootstrap.Backend) (bool, error) { return present, nil },
+		Install: func(b bootstrap.Backend) error {
+			calls = append(calls, "install:"+string(b))
+			return installErr
+		},
+		Verify: func(b bootstrap.Backend) (bool, error) {
+			calls = append(calls, "verify:"+string(b))
+			return verifyOK, nil
+		},
+	}
+	return bs, &calls
+}
+
+// withBootstrapper overrides the newBootstrapperFn seam for the duration of f.
+func withBootstrapper(bs *bootstrap.Bootstrapper, f func()) {
+	orig := newBootstrapperFn
+	newBootstrapperFn = func() *bootstrap.Bootstrapper { return bs }
+	defer func() { newBootstrapperFn = orig }()
+	f()
+}
+
+// captureBootstrapEmitter returns an enabled emitter writing into buf.
+func captureBootstrapEmitter() (*events.Emitter, *bytes.Buffer) {
+	buf := &bytes.Buffer{}
+	return events.NewEmitterWithWriter("test-run", true, buf), buf
+}
+
+// consentLines returns the parsed "consent" events emitted into buf.
+func consentLines(t *testing.T, buf *bytes.Buffer) []map[string]interface{} {
+	t.Helper()
+	var out []map[string]interface{}
+	for _, line := range strings.Split(strings.TrimRight(buf.String(), "\n"), "\n") {
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		var m map[string]interface{}
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("event is not valid JSON: %v\nraw: %q", err, line)
+		}
+		if m["event"] == "consent" {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// nix is bootstrappable on both the linux dev box and darwin CI, so these tests
+// are host-independent.
+
+func TestRealEnsureBackends_PresentNoConsentNoInstall(t *testing.T) {
+	bs, calls := fakeBootstrapper(true /*present*/, nil, true)
+	em, buf := captureBootstrapEmitter()
+	withBootstrapper(bs, func() {
+		avail, eerr := realEnsureBackends([]bootstrap.Backend{bootstrap.BackendNix}, true, Consent{}, em)
+		if eerr != nil {
+			t.Fatalf("unexpected error: %v", eerr)
+		}
+		if !avail[bootstrap.BackendNix] {
+			t.Fatal("present backend must be available")
+		}
+	})
+	if len(*calls) != 0 {
+		t.Fatalf("present backend must not install/verify, calls = %v", *calls)
+	}
+	if got := consentLines(t, buf); len(got) != 0 {
+		t.Fatalf("present backend must not emit a consent event, got %d", len(got))
+	}
+}
+
+func TestRealEnsureBackends_AbsentNoConsent_EmitsRequestAndSkips(t *testing.T) {
+	bs, calls := fakeBootstrapper(false /*absent*/, nil, true)
+	em, buf := captureBootstrapEmitter()
+	withBootstrapper(bs, func() {
+		avail, eerr := realEnsureBackends([]bootstrap.Backend{bootstrap.BackendNix}, true, Consent{}, em)
+		if eerr != nil {
+			t.Fatalf("unexpected error: %v", eerr)
+		}
+		if avail[bootstrap.BackendNix] {
+			t.Fatal("absent + no consent must NOT be available")
+		}
+	})
+	if len(*calls) != 0 {
+		t.Fatalf("no consent must not install, calls = %v", *calls)
+	}
+	ev := consentLines(t, buf)
+	if len(ev) != 1 {
+		t.Fatalf("want exactly one consent event, got %d", len(ev))
+	}
+	backends, _ := ev[0]["backends"].([]interface{})
+	if len(backends) != 1 || backends[0] != "nix" {
+		t.Fatalf("consent backends = %v, want [nix]", ev[0]["backends"])
+	}
+	msg, _ := ev[0]["message"].(string)
+	if msg == "" || strings.Contains(strings.ToLower(msg), "nix") {
+		t.Fatalf("consent message must be present and product-neutral: %q", msg)
+	}
+	details, _ := ev[0]["details"].([]interface{})
+	if len(details) != 1 {
+		t.Fatalf("consent details must carry the installer command, got %v", ev[0]["details"])
+	}
+}
+
+func TestRealEnsureBackends_AbsentGranted_InstallsAndVerifies(t *testing.T) {
+	bs, calls := fakeBootstrapper(false, nil, true /*verify ok*/)
+	em, buf := captureBootstrapEmitter()
+	withBootstrapper(bs, func() {
+		avail, eerr := realEnsureBackends([]bootstrap.Backend{bootstrap.BackendNix}, true, Consent{Granted: true}, em)
+		if eerr != nil {
+			t.Fatalf("unexpected error: %v", eerr)
+		}
+		if !avail[bootstrap.BackendNix] {
+			t.Fatal("absent + granted + verify-ok must be available")
+		}
+	})
+	if strings.Join(*calls, ",") != "install:nix,verify:nix" {
+		t.Fatalf("calls = %v, want install then verify", *calls)
+	}
+	if got := consentLines(t, buf); len(got) != 0 {
+		t.Fatalf("granted consent must not emit a consent-request, got %d", len(got))
+	}
+}
+
+func TestRealEnsureBackends_AbsentGranted_VerifyFailUnavailable(t *testing.T) {
+	bs, _ := fakeBootstrapper(false, nil, false /*verify fails*/)
+	em, _ := captureBootstrapEmitter()
+	withBootstrapper(bs, func() {
+		avail, eerr := realEnsureBackends([]bootstrap.Backend{bootstrap.BackendNix}, true, Consent{Granted: true}, em)
+		if eerr != nil {
+			t.Fatalf("unexpected error: %v", eerr)
+		}
+		if avail[bootstrap.BackendNix] {
+			t.Fatal("install ok but verify fail must be UNAVAILABLE")
+		}
+	})
+}
+
+func TestRealEnsureBackends_AbsentGranted_InstallFailUnavailable(t *testing.T) {
+	bs, _ := fakeBootstrapper(false, errors.New("install boom"), true)
+	em, _ := captureBootstrapEmitter()
+	withBootstrapper(bs, func() {
+		avail, _ := realEnsureBackends([]bootstrap.Backend{bootstrap.BackendNix}, true, Consent{Granted: true}, em)
+		if avail[bootstrap.BackendNix] {
+			t.Fatal("install failure must be UNAVAILABLE")
+		}
+	})
+}
+
+func TestRealEnsureBackends_AbsentDenied_SkipsNoEvent(t *testing.T) {
+	bs, calls := fakeBootstrapper(false, nil, true)
+	em, buf := captureBootstrapEmitter()
+	withBootstrapper(bs, func() {
+		avail, _ := realEnsureBackends([]bootstrap.Backend{bootstrap.BackendNix}, true, Consent{Denied: true}, em)
+		if avail[bootstrap.BackendNix] {
+			t.Fatal("explicit --no-bootstrap must skip (unavailable)")
+		}
+	})
+	if len(*calls) != 0 {
+		t.Fatalf("denied must not install, calls = %v", *calls)
+	}
+	if got := consentLines(t, buf); len(got) != 0 {
+		t.Fatalf("explicit decline must not re-request consent, got %d", len(got))
+	}
+}
+
+func TestRealEnsureBackends_ReadOnlyAbsent_NoInstallNoConsent(t *testing.T) {
+	bs, calls := fakeBootstrapper(false, nil, true)
+	em, buf := captureBootstrapEmitter()
+	withBootstrapper(bs, func() {
+		avail, _ := realEnsureBackends([]bootstrap.Backend{bootstrap.BackendNix}, false /*read-only*/, Consent{}, em)
+		if avail[bootstrap.BackendNix] {
+			t.Fatal("read-only must not make an absent backend available")
+		}
+	})
+	if len(*calls) != 0 {
+		t.Fatalf("read-only must never install, calls = %v", *calls)
+	}
+	if got := consentLines(t, buf); len(got) != 0 {
+		t.Fatalf("read-only must not request install consent, got %d", len(got))
+	}
+}
+
+func TestBootstrappableOn_HostMatrix(t *testing.T) {
+	cases := []struct {
+		goos string
+		b    bootstrap.Backend
+		want bool
+	}{
+		{"darwin", bootstrap.BackendBrew, true},
+		{"linux", bootstrap.BackendBrew, false}, // brew driver is darwin-only
+		{"windows", bootstrap.BackendBrew, false},
+		{"darwin", bootstrap.BackendNix, true},
+		{"linux", bootstrap.BackendNix, true},
+		{"windows", bootstrap.BackendNix, false}, // winget ships with the OS
+	}
+	for _, c := range cases {
+		if got := bootstrappableOn(c.goos, c.b); got != c.want {
+			t.Errorf("bootstrappableOn(%q, %q) = %v, want %v", c.goos, c.b, got, c.want)
+		}
+	}
+}
+
+// withBootstrapAvail overrides the bootstrapBackendsFn pre-step seam to return a
+// fixed availability map, so the apply-gate wiring can be tested independently of
+// the real detect/install path.
+func withBootstrapAvail(avail map[bootstrap.Backend]bool, f func()) {
+	orig := bootstrapBackendsFn
+	bootstrapBackendsFn = func(_ []bootstrap.Backend, _ bool, _ Consent, _ *events.Emitter) (map[bootstrap.Backend]bool, *envelope.Error) {
+		return avail, nil
+	}
+	defer func() { bootstrapBackendsFn = orig }()
+	f()
+}
+
+// TestRunApply_BrewLane_DeclinedBootstrap_SkipsBrewContinuesRun proves the apply
+// GATE: when the brew bootstrap pre-step reports brew unavailable (declined), the
+// brew factory is NEVER resolved (panicBrewDriverFn would fail the test), the brew
+// app is a visible skip, the realizer lane still installs, the run does not error,
+// and exactly ONE (nix) provisioning generation is written — declined brew behaves
+// like a no-brew manifest.
+func TestRunApply_BrewLane_DeclinedBootstrap_SkipsBrewContinuesRun(t *testing.T) {
+	manifestJSON := replaceGOOS(`{
+  "version": 1, "name": "brew-declined",
+  "apps": [
+    { "id": "ripgrep", "displayName": "ripgrep", "refs": { "GOOS": "nixpkgs#ripgrep" } },
+    { "id": "hello", "displayName": "hello", "driver": "brew", "refs": { "darwin": "hello" } }
+  ]
+}`)
+	mfPath := writeTempManifest(t, manifestJSON)
+	t.Setenv("ENDSTATE_ROOT", t.TempDir())
+
+	fr := &fakeRealizer{
+		planDiff:      realizer.Diff{ToAdd: []realizer.Installable{{ID: "ripgrep", Ref: "nixpkgs#ripgrep"}}},
+		realizeResult: realizer.Result{Advanced: true, ToGeneration: 1, After: realizer.Set{Elements: map[string]realizer.Element{}}},
+		currentSet:    realizer.Set{Elements: map[string]realizer.Element{"ripgrep": {Name: "ripgrep"}}},
+	}
+
+	var result interface{}
+	var eerr *envelope.Error
+	withBootstrapAvail(map[bootstrap.Backend]bool{bootstrap.BackendBrew: false}, func() {
+		// panicBrewDriverFn fails the test if the gate resolves the brew factory.
+		withRealizerAndBrew(fr, panicBrewDriverFn(t), func() {
+			r, e := RunApply(ApplyFlags{Manifest: mfPath, Events: "jsonl", NoBootstrap: true})
+			result, eerr = r, e
+		})
+	})
+	if eerr != nil {
+		t.Fatalf("declined bootstrap must not error the run: %v", eerr)
+	}
+	ar := result.(*ApplyResult)
+	if !hasAction(ar.Actions, "hello", "brew", "skipped") {
+		t.Errorf("declined brew app must be a visible skip, got %+v", ar.Actions)
+	}
+	if !hasAction(ar.Actions, "ripgrep", "nix", "installed") {
+		t.Errorf("realizer lane must still install when brew is declined, got %+v", ar.Actions)
+	}
+	gens, _ := provision.List()
+	if len(gens) != 1 || gens[0].Backend != "nix" {
+		t.Fatalf("declined brew → exactly one nix generation, got %+v", gens)
+	}
+}
+
+func TestBootstrapConsent_FlagMapping(t *testing.T) {
+	if c := bootstrapConsent(ApplyFlags{BootstrapBackends: true}); !c.Granted || c.Denied {
+		t.Fatalf("--bootstrap-backends → %+v, want Granted", c)
+	}
+	if c := bootstrapConsent(ApplyFlags{NoBootstrap: true}); c.Granted || !c.Denied {
+		t.Fatalf("--no-bootstrap → %+v, want Denied", c)
+	}
+	// Conflicting flags: --no-bootstrap wins (conservative "no").
+	if c := bootstrapConsent(ApplyFlags{BootstrapBackends: true, NoBootstrap: true}); c.Granted || !c.Denied {
+		t.Fatalf("both flags → %+v, want Denied wins", c)
+	}
+	if c := bootstrapConsent(ApplyFlags{}); c.Granted || c.Denied {
+		t.Fatalf("no flag → %+v, want neither", c)
+	}
+}

--- a/go-engine/internal/commands/main_test.go
+++ b/go-engine/internal/commands/main_test.go
@@ -6,7 +6,24 @@ package commands
 import (
 	"os"
 	"testing"
+
+	"github.com/Artexis10/endstate/go-engine/internal/bootstrap"
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+	"github.com/Artexis10/endstate/go-engine/internal/events"
 )
+
+// presentBootstrapFn is the default backend-bootstrap pre-step fake: it reports
+// every needed backend as present/available, so the real detect/install/verify
+// path never runs under `go test` and the factory gate (newRealizerFn /
+// newBrewDriverFn) still decides resolution exactly as before this change. Tests
+// that exercise decline/skip/install wiring override bootstrapBackendsFn locally.
+func presentBootstrapFn(needed []bootstrap.Backend, _ bool, _ Consent, _ *events.Emitter) (map[bootstrap.Backend]bool, *envelope.Error) {
+	avail := make(map[bootstrap.Backend]bool, len(needed))
+	for _, b := range needed {
+		avail[b] = true
+	}
+	return avail, nil
+}
 
 // TestMain keeps the commands package tests hermetic. Several tests drive a
 // successful apply, which records a Provisioning Generation under the resolved
@@ -33,6 +50,12 @@ func TestMain(m *testing.M) {
 	// host-independent WITHOUT touching captureGOOSFn, which also keys the emitted
 	// host ref (a.Refs[runtime.GOOS]) and must stay the real host OS.
 	newBrewDriverFn = failBrewDriverFn
+
+	// Default the backend-bootstrap pre-step to a present/available no-op so the
+	// real installer is never shelled in tests and existing command tests stay
+	// byte-identical (the factory gate still decides resolution). Tests that
+	// exercise the bootstrap wiring override bootstrapBackendsFn locally.
+	bootstrapBackendsFn = presentBootstrapFn
 
 	code := m.Run()
 	cleanup()

--- a/go-engine/internal/events/emitter.go
+++ b/go-engine/internal/events/emitter.go
@@ -133,6 +133,22 @@ func (e *Emitter) EmitArtifact(phase, kind, path string) {
 	})
 }
 
+// EmitConsent emits a consent-request event for one or more absent backends the
+// run needs to bootstrap. message is the plain-language, product-neutral ask;
+// details are the exact installer commands (the inspectable "what will run").
+// One event covers the combined backend set so the GUI renders a single dialog.
+func (e *Emitter) EmitConsent(backends []string, message string, details []string) {
+	if !e.enabled {
+		return
+	}
+	e.emit(ConsentEvent{
+		BaseEvent: e.base("consent"),
+		Backends:  backends,
+		Message:   message,
+		Details:   details,
+	})
+}
+
 // BackupChunkProgress carries the per-chunk fields emitted as a
 // `backup-chunk` event. Pass into EmitBackupChunk so future fields can be
 // added without breaking call sites.

--- a/go-engine/internal/events/emitter_test.go
+++ b/go-engine/internal/events/emitter_test.go
@@ -80,6 +80,47 @@ func assertBaseFields(t *testing.T, ev map[string]interface{}, wantRunID, wantEv
 }
 
 // ---------------------------------------------------------------------------
+// Consent event
+// ---------------------------------------------------------------------------
+
+func TestEmitConsent(t *testing.T) {
+	runID := "apply-20250101-120000-TEST"
+	em, buf := captureEmitter(runID)
+	em.EmitConsent([]string{"brew", "nix"}, "Endstate needs to set up its tools.",
+		[]string{"brew-cmd", "nix-cmd"})
+
+	line := lastLine(buf)
+	if line == "" {
+		t.Fatal("no output written")
+	}
+	ev := parseEvent(t, line)
+	assertBaseFields(t, ev, runID, "consent")
+
+	backends, ok := ev["backends"].([]interface{})
+	if !ok || len(backends) != 2 || backends[0] != "brew" || backends[1] != "nix" {
+		t.Errorf("backends = %v, want [brew nix]", ev["backends"])
+	}
+	if ev["message"] != "Endstate needs to set up its tools." {
+		t.Errorf("message = %v", ev["message"])
+	}
+	details, ok := ev["details"].([]interface{})
+	if !ok || len(details) != 2 {
+		t.Errorf("details = %v, want 2 entries", ev["details"])
+	}
+}
+
+// A disabled emitter writes nothing for consent (no-op guard), like every other
+// Emit* method.
+func TestEmitConsentDisabledIsNoOp(t *testing.T) {
+	buf := &bytes.Buffer{}
+	em := NewEmitterWithWriter("run", false, buf)
+	em.EmitConsent([]string{"brew"}, "msg", nil)
+	if buf.Len() != 0 {
+		t.Fatalf("disabled emitter wrote %q, want nothing", buf.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Phase event
 // ---------------------------------------------------------------------------
 

--- a/go-engine/internal/events/types.go
+++ b/go-engine/internal/events/types.go
@@ -62,6 +62,28 @@ type ArtifactEvent struct {
 	Path  string `json:"path"`
 }
 
+// ConsentEvent requests the user's consent to bootstrap one or more absent
+// package backends (the engine installs its own backend when it is missing on
+// macOS/Linux). It is a non-breaking addition under the event-contract
+// extensibility rules (new event type, no version bump).
+//
+// One event covers the COMBINED set of backends a run needs and lacks, so the
+// GUI renders a single plain-language dialog. The Message is product-neutral
+// (it never names "Nix"/"Homebrew") to keep the concepts invisible; the Details
+// carry the exact, inspectable installer commands for anyone who looks. Backends
+// are the internal lane identifiers the GUI maps back to the run.
+type ConsentEvent struct {
+	BaseEvent
+	// Backends are the internal identifiers of the absent backends needing
+	// consent (e.g. "brew", "nix"). Structured metadata, not user-facing copy.
+	Backends []string `json:"backends"`
+	// Message is the plain-language, product-neutral consent ask.
+	Message string `json:"message"`
+	// Details are the exact installer commands the privileged step would run,
+	// one per backend, surfaced as the inspectable "what will run" affordance.
+	Details []string `json:"details,omitempty"`
+}
+
 // BackupChunkEvent tracks per-chunk progress of a hosted-backup push or pull.
 //
 // Status values:

--- a/go-engine/internal/manifest/validator.go
+++ b/go-engine/internal/manifest/validator.go
@@ -176,35 +176,24 @@ func ValidateManifestApps(m *Manifest) []ValidationError {
 	return errs
 }
 
-// brewCaskPrefix marks a darwin ref as a Homebrew Cask (a GUI app). It mirrors
-// the brew driver's caskPrefix; kept local so the manifest package has no
-// dependency on the driver package.
-const brewCaskPrefix = "cask:"
-
 // validateBrewApp enforces the brew driver routing rules (host-independent, so a
-// manifest authored on any OS is rejected the same way):
+// manifest authored on any OS is checked the same way):
 //
-//   - a darwin ref marked as a Cask (cask: prefix) WITHOUT driver:"brew" →
-//     CASK_REF_REQUIRES_BREW_DRIVER. The Nix realizer must never receive a cask
-//     ref; declaring the brew driver is the only valid home for one.
 //   - driver:"brew" WITHOUT a darwin ref → BREW_DRIVER_REQUIRES_DARWIN_REF. The
 //     brew driver only installs on darwin, so a brew app needs a darwin package
 //     to install (a bare formula ref or a cask: ref).
 //
-// Driver matching is case-insensitive (EqualFold), matching the apply-lane
-// partition. The windows-brew-ref conflict check is deferred (out of scope).
+// A darwin ref marked as a Cask (cask: prefix) WITHOUT driver:"brew" is NO LONGER
+// rejected: the cask: prefix routes the app to the brew lane BY DEFAULT
+// (partitionBrewLane), so the Nix realizer still never receives a cask ref — the
+// invariant is now upheld by routing, not by a manifest rejection
+// (brew-default-for-apps). Driver matching is case-insensitive (EqualFold),
+// matching the apply-lane partition.
 func validateBrewApp(app App) []ValidationError {
 	var errs []ValidationError
 	isBrew := strings.EqualFold(app.Driver, "brew")
 	darwinRef := app.Refs["darwin"]
-	isCask := strings.HasPrefix(strings.ToLower(strings.TrimSpace(darwinRef)), brewCaskPrefix)
 
-	if isCask && !isBrew {
-		errs = append(errs, ValidationError{
-			Code:    "CASK_REF_REQUIRES_BREW_DRIVER",
-			Message: fmt.Sprintf(`app %q: a "cask:" darwin ref requires driver:"brew" (the Nix realizer cannot install a Cask)`, app.ID),
-		})
-	}
 	if isBrew && darwinRef == "" {
 		errs = append(errs, ValidationError{
 			Code:    "BREW_DRIVER_REQUIRES_DARWIN_REF",

--- a/go-engine/internal/manifest/validator_brew_test.go
+++ b/go-engine/internal/manifest/validator_brew_test.go
@@ -4,7 +4,6 @@
 package manifest
 
 import (
-	"strings"
 	"testing"
 )
 
@@ -18,10 +17,11 @@ func findCode(errs []ValidationError, code string) bool {
 	return false
 }
 
-// TestValidateManifestApps_CaskRefWithoutBrewDriver: a darwin ref marked as a
-// Cask (cask: prefix) without driver:"brew" is rejected — the Nix realizer must
-// never see a cask ref. Host-independent (validation runs on all OSes).
-func TestValidateManifestApps_CaskRefWithoutBrewDriver(t *testing.T) {
+// TestValidateManifestApps_CaskRefWithoutBrewDriver_AutoRoutes: a darwin ref
+// marked as a Cask (cask: prefix) without driver:"brew" is now VALID — the cask:
+// prefix routes the app to the brew lane by default (brew-default-for-apps), so
+// the realizer-protection invariant is upheld by routing, not a rejection.
+func TestValidateManifestApps_CaskRefWithoutBrewDriver_AutoRoutes(t *testing.T) {
 	m := &Manifest{
 		Version: 1,
 		Apps: []App{
@@ -29,8 +29,11 @@ func TestValidateManifestApps_CaskRefWithoutBrewDriver(t *testing.T) {
 		},
 	}
 	errs := ValidateManifestApps(m)
-	if !findCode(errs, "CASK_REF_REQUIRES_BREW_DRIVER") {
-		t.Fatalf("expected CASK_REF_REQUIRES_BREW_DRIVER, got %+v", errs)
+	if findCode(errs, "CASK_REF_REQUIRES_BREW_DRIVER") {
+		t.Fatalf("a cask: ref without driver:brew must now auto-route (no rejection), got %+v", errs)
+	}
+	if len(errs) != 0 {
+		t.Fatalf("a cask: ref without driver:brew must validate cleanly, got %+v", errs)
 	}
 }
 
@@ -112,19 +115,16 @@ func TestValidateManifestApps_NoBrewNoCask_Unchanged(t *testing.T) {
 	}
 }
 
-// TestLoadManifest_CaskRefWithoutBrewDriver_FailsLoad: the cask validation
-// surfaces through the loader (host-independent) with a clear message.
-func TestLoadManifest_CaskRefWithoutBrewDriver_FailsLoad(t *testing.T) {
+// TestLoadManifest_CaskRefWithoutBrewDriver_LoadsAndAutoRoutes: a cask: ref
+// without driver:"brew" now LOADS cleanly through the loader — it auto-routes to
+// the brew lane (brew-default-for-apps) instead of being rejected.
+func TestLoadManifest_CaskRefWithoutBrewDriver_LoadsAndAutoRoutes(t *testing.T) {
 	p := writeSecretsManifest(t, `{
-  "version": 1, "name": "cask-noload", "apps": [
+  "version": 1, "name": "cask-autoroute", "apps": [
     { "id": "chrome", "refs": { "darwin": "cask:google-chrome" } }
   ]
 }`)
-	_, err := LoadManifest(p)
-	if err == nil {
-		t.Fatal("expected a load error for a cask ref without driver:brew, got nil")
-	}
-	if !strings.Contains(err.Error(), "brew") {
-		t.Errorf("error = %q, want it to mention the brew driver requirement", err)
+	if _, err := LoadManifest(p); err != nil {
+		t.Fatalf("a cask: ref without driver:brew must now load (auto-route), got error: %v", err)
 	}
 }

--- a/openspec/changes/engine-backend-bootstrap-impl/.openspec.yaml
+++ b/openspec/changes/engine-backend-bootstrap-impl/.openspec.yaml
@@ -1,0 +1,10 @@
+id: engine-backend-bootstrap-impl
+title: "Implement engine-installed backends — invisible Nix/Homebrew bootstrap"
+status: implementing
+spec: engine-backend-bootstrap-impl
+created: "2026-06-06"
+author: Hugo Ander Kivi
+artifacts:
+  - proposal.md
+  - design.md
+  - tasks.md

--- a/openspec/changes/engine-backend-bootstrap-impl/design.md
+++ b/openspec/changes/engine-backend-bootstrap-impl/design.md
@@ -1,0 +1,114 @@
+## Context
+
+The design-only `engine-backend-bootstrap` change scoped this capability and left six decisions to
+the human. Those are now ratified:
+
+1. **Scope = maximal**: shared contract + brew instance + Nix instance + the brew-default routing
+   flip, delivered as one arc across three stacked PRs.
+2. **Combined consent**: the engine aggregates the backends a run needs and emits **one**
+   consent-request; on the single yes it installs+verifies each backend independently.
+3. **Non-interactive default = skip-the-lane-with-a-clear-message** + emit the consent-request event;
+   `--bootstrap-backends` opts in, `--no-bootstrap` forces skip. Never installs without an explicit
+   yes; never hard-crashes on no.
+4. **Never silently uninstall** a backend the engine installed; removal is a separate user-owned
+   action — at most point at the official uninstaller.
+5. **Nix flavor = Determinate multi-user** installer (matches CI, flake-enabled).
+6. **Disclosure = plain-language + inspectable details**: the consent names no product but plainly
+   states it will set up installers, that the OS will ask for a password, and that a background helper
+   and a dedicated storage area may be created — with an inspectable details field carrying the exact
+   commands.
+
+## Goals / Non-Goals
+
+**Goals (this increment, PR 1):**
+
+- One backend-agnostic contract — *detect → consent → official install → verify → proceed-or-decline*
+  — implemented behind injectable seams, hermetically testable with no real installer.
+- Wire the **Homebrew** instance into the apply brew lane: present → no-op; absent+consented →
+  install → verify → use; declined/failed → the existing visible-skip path; never silent.
+- The flag + streamed-consent-event contract (`--bootstrap-backends` / `--no-bootstrap`; combined
+  consent-request event; install path is apply-only).
+
+**Non-Goals (this increment):**
+
+- The **Nix** command-lane wiring + the declined-Nix-but-consented-brew restructuring (PR 2).
+- The **brew-default-for-apps** routing flip (PR 3).
+- Any interactive CLI stdin prompt — the GUI event path is the primary audience; consent arrives as a
+  flag (the GUI re-invokes with `--bootstrap-backends`).
+- An assisted backend **uninstall** flow — never silently uninstall; at most point at the official
+  uninstaller.
+
+## 1. The contract — five states, backend-agnostic
+
+| State | Brew | Nix | Behavior |
+|---|---|---|---|
+| **Detect** | `brew` on PATH / known prefix | `nix` on PATH / Determinate default | present → no-op, no prompt |
+| **Consent** | combined plain-language ask | combined plain-language ask | **one** request; concept hidden, consent not |
+| **Install** | upstream `install.sh` | Determinate installer | the **official** installer, orchestrated, inspectable |
+| **Verify** | `brew --version` | `nix --version` + trivial eval | must pass **before** any package work |
+| **Decline / fail** | visible-skip the brew lane | (PR 2) skip the realizer lane | clear message; the rest of the run continues |
+
+Load-bearing rules: present → silent no-op; absent → exactly one combined consent then the official
+installer, never silent; verify gates use; decline/failure is graceful, never a half-done apply.
+
+## 2. Package shape (`internal/bootstrap`)
+
+```go
+type Backend string
+const ( BackendBrew Backend = "brew"; BackendNix Backend = "nix" )
+
+type Bootstrapper struct {
+    GOOS    string
+    Detect  func(b Backend) (present bool, err error) // LookPath / known prefix
+    Install func(b Backend) error                     // shells the OFFICIAL installer
+    Verify  func(b Backend) (ok bool, err error)      // <backend> --version (+ nix eval)
+}
+
+func (bs *Bootstrapper) Probe(needed []Backend)   (absent, present []Backend)
+func (bs *Bootstrapper) Provision(absent []Backend) map[Backend]Outcome // Installed|InstallFailed|VerifyFailed
+```
+
+Two-phase to support **combined** consent: `Probe` detects the whole needed set first (so the engine
+can emit one consent-request for all absent backends), then `Provision` installs+verifies each only
+after consent is granted. The real `Install` strategies are the only place a privileged installer is
+shelled, and they are never invoked under `go test` (tests inject fakes) — mirroring the winget
+real-output lesson: the install path is validated on a real machine, not reasoned about in CI.
+
+## 3. Where it runs (the pre-step seam)
+
+`apply`/`capture`/`verify`/`plan` resolve backends at the factory gate
+(`newRealizerFn`/`newBrewDriverFn`, defined in `commands/verify.go`). The bootstrap is a **pre-step in
+front of that gate**, behind a new injectable seam `bootstrapBackendsFn` (default no-op fake in the
+commands `TestMain`, so every existing test stays byte-identical). In PR 1 only the **brew** lane is
+gated through it: when the run has brew apps, `ensureBackendsForRun([BackendBrew], mutating, …)` runs
+*detect → (consent → install → verify)*; only an `available` brew backend resolves `newBrewDriverFn()`.
+Absent+declined leaves `brewDrv` nil → the existing visible-skip path (`apply_brew.go`).
+
+The **install path is apply-only**. `mutating=false` (plan/verify/capture) means detect → use-or-skip
+with a clear message, no install and no consent prompt — you do not install a package manager just to
+preview or read state.
+
+## 4. Consent surface
+
+The **engine owns the gate** (never install without consent) and **emits a streamed consent-request
+event** carrying the combined absent-backend set, a plain-language message, and an inspectable
+`details` field (the exact installer commands). It accepts the human's answer as
+`--bootstrap-backends` / `--no-bootstrap`. The **GUI renders** the event and re-invokes with the flag
+(CLI is source of truth). No interactive stdin prompt is implemented in this increment.
+
+## 5. The CI-test wrinkle (recorded, not solved here)
+
+The GH `macos-latest` runner has Homebrew and (via the Determinate action) Nix preinstalled, so the
+path-filtered macOS smoke exercises only **detect → present → no-op**. The *absent → consent →
+install → verify* path is validated on a **clean real machine / throwaway VM**, out of band. Hermetic
+unit tests cover the detect/consent/verify orchestration with fake installers; the spec and tests do
+**not** over-claim CI coverage of the install path.
+
+## Risks / Verification
+
+- **Unsuppressable, environment-specific prompts** (Xcode-CLT, sudo, MDM/corp policy) — surfaced as
+  plain-language failure states, never reasoned away; failure is a clear error, not a half-done apply.
+- **Install path under-covered by CI** (§5) — mitigated by hermetic fake-installer tests + a
+  manual/real-machine run before any correctness claim.
+- **Non-regression** — present-backend and no-brew-manifest paths must be byte-identical to today; the
+  default `bootstrapBackendsFn` fake (present/available) guarantees existing tests are unchanged.

--- a/openspec/changes/engine-backend-bootstrap-impl/proposal.md
+++ b/openspec/changes/engine-backend-bootstrap-impl/proposal.md
@@ -1,0 +1,84 @@
+## Why
+
+On Windows Endstate's package backend ships with the OS (`winget`), so "rebuild my machine" needs
+no prerequisites. On **macOS and Linux it does not**: Endstate's backends — the **Nix realizer**
+(the default lane: cross-OS CLI packages + home-manager config) and the **Homebrew driver** (the
+`driver: "brew"` lane: GUI apps/casks) — are **not preinstalled**. Today a missing backend is a hard
+stop: the realizer surfaces `REALIZER_UNAVAILABLE` when Nix is absent, and the brew lane degrades to
+visible skips when `brew` is absent. For the non-technical audience Endstate targets first, "go
+install Nix / Homebrew first" is exactly the wall the product exists to remove.
+
+This change **implements** the `engine-backend-bootstrap` capability that was scoped design-only in
+the `engine-backend-bootstrap` change: the engine **detects** a needed backend, and when it is absent
+on macOS/Linux, **requests one plain-language consent**, runs the **official upstream installer**,
+**verifies** the backend works, then **proceeds** — or, on decline, **skips that lane with a clear
+message and continues the run**. The governing principle is **invisible but inspectable**: the user
+never learns the words "Nix"/"Homebrew," but every privileged step stays explicit, consented, and
+auditable.
+
+This is delivered as **one arc across three stacked PRs** under a single capability:
+
+1. the **shared backend-agnostic contract** (detect → consent → official install → verify →
+   proceed-or-decline) **plus the Homebrew instance wired into the command lanes** — this change's
+   first increment;
+2. the **Nix instance** + the lane restructuring that lets a declined Nix still run a consented brew
+   lane;
+3. the **brew-default-for-apps routing flip** (which depends on brew being reliably bootstrappable).
+
+## What Changes
+
+- **ADD a backend-agnostic bootstrap contract** — a new `internal/bootstrap` package implementing
+  *detect → consent → official install → verify → proceed-or-decline-gracefully* behind injectable
+  seams (`Detect`/`Install`/`Verify`) so it is hermetically testable. **No real installer ever runs
+  in `go test`.** A present+working backend is a silent no-op (no prompt). An absent backend is
+  installed only after **one explicit, combined consent**, never silently. A declined consent skips
+  that backend's lane with a clear message and continues the rest of the run. A backend that installs
+  but fails its verify probe is treated as **unavailable**, not used half-configured.
+- **Orchestrate the OFFICIAL upstream installer, never a vendored fork** — Nix → the Determinate Nix
+  installer (matching `.github/workflows/nix-integration.yml`); Homebrew → the upstream `install.sh`.
+  The engine drives the installer and never suppresses the OS credential / Xcode-CLT prompts it forces.
+- **Wire the consent as a flag-driven gate + streamed event** — `--bootstrap-backends` opts in,
+  `--no-bootstrap` forces skip; in a non-interactive context with no consent the engine **skips the
+  lane with a clear message** and emits a single combined **consent-request event** the GUI renders
+  (CLI is source of truth). The install path runs only on the mutating `apply` command; read-only
+  commands (`plan`/`verify`/`capture`) detect → use-or-skip without offering to install.
+- **Wire the Homebrew instance** into the apply brew lane (this increment): an absent+declined brew
+  backend reuses the existing visible-skip path, so a present brew backend or a no-brew manifest is
+  behavior-identical to today.
+
+Increment 2 (the Nix instance + declined-lane restructuring) and increment 3 (the brew-default
+routing flip) extend this same change's spec and tasks; the change is archived after increment 3.
+
+## Capabilities
+
+### New Capabilities
+
+- `engine-backend-bootstrap-impl`: Endstate installs **its own** package backend when it is absent on
+  macOS/Linux — consented, via the official installer, verified before use, and gracefully skippable.
+  A distinct capability id from the design-only `engine-backend-bootstrap` (which this implements) so
+  `openspec validate --all --strict` does not collide while both are active.
+
+### Modified Capabilities
+
+- None in this increment. The **Homebrew-specific** bootstrap requirement remains owned by
+  `macos-brew-driver` §8 (the brew instance here is one instance of this shared contract); this change
+  does not restate it. The brew-default routing flip (increment 3) coordinates with
+  `macos-brew-driver`'s per-app driver-selection requirement.
+
+## Impact
+
+- New `go-engine/internal/bootstrap/` — the detect/consent/install/verify orchestration, one strategy
+  per backend (Determinate Nix, Homebrew), each shelling the **official** installer behind an
+  injectable seam so it is hermetically testable.
+- New `go-engine/internal/commands/bootstrap.go` — the `bootstrapBackendsFn` pre-step seam,
+  `neededBackends`, and `ensureBackendsForRun`, run before the backend factory gate
+  (`newRealizerFn`/`newBrewDriverFn`) resolves.
+- `go-engine/internal/commands/apply.go` — the brew lane resolves through the bootstrap pre-step;
+  a declined/failed brew bootstrap leaves the lane in its existing visible-skip state.
+- `go-engine/internal/events/` — a new streamed `consent` event carrying the combined backend set,
+  the plain-language message, and an inspectable details field (the exact installer commands).
+- `go-engine/cmd/endstate/main.go` — `--bootstrap-backends` / `--no-bootstrap` flags.
+- **CI wrinkle (recorded, not solved):** the GH `macos-latest` runner has Homebrew and (via the
+  Determinate action) Nix preinstalled, so the macOS smoke can only exercise *detect → present →
+  no-op*. The *absent → consent → install → verify* path is validated on a clean real machine / VM,
+  out of band. Hermetic unit tests cover the contract logic with fake installers.

--- a/openspec/changes/engine-backend-bootstrap-impl/specs/engine-backend-bootstrap-impl/spec.md
+++ b/openspec/changes/engine-backend-bootstrap-impl/specs/engine-backend-bootstrap-impl/spec.md
@@ -115,3 +115,41 @@ the plain-language portion of the consent.
 - **THEN** the engine SHALL emit one consent-request event covering the combined set of absent
   backends, with a plain-language message and an inspectable details field
 - **AND** it SHALL default to skipping the lane with a clear message rather than installing silently
+
+### Requirement: The Nix backend bootstrap accounts for its heavier footprint and is never silently removed
+
+The engine SHALL treat bootstrapping the Nix realizer as a heavier, privileged system change than the
+Homebrew bootstrap: a multi-user installation with a background daemon and, on macOS, a dedicated store
+volume, installed by the official Determinate installer. When the Nix realizer is needed by a run but is
+unavailable — the user declined the bootstrap, or it failed verification — the engine SHALL skip the
+realizer lane with a clear message and SHALL still run any other available lane (for example, an
+already-consented Homebrew lane), rather than aborting the run or leaving a half-done apply. The engine
+SHALL NOT silently uninstall a backend it installed; removing a backend SHALL be a separate, explicit,
+user-owned action. On Windows the engine SHALL NOT attempt a backend bootstrap, because the platform
+package backend ships with the operating system.
+
+#### Scenario: Nix is bootstrapped as a multi-user system change
+
+- **WHEN** the engine bootstraps Nix on macOS or Linux after consent
+- **THEN** it SHALL use the multi-user installation (background daemon, and on macOS the dedicated store
+  volume) provided by the official Determinate installer
+
+#### Scenario: Declined Nix skips the realizer lane but a consented brew lane still runs
+
+- **WHEN** an `apply` needs both the Nix realizer and the Homebrew driver, the user consents, Homebrew
+  installs and verifies, but Nix is unavailable (declined or failed)
+- **THEN** the engine SHALL skip the realizer-lane apps with a clear message
+- **AND** it SHALL still install the brew-routed apps through Homebrew
+- **AND** the run SHALL NOT return a top-level error solely because the realizer lane was skipped
+
+#### Scenario: The engine does not silently remove a backend it installed
+
+- **WHEN** a backend was bootstrapped by the engine
+- **THEN** the engine SHALL NOT silently uninstall it as part of any later run
+- **AND** removing the backend SHALL require a separate, explicit, user-owned action
+
+#### Scenario: Windows needs no backend bootstrap
+
+- **WHEN** a run executes on Windows
+- **THEN** the engine SHALL NOT attempt to bootstrap a package backend
+- **AND** it SHALL use the operating-system-provided backend directly

--- a/openspec/changes/engine-backend-bootstrap-impl/specs/engine-backend-bootstrap-impl/spec.md
+++ b/openspec/changes/engine-backend-bootstrap-impl/specs/engine-backend-bootstrap-impl/spec.md
@@ -153,3 +153,30 @@ package backend ships with the operating system.
 - **WHEN** a run executes on Windows
 - **THEN** the engine SHALL NOT attempt to bootstrap a package backend
 - **AND** it SHALL use the operating-system-provided backend directly
+
+### Requirement: A Cask reference routes to the brew lane by default
+
+The engine SHALL route an app whose `darwin` reference is a Homebrew Cask (the `cask:` prefix,
+case-insensitive) to the brew lane by default on macOS, without the user also declaring
+`driver: "brew"`. The engine SHALL NOT reject a manifest solely because a `cask:` darwin reference
+omits `driver: "brew"`. The Nix realizer SHALL never receive a `cask:` reference, and the engine SHALL
+uphold that invariant by routing the Cask to the brew lane rather than by rejecting the manifest. The
+engine SHALL still route an app that declares `driver: "brew"` to the brew lane regardless of its
+reference shape, and SHALL continue to route a bare (non-Cask) darwin reference without `driver: "brew"`
+to the Nix realizer (the default lane), so a manifest that declares no Cask and no brew driver behaves
+identically to the realizer-only path. This routing supersedes the `macos-brew-driver` scenario that
+rejected a Cask reference lacking `driver: "brew"`, reconciled into that change's spec when it graduates.
+
+#### Scenario: A Cask reference without the brew driver auto-routes to brew
+
+- **WHEN** a manifest declares an app whose `darwin` reference is a `cask:` Cask and does not declare
+  `driver: "brew"`
+- **THEN** the engine SHALL accept the manifest
+- **AND** it SHALL provision that app through the brew lane
+- **AND** it SHALL NOT pass the `cask:` reference to the Nix realizer
+
+#### Scenario: A bare darwin reference without a driver stays on the realizer
+
+- **WHEN** a manifest declares an app with a bare (non-`cask:`) `darwin` reference and no `driver`
+- **THEN** the engine SHALL route it to the Nix realizer (the default lane)
+- **AND** the behavior SHALL be unchanged from before the Cask auto-routing

--- a/openspec/changes/engine-backend-bootstrap-impl/specs/engine-backend-bootstrap-impl/spec.md
+++ b/openspec/changes/engine-backend-bootstrap-impl/specs/engine-backend-bootstrap-impl/spec.md
@@ -1,0 +1,117 @@
+## ADDED Requirements
+
+### Requirement: A missing backend is bootstrapped only with explicit consent
+
+The engine SHALL bootstrap a package backend a run needs (the Nix realizer or the Homebrew driver)
+when it is absent on macOS or Linux only after explicit, plain-language user consent. When the backend
+is already present and working, the engine SHALL use it directly without prompting or re-installing.
+When a run needs more than one absent backend, the engine SHALL request consent **once** for the
+combined set rather than once per backend. The engine SHALL NOT install a backend silently or without
+consent. When the user declines, the engine SHALL skip that backend's lane with a clear message and
+SHALL still run the rest of the apply. Installation SHALL be attempted only during the mutating
+`apply` command; read-only commands SHALL detect the backend and use it or skip its lane without
+attempting an install.
+
+#### Scenario: Backend already present — no prompt, no install
+
+- **WHEN** a run needs a backend that is already installed and working
+- **THEN** the engine SHALL use it directly
+- **AND** it SHALL NOT request consent or attempt a bootstrap
+
+#### Scenario: Backend absent — one combined consent before any install
+
+- **WHEN** an `apply` run needs one or more backends that are not installed
+- **THEN** the engine SHALL request consent once, in plain language, describing the action without
+  requiring knowledge of the backend's product name
+- **AND** it SHALL install the needed backends only after the user explicitly consents
+- **AND** it SHALL NOT install any backend silently
+
+#### Scenario: Consent declined — lane skipped, run continues
+
+- **WHEN** the user declines the bootstrap for a backend an `apply` needs
+- **THEN** the engine SHALL NOT install that backend
+- **AND** it SHALL skip that backend's lane with a clear message
+- **AND** it SHALL still run the remaining lanes and configuration of the apply
+
+#### Scenario: Read-only command does not install an absent backend
+
+- **WHEN** a read-only command (for example `verify` or `plan`) runs and a backend it would use is absent
+- **THEN** the engine SHALL NOT attempt to install the backend
+- **AND** it SHALL NOT request install consent
+
+### Requirement: A bootstrapped backend is verified working before use
+
+After installing a backend, the engine SHALL verify the backend actually works before provisioning any
+package or configuration through it. A backend whose installer completes but whose verification probe
+fails SHALL be treated as unavailable, and the engine SHALL surface a clear error rather than
+proceeding as if the backend were present. A bootstrap that fails SHALL NOT leave the run silently
+half-completed.
+
+#### Scenario: Post-install verification gates use
+
+- **WHEN** the engine has just installed a backend
+- **THEN** it SHALL run a verification probe (for example the backend's version command or an
+  evaluation) confirming the backend works
+- **AND** it SHALL provision through the backend only after that probe passes
+
+#### Scenario: Verification failure is surfaced, not silent
+
+- **WHEN** a backend installs but its verification probe fails
+- **THEN** the engine SHALL treat the backend as unavailable
+- **AND** it SHALL report a clear error
+- **AND** it SHALL NOT proceed as if the backend were available
+
+### Requirement: The engine orchestrates the official installer, never a vendored fork
+
+When bootstrapping a backend, the engine SHALL run the backend's official upstream installer — the
+Determinate installer for Nix and the upstream installer script for Homebrew — orchestrating it rather
+than vendoring, forking, or re-implementing it. The privileged, system-modifying step SHALL be
+inspectable. The engine SHALL NOT suppress operating-system credential or component prompts (such as
+the macOS administrator password or the Xcode Command Line Tools install) that the official installer
+requires.
+
+#### Scenario: Homebrew bootstrap runs the official installer
+
+- **WHEN** the engine bootstraps the Homebrew backend
+- **THEN** it SHALL run the official upstream Homebrew installer
+- **AND** it SHALL NOT use a vendored or re-implemented installer
+
+#### Scenario: Nix bootstrap runs the official installer
+
+- **WHEN** the engine bootstraps the Nix backend
+- **THEN** it SHALL run the official Determinate Nix installer
+- **AND** it SHALL NOT use a vendored or re-implemented installer
+
+#### Scenario: Operating-system prompts are not suppressed
+
+- **WHEN** the official installer triggers an operating-system credential or component prompt
+- **THEN** the engine SHALL let that prompt proceed
+- **AND** it SHALL NOT attempt to suppress or bypass it
+
+### Requirement: Backend bootstrap consent is flag-driven with a streamed consent request
+
+The engine SHALL accept the user's bootstrap consent through command-line flags — an opt-in flag that
+authorizes installing absent backends and an opt-out flag that forces skipping them. When neither flag
+is given and an `apply` needs an absent backend, the engine SHALL emit a single streamed
+consent-request event describing the combined set of absent backends in plain language, including an
+inspectable details field carrying the exact installer commands, and SHALL default to skipping the
+lane with a clear message rather than installing. The engine SHALL NOT name the backend's product in
+the plain-language portion of the consent.
+
+#### Scenario: Opt-in flag authorizes the install
+
+- **WHEN** `apply` runs with the bootstrap opt-in flag and a needed backend is absent
+- **THEN** the engine SHALL install that backend via its official installer and verify it before use
+
+#### Scenario: Opt-out flag forces a skip
+
+- **WHEN** `apply` runs with the bootstrap opt-out flag and a needed backend is absent
+- **THEN** the engine SHALL NOT install the backend
+- **AND** it SHALL skip that backend's lane with a clear message and continue the run
+
+#### Scenario: No flag — consent requested and lane skipped by default
+
+- **WHEN** `apply` needs an absent backend and neither bootstrap flag is given
+- **THEN** the engine SHALL emit one consent-request event covering the combined set of absent
+  backends, with a plain-language message and an inspectable details field
+- **AND** it SHALL default to skipping the lane with a clear message rather than installing silently

--- a/openspec/changes/engine-backend-bootstrap-impl/tasks.md
+++ b/openspec/changes/engine-backend-bootstrap-impl/tasks.md
@@ -41,16 +41,20 @@
 > maintainer-gated follow-up (protected area). The event type is a contract-sanctioned non-breaking
 > addition (no version bump); it is implemented in code but not yet listed in the contract doc.
 
-## PR 2 — Nix instance + declined-lane restructuring (subsequent PR)
+## PR 2 — Nix instance + declined-lane restructuring
 
-- [ ] 2.1 Wire the **realizer** lane through `ensureBackendsForRun([BackendNix], …)` ahead of the
-      `newRealizerFn()` gate in apply/verify/plan/capture.
-- [ ] 2.2 Extract a standalone brew-only apply path (`runApplyBrewOnly`) so a declined/unavailable Nix
-      with a consented brew lane still installs brew apps; Nix-only-and-declined → "lane skipped",
-      never a crash. Keep `runApplyRealizer`'s present-Nix path byte-identical.
-- [ ] 2.3 Add the **Nix footprint** requirement to the delta spec (multi-user daemon + macOS APFS
-      store volume + root; **no silent uninstall**; Windows exempt) + the combined-consent-over-both
-      scenario.
+- [x] 2.1 Wire the **realizer** lane through the bootstrap pre-step on **apply** with ONE combined
+      consent over the needed set (`neededBackends`: Nix when restApps or a config stage; brew when
+      brew apps). Route on `nixNeeded && avail[Nix]`. (Read-only commands verify/plan/capture keep
+      today's behavior — they never install, and surface REALIZER_UNAVAILABLE when Nix is absent; a
+      graceful read-only skip is a deferred follow-up, NOT a regression.)
+- [x] 2.2 New `runApplyBrewOnly` (apply_brew_only.go) + `configStageApplies`: a declined/unavailable
+      Nix with a consented brew lane still installs brew apps (realizer-lane apps → visible skip,
+      manual apps still evaluated); Nix-only-and-declined → all skipped, no crash, no generation. Keep
+      `runApplyRealizer`'s present-Nix path byte-identical (all existing brew tests have a nix app →
+      still routed to runApplyRealizer).
+- [x] 2.3 Add the **Nix footprint + no-silent-uninstall + Windows-exempt** requirement to the delta
+      spec, with the declined-Nix-but-consented-brew scenario.
 
 ## PR 3 — brew-default-for-apps routing flip (subsequent PR)
 

--- a/openspec/changes/engine-backend-bootstrap-impl/tasks.md
+++ b/openspec/changes/engine-backend-bootstrap-impl/tasks.md
@@ -1,0 +1,68 @@
+# Tasks — engine-backend-bootstrap-impl (one arc, three stacked PRs)
+
+> Implementation change. TDD RED→GREEN. No real installer runs in `go test`. Verification each PR:
+> `cd go-engine && go test ./...` + `go vet ./...` + `GOOS=windows go build ./...` +
+> `openspec validate --all --strict --no-interactive`.
+
+## PR 1 — shared contract package + Homebrew instance
+
+- [x] 1.1 New `go-engine/internal/bootstrap/` package: `Backend` (`BackendBrew`/`BackendNix`),
+      `Bootstrapper{Detect, Install, Verify}` seams, `Probe(needed) → (absent, present)`,
+      `Provision(absent) → map[Backend]Outcome` (`Installed`/`InstallFailed`/`VerifyFailed`).
+- [x] 1.2 Real `Detect` (both backends): brew → `exec.LookPath("brew")` + known prefixes; nix →
+      `exec.LookPath("nix")` + the Determinate default path.
+- [x] 1.3 Real `Install` (both backends; NEVER run in tests): brew → upstream `install.sh`; nix →
+      the Determinate installer. OS credential/Xcode-CLT prompts passed through, never suppressed.
+- [x] 1.4 Real `Verify` (both backends): `brew --version` / `nix --version`.
+- [x] 1.5 Hermetic `bootstrap` tests with fake `Detect`/`Install`/`Verify`: present→no-op,
+      absent+granted→install→verify→available, absent+declined→skip, installer-ok-but-verify-fail→
+      unavailable, multiple backends independent; assert no real installer is invoked.
+- [x] 1.6 `events`: add `ConsentEvent` to `types.go` + `EmitConsent` to `emitter.go` (no-op when
+      disabled), carrying the combined backend set, the plain-language message, and inspectable
+      details. Tests for the emitted shape.
+- [x] 1.7 New `go-engine/internal/commands/backend_bootstrap.go` (bootstrap.go was taken by the
+      `endstate bootstrap` self-install command): `bootstrapBackendsFn` seam, `bootstrapConsent`,
+      `bootstrappableOn`, `realEnsureBackends(needed, mutating, consent, emitter) → (available map,
+      *envelope.Error)`. Install path is apply-only (`mutating=true`); read-only → no install, no consent.
+- [x] 1.8 Default present/available no-op fake for `bootstrapBackendsFn` in `commands/main_test.go`,
+      so every existing command test stays byte-identical.
+- [x] 1.9 `ApplyFlags` gains `BootstrapBackends`/`NoBootstrap`; flag-parse loop + usage in
+      `cmd/endstate/main.go`; pass-through at the `RunApply` call site.
+- [x] 1.10 Wire the **brew** lane: gate `newBrewDriverFn()` resolution in `apply.go` through
+      `bootstrapBackendsFn([BackendBrew], mutating=true, …)`. Absent+declined → `brewDrv` nil →
+      existing visible-skip. Present / no-brew-manifest → byte-identical to today.
+- [x] 1.11 `commands` wiring tests: declined → brew lane skipped + run continues (one nix generation,
+      brew factory never resolved); realEnsureBackends branch tests + the consent event with the
+      combined set + inspectable details.
+- [x] 1.12 Delta spec (`specs/engine-backend-bootstrap-impl/spec.md`) for the four PR-1 requirements;
+      `openspec validate --all --strict --no-interactive` passes.
+
+> NOTE: documenting the new `consent` event type in `docs/contracts/event-contract.md` is a
+> maintainer-gated follow-up (protected area). The event type is a contract-sanctioned non-breaking
+> addition (no version bump); it is implemented in code but not yet listed in the contract doc.
+
+## PR 2 — Nix instance + declined-lane restructuring (subsequent PR)
+
+- [ ] 2.1 Wire the **realizer** lane through `ensureBackendsForRun([BackendNix], …)` ahead of the
+      `newRealizerFn()` gate in apply/verify/plan/capture.
+- [ ] 2.2 Extract a standalone brew-only apply path (`runApplyBrewOnly`) so a declined/unavailable Nix
+      with a consented brew lane still installs brew apps; Nix-only-and-declined → "lane skipped",
+      never a crash. Keep `runApplyRealizer`'s present-Nix path byte-identical.
+- [ ] 2.3 Add the **Nix footprint** requirement to the delta spec (multi-user daemon + macOS APFS
+      store volume + root; **no silent uninstall**; Windows exempt) + the combined-consent-over-both
+      scenario.
+
+## PR 3 — brew-default-for-apps routing flip (subsequent PR)
+
+- [ ] 3.1 Flip `partitionBrewLane` default routing on darwin (define precisely which app shapes route
+      to brew by default); table tests. Coordinate with `macos-brew-driver`'s per-app driver-selection
+      requirement.
+- [ ] 3.2 Add the routing requirement to the delta spec.
+
+## Non-tasks (out of scope for this change)
+
+- [ ] N.1 Interactive CLI stdin consent prompt (the GUI event path is the primary audience).
+- [ ] N.2 An assisted backend **uninstall** flow (never silently uninstall; point at the official
+      uninstaller only).
+- [ ] N.3 A Windows bootstrap (winget ships with the OS).
+- [ ] N.4 Vendoring or forking any installer (the engine orchestrates the official installer only).

--- a/openspec/changes/engine-backend-bootstrap-impl/tasks.md
+++ b/openspec/changes/engine-backend-bootstrap-impl/tasks.md
@@ -56,12 +56,17 @@
 - [x] 2.3 Add the **Nix footprint + no-silent-uninstall + Windows-exempt** requirement to the delta
       spec, with the declined-Nix-but-consented-brew scenario.
 
-## PR 3 — brew-default-for-apps routing flip (subsequent PR)
+## PR 3 — brew-default-for-apps routing flip
 
-- [ ] 3.1 Flip `partitionBrewLane` default routing on darwin (define precisely which app shapes route
-      to brew by default); table tests. Coordinate with `macos-brew-driver`'s per-app driver-selection
-      requirement.
-- [ ] 3.2 Add the routing requirement to the delta spec.
+- [x] 3.1 Flip routing: a `cask:` darwin ref auto-routes to the brew lane WITHOUT requiring
+      `driver: "brew"` (the cask: prefix is the unambiguous GUI-app signal). `partitionBrewLane` routes
+      on `driver:"brew"` OR `isCaskRef(refs["darwin"])`; the manifest validator no longer rejects a
+      cask: ref without driver:brew (the realizer-never-sees-cask invariant is now upheld by routing).
+      Bare darwin refs without a driver stay on the realizer (default lane unchanged). Table tests +
+      inverted validator tests.
+- [x] 3.2 Add the Cask-auto-routing requirement to the delta spec. It SUPERSEDES `macos-brew-driver`'s
+      "A Cask reference without the brew driver is rejected" scenario — reconciled into
+      `macos-brew-driver` when that change graduates (maintainer-coordinated).
 
 ## Non-tasks (out of scope for this change)
 


### PR DESCRIPTION
## Summary

Implements the **`engine-backend-bootstrap`** capability (previously design-only, PR #116): on macOS/Linux the engine now installs its own absent package backend — **consented, via the official installer, verified before use, gracefully skippable**. This is the "zero prerequisites" keystone for the non-technical audience: a fresh Mac/Linux box with neither Nix nor Homebrew can rebuild from a manifest with one plain-language consent.

Governing principle — **invisible but inspectable**: the user never learns the words "Nix"/"Homebrew", but every privileged step is explicit, consented, and auditable.

Delivered as one OpenSpec arc (`engine-backend-bootstrap-impl`, strict-valid) across **3 stacked commits**:

- **PR1 `9f11dbd`** — shared backend-agnostic contract (`internal/bootstrap`: `detect → consent → official install → verify → proceed-or-decline` behind injectable seams; real installers **never run in `go test`**) + the **Homebrew** instance wired into the apply brew lane via a `bootstrapBackendsFn` pre-step. New `consent` event; `--bootstrap-backends` / `--no-bootstrap` flags.
- **PR2 `57b44b9`** — the **Nix** instance + **one combined consent** over the needed set + `runApplyBrewOnly`: a declined/unavailable Nix with a consented brew lane still installs brew (realizer-lane apps → visible skip; manual apps still evaluated); a Nix-only manifest with Nix declined skips everything and never crashes. Fixes today's `REALIZER_UNAVAILABLE` hard stop. `runApplyRealizer`'s present-Nix path stays byte-identical.
- **PR3 `81129a8`** — **brew-default-for-apps**: a `cask:` darwin ref auto-routes to the brew lane without requiring `driver: "brew"`. The "Nix realizer never receives a cask ref" invariant is now upheld by routing (not a load-time rejection). Bare darwin refs stay on the realizer (default lane unchanged).

## Ratified decisions

Combined consent · skip-the-lane-with-message default (never install without explicit consent, never crash on decline) · never silently uninstall · Determinate multi-user Nix installer · plain-language (product-neutral) consent + inspectable exact-command details.

## Verification

`go test ./...` · `go vet ./...` · `GOOS=windows go build ./...` · `openspec validate --all --strict` (**73/73**) — all pass on every commit. Pre-push hooks (openspec-validate + version-format) pass.

**CI cannot smoke the install path:** the GitHub `macos-latest` runner has Homebrew and (via the Determinate action) Nix preinstalled, so the macOS smoke only exercises *detect → present → no-op*. The *absent → consent → install → verify* path must be validated on a **clean real machine / VM**, out of band. Hermetic unit tests cover the contract logic with fake installers; the real install path is **not** CI-covered (intentionally not over-claimed).

## Maintainer follow-ups (not in this PR)

1. **`docs/contracts/event-contract.md`** — document the new `consent` event type (protected doc; contract-sanctioned non-breaking addition, implemented but not yet listed). Not edited here without explicit go-ahead.
2. **`macos-brew-driver` reconciliation** — PR3 supersedes that design's "A Cask reference without the brew driver is rejected" scenario (cask now auto-routes). Reconcile when `macos-brew-driver` graduates.

## Deferred (noted in spec/tasks; not regressions)

- Read-only `verify`/`plan`/`capture` keep today's behavior when Nix is absent (they never install; a graceful read-only detect→skip is a later nicety). `REALIZER_UNAVAILABLE` for a *present-but-unhealthy* Nix (daemon down mid-run) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
