### PR TITLE
feat(backup): macOS Keychain + Linux Secret Service keychain backends

### DIFF
--- a/go-engine/go.mod
+++ b/go-engine/go.mod
@@ -4,10 +4,12 @@ go 1.22
 
 require (
 	github.com/danieljoos/wincred v1.2.3
+	github.com/gofrs/flock v0.11.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/tyler-smith/go-bip39 v1.1.0
+	github.com/zalando/go-keyring v0.2.8
 	golang.org/x/crypto v0.32.0
 	golang.org/x/sys v0.29.0
 )
 
-require github.com/gofrs/flock v0.11.0 // indirect
+require github.com/godbus/dbus/v5 v5.2.2 // indirect

--- a/go-engine/go.sum
+++ b/go-engine/go.sum
@@ -2,6 +2,8 @@ github.com/danieljoos/wincred v1.2.3 h1:v7dZC2x32Ut3nEfRH+vhoZGvN72+dQ/snVXo/vMF
 github.com/danieljoos/wincred v1.2.3/go.mod h1:6qqX0WNrS4RzPZ1tnroDzq9kY3fu1KwE7MRLQK4X0bs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/godbus/dbus/v5 v5.2.2 h1:TUR3TgtSVDmjiXOgAAyaZbYmIeP3DPkld3jgKGV8mXQ=
+github.com/godbus/dbus/v5 v5.2.2/go.mod h1:3AAv2+hPq5rdnr5txxxRwiGjPXamgoIHgz9FPBfOp3c=
 github.com/gofrs/flock v0.11.0 h1:AGFQxrpWd8ezw60AvLWIPbxMydNfF8564pwH3FCty0g=
 github.com/gofrs/flock v0.11.0/go.mod h1:FirDy1Ing0mI2+kB6wk+vyyAH+e6xiE+EYA0jnzV9jc=
 github.com/golang-jwt/jwt/v5 v5.3.1 h1:kYf81DTWFe7t+1VvL7eS+jKFVWaUnK9cB1qbwn63YCY=
@@ -14,6 +16,8 @@ github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 github.com/tyler-smith/go-bip39 v1.1.0 h1:5eUemwrMargf3BSLRRCalXT93Ns6pQJIjYQN2nyfOP8=
 github.com/tyler-smith/go-bip39 v1.1.0/go.mod h1:gUYDtqQw1JS3ZJ8UWVcGTGqqr6YIN3CWg+kkNaLt55U=
+github.com/zalando/go-keyring v0.2.8 h1:6sD/Ucpl7jNq10rM2pgqTs0sZ9V3qMrqfIIy5YPccHs=
+github.com/zalando/go-keyring v0.2.8/go.mod h1:tsMo+VpRq5NGyKfxoBVjCuMrG47yj8cmakZDO5QGii0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.32.0 h1:euUpcYgM8WcP71gNpTqQCn6rC2t6ULUPiOzfWaXVVfc=
@@ -23,8 +27,6 @@ golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.29.0 h1:TPYlXGxvx1MGTn2GiZDhnjPA9wZzZeGKHHmKhHYvgaU=
 golang.org/x/sys v0.29.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/sys v0.37.0 h1:fdNQudmxPjkdUTPnLn5mdQv7Zwvbvpaxqs831goi9kQ=
