### PR TITLE
docs(contract): document consent event + reconcile cask auto-routing (bootstrap follow-ups)

### DIFF
--- a/docs/contracts/event-contract.md
+++ b/docs/contracts/event-contract.md
@@ -46,7 +46,7 @@ Every event **MUST** include:
 | `version` | integer | Event schema version (always `1` for this contract) |
 | `runId` | string | Run identifier (e.g., `"apply-20250101-120000-MACHINE"`) |
 | `timestamp` | string | RFC3339 UTC timestamp (informational; NDJSON line order is authoritative) |
-| `event` | string | Event type: `"phase"`, `"item"`, `"summary"`, `"error"`, `"artifact"`, `"restore-item"`, `"backup-chunk"` |
+| `event` | string | Event type: `"phase"`, `"item"`, `"summary"`, `"error"`, `"artifact"`, `"restore-item"`, `"backup-chunk"`, `"consent"` |
 
 ### Event Types
 
@@ -297,6 +297,43 @@ Tracks per-chunk progress of a hosted-backup push or pull (added in engine v2.3.
 **Consumer notes:**
 - The GUI MUST handle missing `attempt` / `maxAttempts` gracefully (treat as a generic retry indicator) so a GUI built against this event can still consume events from an older engine that doesn't yet emit them
 - `current` is omitted from the manifest chunk (chunkIndex == -1); the GUI should render "manifest" rather than a chunk number
+
+---
+
+#### 8. Consent Event
+
+Requests the user's consent to bootstrap one or more absent package backends — on macOS/Linux the engine installs its own package backend (the Nix realizer / Homebrew driver) when it is missing. Non-breaking addition (new event type, no version bump required per extensibility rules).
+
+One event covers the **combined** set of backends a run needs and lacks, so the GUI renders a single plain-language consent dialog. The `message` is product-neutral (it never names "Nix"/"Homebrew") to keep the backend concepts invisible; the `details` carry the exact, inspectable installer commands for anyone who looks.
+
+```json
+{
+  "version": 1,
+  "runId": "apply-20260606-120000-MACHINE",
+  "timestamp": "2026-06-06T12:00:01.000Z",
+  "event": "consent",
+  "backends": ["brew", "nix"],
+  "message": "Endstate needs to set up the tools it uses to install and configure your software. You may be asked for your administrator password, and a background helper and a dedicated storage area may be created. See the details for the exact commands that will run.",
+  "details": [
+    "/bin/bash -c \"$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)\"",
+    "curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | sh -s -- install --no-confirm"
+  ]
+}
+```
+
+**Fields:**
+- `backends` (array of string, required): Internal identifiers of the absent backends needing consent (e.g. `"brew"`, `"nix"`). Structured metadata the GUI maps back to the run — not user-facing copy.
+- `message` (string, required): The plain-language, product-neutral consent ask. Names no backend product.
+- `details` (array of string, optional): The exact installer commands the privileged step would run, one per backend — the inspectable "what will run" affordance. Omitted when empty.
+
+**Guarantees:**
+- At most ONE consent event per run, covering the combined set of absent needed backends (combined consent).
+- Emitted only by the mutating `apply` command, and only when a needed backend is absent and consent has not yet been given. A present/working backend never emits it; `--bootstrap-backends` installs without emitting a request; `--no-bootstrap` skips without emitting a request.
+- The engine never installs a backend without explicit consent; absent a consent decision it defaults to skipping that backend's lane and continuing the run.
+
+**Consumer notes:**
+- The GUI renders `message` as the dialog body and may reveal `details` behind a "show details" affordance; on the user's affirmative it re-invokes the engine with `--bootstrap-backends`.
+- A consumer built against an older engine that does not emit `consent` is unaffected (forward compatibility — unknown event types are ignored).
 
 ---
 

--- a/openspec/changes/macos-brew-driver/specs/macos-brew-driver/spec.md
+++ b/openspec/changes/macos-brew-driver/specs/macos-brew-driver/spec.md
@@ -84,11 +84,13 @@ does not remove user data.
 ### Requirement: Per-app driver selection routes brew versus nix on darwin
 
 On macOS, where both the Nix realizer and the brew driver are available, the engine SHALL route each
-manifest app to a backend using the per-app `driver` field: an app declaring the brew driver SHALL be
-provisioned through Homebrew, and every other app together with all home-manager configuration SHALL
-be provisioned through the Nix realizer, which remains the default. The engine SHALL run both backends
-in the same `apply`, `capture`, `verify`, and `plan` invocation rather than letting one backend
-exclude the other.
+manifest app to a backend: an app declaring the brew driver — or whose `darwin` reference is a Homebrew
+Cask (the `cask:` prefix) — SHALL be provisioned through Homebrew, and every other app together with all
+home-manager configuration SHALL be provisioned through the Nix realizer, which remains the default. The
+engine SHALL run both backends in the same `apply`, `capture`, `verify`, and `plan` invocation rather
+than letting one backend exclude the other. The Cask auto-routing default (a `cask:` reference routes to
+brew without `driver: "brew"`) is owned by the `engine-backend-bootstrap-impl` capability; this
+requirement composes with it.
 
 #### Scenario: A brew-driver app and a default app coexist in one apply
 
@@ -105,12 +107,13 @@ exclude the other.
 - **AND** the behavior of a manifest that declares no brew-driver apps SHALL be unchanged from the
   realizer-only path
 
-#### Scenario: A Cask reference without the brew driver is rejected
+#### Scenario: A Cask reference without the brew driver auto-routes to brew
 
-- **WHEN** a manifest declares an app whose `darwin` reference marks it as a Cask but does not route it
-  to the brew driver
-- **THEN** the engine SHALL reject the manifest at load with a clear error
-- **AND** it SHALL NOT attempt to install the Cask through the Nix realizer
+- **WHEN** a manifest declares an app whose `darwin` reference marks it as a Cask but does not declare
+  the brew driver
+- **THEN** the engine SHALL route that app to the brew lane by default (the `cask:` prefix is the
+  routing signal) rather than rejecting the manifest at load
+- **AND** it SHALL NOT pass the Cask reference to the Nix realizer
 
 ### Requirement: Brew verifies presence and best-effort version
 


### PR DESCRIPTION
Two post-merge reconciliations of the engine-backend-bootstrap arc (#125). **No engine code changes.**

### 1. Document the `consent` event (`docs/contracts/event-contract.md`)
The bootstrap pre-step emits a `consent` event (combined absent-backend set + product-neutral message + inspectable installer-command details). It shipped in #125 but wasn't yet recorded in the contract. Adds it to the event-type table + a new **Consent Event** section (fields, guarantees — one event per run / apply-only / never-install-without-consent, and consumer notes). Contract-sanctioned **non-breaking** addition (new event type, no version bump).

### 2. Reconcile cask auto-routing (`openspec/changes/macos-brew-driver`)
PR3 of the arc made a `cask:` darwin ref auto-route to the brew lane **by default** (no `driver: "brew"` needed). The macos-brew-driver design still said such a manifest is *rejected at load*. Updates the "Per-app driver selection" requirement + flips the "A Cask reference without the brew driver is **rejected**" scenario to "**auto-routes to brew**". The auto-routing default is owned by `engine-backend-bootstrap-impl`; this requirement now composes with it instead of contradicting it.

### Verification
`openspec validate --all --strict` → **74/74**. No Go changed; affected packages (events/manifest/commands) still pass. No conformance test parses the contract doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)