-golang.org/x/sys v0.37.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/go-engine/internal/backup/keychain/keychain_darwin.go
+++ b/go-engine/internal/backup/keychain/keychain_darwin.go
@@ -1,0 +1,69 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build darwin
+
+package keychain
+
+import (
+	"errors"
+
+	"github.com/zalando/go-keyring"
+)
+
+// serviceName is the single label every Endstate secret is filed under in
+// the platform secret store. It mirrors the Windows backend's flat target
+// naming: there the account string (from AccountForUser / AccountForDEK) is
+// the credential target directly; here go-keyring needs a (service, user)
+// tuple, so the account string becomes the per-entry user and serviceName
+// groups them under one human-readable heading in Keychain Access /
+// Secret Service browsers.
+const serviceName = "Endstate"
+
+// NewSystem returns the platform-native Keychain — the macOS login
+// keychain via github.com/zalando/go-keyring, which shells out to
+// /usr/bin/security (no cgo).
+//
+// The contract requires no fallback to plaintext file storage: if the
+// keychain is unavailable the caller surfaces the error rather than
+// silently degrading (contract §1, §5).
+func NewSystem() Keychain {
+	return &keyringKeychain{}
+}
+
+// keyringKeychain adapts go-keyring's package-level Set/Get/Delete to the
+// narrow Keychain interface. go-keyring is stateless (it holds no handles),
+// so a zero-value struct is safe for concurrent use by multiple goroutines.
+type keyringKeychain struct{}
+
+func (*keyringKeychain) Store(account string, secret []byte) error {
+	if err := keyring.Set(serviceName, account, string(secret)); err != nil {
+		return mapKeyringErr("store", err)
+	}
+	return nil
+}
+
+func (*keyringKeychain) Load(account string) ([]byte, error) {
+	v, err := keyring.Get(serviceName, account)
+	if err != nil {
+		return nil, mapKeyringErr("load", err)
+	}
+	return []byte(v), nil
+}
+
+func (*keyringKeychain) Delete(account string) error {
+	if err := keyring.Delete(serviceName, account); err != nil {
+		return mapKeyringErr("delete", err)
+	}
+	return nil
+}
+
+// mapKeyringErr translates go-keyring's not-found sentinel to the package's
+// ErrNotFound and wraps every other error with a "keychain:" prefix
+// consistent with the existing backends.
+func mapKeyringErr(op string, err error) error {
+	if errors.Is(err, keyring.ErrNotFound) {
+		return ErrNotFound
+	}
+	return errors.New("keychain: " + op + ": " + err.Error())
+}

--- a/go-engine/internal/backup/keychain/keychain_darwin_test.go
+++ b/go-engine/internal/backup/keychain/keychain_darwin_test.go
@@ -1,0 +1,112 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build darwin
+
+package keychain
+
+import (
+	"bytes"
+	"errors"
+	"testing"
+
+	"github.com/zalando/go-keyring"
+)
+
+// Compile-time assertion that the darwin backend satisfies the interface.
+var _ Keychain = (*keyringKeychain)(nil)
+
+// useMockKeyring swaps go-keyring's provider for an in-memory mock so these
+// tests never touch the real macOS Keychain or shell out to /usr/bin/security.
+// CI runs `go test ./...` on a macos runner without an unlocked login
+// keychain, so hitting the real store would hang or fail.
+func useMockKeyring(t *testing.T) {
+	t.Helper()
+	keyring.MockInit()
+}
+
+func TestDarwin_StoreLoadRoundTrip(t *testing.T) {
+	useMockKeyring(t)
+	kc := NewSystem()
+	account := AccountForUser("user-1")
+	secret := []byte("rt-1234567890")
+
+	if err := kc.Store(account, secret); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	got, err := kc.Load(account)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !bytes.Equal(got, secret) {
+		t.Errorf("Load = %q, want %q", got, secret)
+	}
+}
+
+func TestDarwin_StoreLoadBinaryDEK(t *testing.T) {
+	// The DEK is 32 raw bytes (non-UTF-8). go-keyring base64-encodes on
+	// darwin internally, so binary round-trips must survive string<->[]byte.
+	useMockKeyring(t)
+	kc := NewSystem()
+	account := AccountForDEK("user-1")
+	secret := []byte{0x00, 0xff, 0x10, 0x80, 0x7f, 0x00, 0xaa}
+
+	if err := kc.Store(account, secret); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	got, err := kc.Load(account)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !bytes.Equal(got, secret) {
+		t.Errorf("Load = %v, want %v", got, secret)
+	}
+}
+
+func TestDarwin_LoadMissingMapsToErrNotFound(t *testing.T) {
+	useMockKeyring(t)
+	kc := NewSystem()
+	if _, err := kc.Load(AccountForUser("absent")); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Load missing: expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestDarwin_DeleteMissingMapsToErrNotFound(t *testing.T) {
+	useMockKeyring(t)
+	kc := NewSystem()
+	if err := kc.Delete(AccountForUser("absent")); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Delete missing: expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestDarwin_DeleteRemoves(t *testing.T) {
+	useMockKeyring(t)
+	kc := NewSystem()
+	account := AccountForUser("user-1")
+	if err := kc.Store(account, []byte("rt")); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if err := kc.Delete(account); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := kc.Load(account); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Load after Delete: expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestDarwin_StoreOverwrites(t *testing.T) {
+	useMockKeyring(t)
+	kc := NewSystem()
+	account := AccountForUser("user-1")
+	_ = kc.Store(account, []byte("first"))
+	if err := kc.Store(account, []byte("second")); err != nil {
+		t.Fatalf("Store overwrite: %v", err)
+	}
+	got, err := kc.Load(account)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if string(got) != "second" {
+		t.Errorf("Load = %q, want %q", got, "second")
+	}
+}

--- a/go-engine/internal/backup/keychain/keychain_linux.go
+++ b/go-engine/internal/backup/keychain/keychain_linux.go
@@ -1,0 +1,83 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package keychain
+
+import (
+	"errors"
+
+	"github.com/zalando/go-keyring"
+)
+
+// serviceName is the single label every Endstate secret is filed under in
+// the platform secret store. It mirrors the Windows backend's flat target
+// naming: there the account string (from AccountForUser / AccountForDEK) is
+// the credential target directly; here go-keyring needs a (service, user)
+// tuple, so the account string becomes the per-entry user and serviceName
+// groups them under one collection in the Secret Service (e.g. the GNOME
+// Keyring / KWallet "login" collection).
+const serviceName = "Endstate"
+
+// NewSystem returns the platform-native Keychain — the freedesktop Secret
+// Service (GNOME Keyring, KWallet, …) over D-Bus via
+// github.com/zalando/go-keyring (no cgo).
+//
+// The contract requires no fallback to plaintext file storage: if no
+// Secret Service daemon is reachable (headless box, WSL, locked keyring)
+// the caller surfaces the error rather than silently degrading
+// (contract §1, §5). That fail-closed behaviour is intentional — see
+// mapKeyringErr for the actionable hint attached to those failures.
+func NewSystem() Keychain {
+	return &keyringKeychain{}
+}
+
+// keyringKeychain adapts go-keyring's package-level Set/Get/Delete to the
+// narrow Keychain interface. go-keyring is stateless (it dials D-Bus per
+// call and holds no handles), so a zero-value struct is safe for
+// concurrent use by multiple goroutines.
+type keyringKeychain struct{}
+
+func (*keyringKeychain) Store(account string, secret []byte) error {
+	if err := keyring.Set(serviceName, account, string(secret)); err != nil {
+		return mapKeyringErr("store", err)
+	}
+	return nil
+}
+
+func (*keyringKeychain) Load(account string) ([]byte, error) {
+	v, err := keyring.Get(serviceName, account)
+	if err != nil {
+		return nil, mapKeyringErr("load", err)
+	}
+	return []byte(v), nil
+}
+
+func (*keyringKeychain) Delete(account string) error {
+	if err := keyring.Delete(serviceName, account); err != nil {
+		return mapKeyringErr("delete", err)
+	}
+	return nil
+}
+
+// mapKeyringErr translates go-keyring's not-found sentinel to the package's
+// ErrNotFound and wraps every other error with a "keychain:" prefix
+// consistent with the existing backends.
+//
+// On Linux the most common non-not-found failure is "no Secret Service
+// daemon reachable" (headless server, WSL, or a locked session keyring).
+// That is correct fail-closed behaviour — the engine never falls back to
+// plaintext — so the wrapped error carries an actionable hint naming what
+// the user must provide. The hint is appended in the keychain layer
+// because that is the only place that knows the failure is Secret-Service
+// shaped; the command layer's envelope remediation (see
+// internal/commands/backup_recover.go) then surfaces it verbatim.
+func mapKeyringErr(op string, err error) error {
+	if errors.Is(err, keyring.ErrNotFound) {
+		return ErrNotFound
+	}
+	return errors.New("keychain: " + op + ": " + err.Error() +
+		" (requires an unlocked OS keyring exposing the Secret Service API, " +
+		"e.g. GNOME Keyring or KWallet; headless or WSL sessions may have none running)")
+}

--- a/go-engine/internal/backup/keychain/keychain_linux_test.go
+++ b/go-engine/internal/backup/keychain/keychain_linux_test.go
@@ -1,0 +1,134 @@
+// Copyright 2025 Substrate Systems OÜ
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build linux
+
+package keychain
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/zalando/go-keyring"
+)
+
+// Compile-time assertion that the linux backend satisfies the interface.
+var _ Keychain = (*keyringKeychain)(nil)
+
+// useMockKeyring swaps go-keyring's provider for an in-memory mock so these
+// tests never dial D-Bus. The repo's Linux CI (and this dev box) often have
+// no Secret Service daemon; MockInit guarantees `go test ./...` is hermetic
+// regardless.
+func useMockKeyring(t *testing.T) {
+	t.Helper()
+	keyring.MockInit()
+}
+
+func TestLinux_StoreLoadRoundTrip(t *testing.T) {
+	useMockKeyring(t)
+	kc := NewSystem()
+	account := AccountForUser("user-1")
+	secret := []byte("rt-1234567890")
+
+	if err := kc.Store(account, secret); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	got, err := kc.Load(account)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !bytes.Equal(got, secret) {
+		t.Errorf("Load = %q, want %q", got, secret)
+	}
+}
+
+func TestLinux_StoreLoadBinaryDEK(t *testing.T) {
+	// The DEK is 32 raw bytes (non-UTF-8); ensure binary round-trips
+	// survive the string<->[]byte conversion the wrapper performs.
+	useMockKeyring(t)
+	kc := NewSystem()
+	account := AccountForDEK("user-1")
+	secret := []byte{0x00, 0xff, 0x10, 0x80, 0x7f, 0x00, 0xaa}
+
+	if err := kc.Store(account, secret); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	got, err := kc.Load(account)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if !bytes.Equal(got, secret) {
+		t.Errorf("Load = %v, want %v", got, secret)
+	}
+}
+
+func TestLinux_LoadMissingMapsToErrNotFound(t *testing.T) {
+	useMockKeyring(t)
+	kc := NewSystem()
+	if _, err := kc.Load(AccountForUser("absent")); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Load missing: expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestLinux_DeleteMissingMapsToErrNotFound(t *testing.T) {
+	useMockKeyring(t)
+	kc := NewSystem()
+	if err := kc.Delete(AccountForUser("absent")); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Delete missing: expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestLinux_DeleteRemoves(t *testing.T) {
+	useMockKeyring(t)
+	kc := NewSystem()
+	account := AccountForUser("user-1")
+	if err := kc.Store(account, []byte("rt")); err != nil {
+		t.Fatalf("Store: %v", err)
+	}
+	if err := kc.Delete(account); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := kc.Load(account); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Load after Delete: expected ErrNotFound, got %v", err)
+	}
+}
+
+func TestLinux_StoreOverwrites(t *testing.T) {
+	useMockKeyring(t)
+	kc := NewSystem()
+	account := AccountForUser("user-1")
+	_ = kc.Store(account, []byte("first"))
+	if err := kc.Store(account, []byte("second")); err != nil {
+		t.Fatalf("Store overwrite: %v", err)
+	}
+	got, err := kc.Load(account)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if string(got) != "second" {
+		t.Errorf("Load = %q, want %q", got, "second")
+	}
+}
+
+// TestLinux_DaemonFailureCarriesRemediationHint verifies that a non-not-found
+// Secret Service failure (the headless / WSL / locked-keyring case) is wrapped
+// with the actionable hint, not silently degraded. MockInitWithError simulates
+// the unreachable-daemon path without needing a real D-Bus session.
+func TestLinux_DaemonFailureCarriesRemediationHint(t *testing.T) {
+	keyring.MockInitWithError(errors.New("dbus: couldn't determine address of session bus"))
+	t.Cleanup(func() { keyring.MockInit() })
+
+	kc := NewSystem()
+	err := kc.Store(AccountForUser("user-1"), []byte("rt"))
+	if err == nil {
+		t.Fatal("Store: expected error when Secret Service is unreachable, got nil")
+	}
+	if errors.Is(err, ErrNotFound) {
+		t.Fatalf("Store: daemon failure must not map to ErrNotFound, got %v", err)
+	}
+	if !strings.Contains(err.Error(), "Secret Service") {
+		t.Errorf("Store error %q: expected an actionable Secret Service remediation hint", err.Error())
+	}
+}

--- a/go-engine/internal/backup/keychain/keychain_other.go
+++ b/go-engine/internal/backup/keychain/keychain_other.go
@@ -1,15 +1,17 @@
 // Copyright 2025 Substrate Systems OÜ
 // SPDX-License-Identifier: Apache-2.0
 
-//go:build !windows
+//go:build !windows && !darwin && !linux
 
 package keychain
 
 import "errors"
 
-// NewSystem on non-Windows platforms returns a Keychain that always errors.
-// Endstate is Windows-first; the engine refuses to store the refresh token
-// in plaintext fallback storage (contract §1, contract §5).
+// NewSystem on platforms without a supported native secret store returns a
+// Keychain that always errors. Windows (Credential Manager), macOS
+// (Keychain), and Linux (Secret Service) each have a real backend; every
+// other platform fails closed. The engine refuses to store the refresh
+// token or DEK in plaintext fallback storage (contract §1, contract §5).
 func NewSystem() Keychain {
 	return &unsupportedKeychain{}
 }
@@ -17,13 +19,18 @@ func NewSystem() Keychain {
 type unsupportedKeychain struct{}
 
 func (*unsupportedKeychain) Store(account string, secret []byte) error {
-	return errors.New("keychain: platform not supported (Windows only)")
+	return errUnsupported()
 }
 
 func (*unsupportedKeychain) Load(account string) ([]byte, error) {
-	return nil, errors.New("keychain: platform not supported (Windows only)")
+	return nil, errUnsupported()
 }
 
 func (*unsupportedKeychain) Delete(account string) error {
-	return errors.New("keychain: platform not supported (Windows only)")
+	return errUnsupported()
+}
+
+func errUnsupported() error {
+	return errors.New("keychain: platform not supported " +
+		"(supported: Windows Credential Manager, macOS Keychain, Linux Secret Service)")
 }

--- a/openspec/changes/backup-keychain-unix/proposal.md
+++ b/openspec/changes/backup-keychain-unix/proposal.md
@@ -1,0 +1,84 @@
+## Why
+
+Endstate Hosted Backup persists two secrets between CLI invocations — the
+auth **refresh token** and the unwrapped **DEK** (plus the non-secret
+wrappedDEK / access-token cache) — in the OS secret store via the narrow
+`internal/backup/keychain` `Keychain{Store,Load,Delete}` interface. The
+trust boundary is the OS user account (contract §1: the masterKey/DEK
+"never leave the device"; the DEK lives "in the same trust boundary as the
+refresh token").
+
+Only Windows had a real backend (Credential Manager, `keychain_windows.go`).
+Every other platform fell through `keychain_other.go` (`//go:build !windows`),
+a **fail-closed stub** that errors `"platform not supported (Windows only)"`
+on every op — by design the engine NEVER falls back to plaintext (contract
+§1/§5). That made `backup login/push/pull/...` unusable on macOS and Linux,
+even though the rest of the backup stack (crypto, auth, upload/download) is
+platform-agnostic and builds for those targets.
+
+This change adds REAL native backends for macOS and Linux so backup works
+there, while preserving fail-closed semantics on every platform that lacks a
+native secret store.
+
+## What Changes
+
+- **macOS backend** (`keychain_darwin.go`, `//go:build darwin`) — backs the
+  `Keychain` interface with the macOS login Keychain via
+  `github.com/zalando/go-keyring` (pure Go; shells out to `/usr/bin/security`,
+  no cgo).
+- **Linux backend** (`keychain_linux.go`, `//go:build linux`) — backs the
+  `Keychain` interface with the freedesktop Secret Service (GNOME Keyring,
+  KWallet, …) over D-Bus via the same library.
+- **Narrowed stub** — `keychain_other.go` becomes
+  `//go:build !windows && !darwin && !linux`; it keeps the fail-closed
+  behaviour and its error now names the three supported stores instead of
+  "Windows only".
+- **Error mapping** — go-keyring's `keyring.ErrNotFound` maps to the
+  package's `ErrNotFound`; all other errors are wrapped with the existing
+  `keychain:` prefix. On Linux a non-not-found failure (headless / WSL /
+  locked keyring — the correct fail-closed path) carries an actionable hint
+  naming the unlocked-OS-keyring requirement.
+- **Dependency** — adds `github.com/zalando/go-keyring v0.2.8` (and its
+  transitive `github.com/godbus/dbus/v5`, indirect) to `go-engine/go.mod`.
+- **Hermetic tests** — `keychain_darwin_test.go` / `keychain_linux_test.go`
+  (build-tagged so each platform's CI exercises its own backend) use
+  go-keyring's `MockInit()` to test the wrapper, ErrNotFound mapping, binary
+  round-trip, and (Linux) the daemon-failure remediation hint — never
+  touching the real keychain or D-Bus.
+
+The account-name convention (`AccountForUser` / `AccountForDEK` / …) is
+unchanged; the `Keychain` interface, the `NewSystem()` constructor signature,
+and all callers are unchanged.
+
+## Capabilities
+
+### New Capabilities
+- `backup-keychain`: where Hosted Backup secrets persist between CLI
+  invocations — ONLY the platform-native secret store (Windows Credential
+  Manager, macOS Keychain, Linux Secret Service) — and the fail-closed
+  guarantee that on any platform without one the engine errors rather than
+  writing plaintext.
+
+### Modified Capabilities
+<!-- None: there is no pre-existing keychain capability in the specs baseline; this delta adds backup-keychain. -->
+
+## Impact
+
+- `go-engine/internal/backup/keychain/keychain_darwin.go` (new) — macOS backend.
+- `go-engine/internal/backup/keychain/keychain_linux.go` (new) — Linux backend.
+- `go-engine/internal/backup/keychain/keychain_other.go` — build tag narrowed
+  to `!windows && !darwin && !linux`; stub error message updated.
+- `go-engine/internal/backup/keychain/keychain_darwin_test.go`,
+  `keychain_linux_test.go` (new) — hermetic wrapper tests via `MockInit()`.
+- `go-engine/go.mod`, `go.sum` — add `github.com/zalando/go-keyring`.
+- No contract edit required: contract §1/§5 describe the trust boundary
+  (on-device secret, gated by the OS user account) platform-agnostically; the
+  new backends uphold it. The §1 "Filen.io — Windows-first" note and the
+  existing `hosted-backup-orchestration` spec's "OS keychain" wording already
+  read generically.
+- Backward-compatible: Windows behaviour is byte-identical; macOS/Linux gain
+  function where they previously errored; truly unsupported platforms still
+  fail closed.
+- **Manual validation (not CI-verifiable here):** a real macOS Keychain
+  round-trip and a real Secret Service round-trip on a desktop Linux session
+  with an unlocked keyring. CI exercises only the hermetic `MockInit()` path.

--- a/openspec/changes/backup-keychain-unix/specs/backup-keychain/spec.md
+++ b/openspec/changes/backup-keychain-unix/specs/backup-keychain/spec.md
@@ -1,0 +1,63 @@
+## ADDED Requirements
+
+### Requirement: Backup secrets persist only in the platform-native secret store
+
+Hosted Backup secrets (the auth refresh token and the unwrapped DEK) SHALL be persisted between CLI invocations ONLY in the operating system's native secret store: Windows Credential Manager, the macOS login Keychain, or the Linux Secret Service (GNOME Keyring, KWallet, or any freedesktop Secret Service provider). The engine MUST NOT write these secrets to a plaintext file or any other fallback location.
+
+The native store gates access on the OS user account, which is the trust boundary the Hosted Backup contract (§1, §5) relies on: the DEK and refresh token live in the same boundary, so a `backup push` after `backup login` does not re-prompt for the passphrase.
+
+#### Scenario: macOS persists secrets in the login Keychain
+
+- **WHEN** the engine runs on macOS and stores a refresh token or DEK
+- **THEN** the value SHALL be written to the macOS login Keychain via the platform-native API
+- **AND** a subsequent CLI invocation SHALL load the same value back
+
+#### Scenario: Linux persists secrets in the Secret Service
+
+- **WHEN** the engine runs on Linux with an unlocked Secret Service provider available
+- **THEN** the value SHALL be written to the Secret Service over D-Bus
+- **AND** a subsequent CLI invocation SHALL load the same value back
+
+#### Scenario: No plaintext fallback is ever written
+
+- **WHEN** the engine stores a refresh token or DEK on any platform
+- **THEN** the engine SHALL NOT write that secret to a plaintext file or any non-native fallback store under any circumstance
+
+### Requirement: The engine fails closed when no native secret store is available
+
+On any platform without a supported native secret store, the engine SHALL fail closed: every keychain operation MUST return a clear error and the engine MUST NOT degrade to plaintext storage. A platform with a native store that is present but unreachable or locked (for example a headless or WSL Linux session with no running Secret Service) is treated the same way — the operation MUST error rather than silently succeed.
+
+The error returned in the no-native-store and locked-store cases SHALL be actionable, naming the supported stores (or, on Linux, the requirement for an unlocked OS keyring exposing the Secret Service API) so the user understands the remediation.
+
+#### Scenario: Unsupported platform errors instead of writing plaintext
+
+- **WHEN** the engine runs on a platform with no supported native secret store
+- **AND** a keychain Store, Load, or Delete is attempted
+- **THEN** the operation SHALL return an error naming the supported stores (Windows Credential Manager, macOS Keychain, Linux Secret Service)
+- **AND** SHALL NOT persist the secret anywhere
+
+#### Scenario: Linux without a reachable Secret Service errors with an actionable hint
+
+- **WHEN** the engine runs on Linux with no reachable or unlocked Secret Service provider
+- **AND** a keychain operation is attempted
+- **THEN** the operation SHALL return an error that does NOT map to the not-found sentinel
+- **AND** the error SHALL include a hint naming the unlocked-OS-keyring (GNOME Keyring / KWallet via Secret Service) requirement
+
+### Requirement: Not-found is reported via a single sentinel across all backends
+
+Every backend SHALL report "no entry exists for this account" via the package's single `ErrNotFound` sentinel, regardless of the underlying platform store's native not-found representation. Callers MUST be able to distinguish "the account is absent" from "the store failed" using only `errors.Is(err, ErrNotFound)`.
+
+#### Scenario: Loading an absent account returns ErrNotFound
+
+- **WHEN** `Load` is called for an account that was never stored
+- **THEN** the backend SHALL return `ErrNotFound`
+
+#### Scenario: Deleting an absent account returns ErrNotFound
+
+- **WHEN** `Delete` is called for an account that does not exist
+- **THEN** the backend SHALL return `ErrNotFound`
+
+#### Scenario: A store failure is not reported as not-found
+
+- **WHEN** a keychain operation fails for a reason other than a missing account (for example the store is unreachable)
+- **THEN** the returned error SHALL NOT satisfy `errors.Is(err, ErrNotFound)`

--- a/openspec/changes/backup-keychain-unix/tasks.md
+++ b/openspec/changes/backup-keychain-unix/tasks.md
@@ -1,0 +1,33 @@
+## 1. Dependency
+
+- [x] 1.1 Add `github.com/zalando/go-keyring` to `go-engine/go.mod`; `go mod tidy` (pins v0.2.8 + indirect `github.com/godbus/dbus/v5`)
+
+## 2. Native backends
+
+- [x] 2.1 `keychain_darwin.go` (`//go:build darwin`): `NewSystem()` returns a go-keyring-backed `Keychain`; single service name `"Endstate"`, account string passed through as the per-entry user
+- [x] 2.2 `keychain_linux.go` (`//go:build linux`): same wrapper over the Secret Service; mirror the Windows naming/labeling convention
+- [x] 2.3 Map `keyring.ErrNotFound` → package `ErrNotFound`; wrap all other errors with the `keychain:` prefix
+- [x] 2.4 Linux: wrap non-not-found failures with an actionable hint (unlocked OS keyring / GNOME Keyring / KWallet via Secret Service) — kept in the keychain layer so the command-layer envelope remediation surfaces it verbatim
+- [x] 2.5 Document concurrency-safety (go-keyring is stateless; zero-value struct is safe for concurrent use)
+
+## 3. Narrow the fail-closed stub
+
+- [x] 3.1 `keychain_other.go`: build tag `!windows && !darwin && !linux`
+- [x] 3.2 Update the stub error to name the three supported stores (Windows Credential Manager, macOS Keychain, Linux Secret Service) instead of "Windows only"
+
+## 4. Hermetic tests (per-platform build tags)
+
+- [x] 4.1 `keychain_darwin_test.go` (`//go:build darwin`): `MockInit()`-backed round-trip, ErrNotFound mapping (load + delete), binary-DEK round-trip, overwrite; compile-time `var _ Keychain` assertion
+- [x] 4.2 `keychain_linux_test.go` (`//go:build linux`): same coverage; plus a `MockInitWithError` test proving a simulated daemon failure carries the remediation hint and does NOT map to ErrNotFound
+- [x] 4.3 Confirm `go test ./...` passes on a Linux box with NO D-Bus session (MockInit guarantees hermeticity)
+
+## 5. Sweep + verification
+
+- [x] 5.1 Grep `internal/backup/` and `internal/commands/backup*.go` for other Windows-only / GOOS gates; confirm the keychain split is the only one (engine never opens a browser — authenticator returns URLs)
+- [x] 5.2 `go test ./...` (Linux), `go vet ./...`, `GOOS=windows go build ./...`, `GOOS=darwin go build ./...`, `GOOS=darwin go vet ./internal/backup/keychain/...` all green
+- [x] 5.3 `npm run openspec:validate` (strict) green
+
+## 6. Manual validation (deferred — not CI-verifiable in this environment)
+
+- [ ] 6.1 Real macOS Keychain round-trip (`backup login` → `backup push` on a Mac with an unlocked login keychain)
+- [ ] 6.2 Real Secret Service round-trip on a desktop Linux session with an unlocked GNOME Keyring / KWallet


### PR DESCRIPTION
## Summary

Unblocks **Hosted Backup on Linux/macOS**: `internal/backup/keychain` previously had a fail-closed stub on everything but Windows, so `backup login/push/...` was Windows-only.

- New `keychain_darwin.go` (macOS Keychain) + `keychain_linux.go` (Secret Service/D-Bus) via **`zalando/go-keyring` v0.2.8** (pure Go, no cgo; darwin shells out to `/usr/bin/security`)
- Service name `Endstate`; existing `AccountForUser`/`AccountForDEK` account strings unchanged (Windows parity)
- `keyring.ErrNotFound` → package `ErrNotFound`; binary-safe round-trip (32-byte DEK) locked by test
- `keychain_other.go` narrows to `!windows && !darwin && !linux` — **fail-closed posture preserved**: no plaintext fallback anywhere; headless Linux (incl. WSL) errors with an actionable hint (unlocked GNOME Keyring / KWallet via Secret Service)
- Hermetic tests only (`keyring.MockInit`) — no real D-Bus/keychain in CI on any OS
- Windows-only-gate sweep: keychain was the single gate in the backup flow (engine never opens a browser); none remain
- OpenSpec change `backup-keychain-unix` (new `backup-keychain` capability: native-store-only, fail-closed). `docs/contracts/` untouched — contract §1/§5 are already platform-agnostic

## Verification
- `go test ./...` green on Linux without a D-Bus session; `go vet`; `GOOS=windows` + `GOOS=darwin` builds + per-pkg vets green
- `openspec validate --all --strict` 72/72
- `go.mod` stays `go 1.22` (deps require ≤1.20) — matches CI's pinned Go
- Independent code review: no blockers

## Manual validation needed (not CI-able)
Real round-trips on a Mac (unlocked login keychain) and desktop Linux (unlocked keyring) — tracked as unchecked tasks 6.1/6.2 in the change; composes with the deferred real-Mac E2E pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)