### PR TITLE
feat(bootstrap): Unix self-install + multi-platform release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,11 @@
 name: Release
 
-# Builds endstate.exe + .sha256 and attaches them to the GitHub Release.
+# Builds the platform binaries + .sha256 checksums and attaches them to the
+# GitHub Release:
+#   - publish-artifacts        (windows-latest): endstate.exe
+#   - publish-unix-artifacts   (ubuntu-latest):  endstate-{linux,darwin}-{amd64,arm64}
+# All artifacts share the same ldflags version-embedding scheme (version from
+# the release tag, schemaVersion from SCHEMA_VERSION).
 #
 # Trigger model: `release: published` fires naturally when release-please
 # cuts a release, because release-please.yml now mints its token from the
@@ -82,3 +87,84 @@ jobs:
             exit 1
           }
           Write-Host "Verified: endstate.exe and endstate.exe.sha256 are present on release $tag"
+
+  publish-unix-artifacts:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - goos: linux
+            goarch: amd64
+          - goos: linux
+            goarch: arm64
+          - goos: darwin
+            goarch: amd64
+          - goos: darwin
+            goarch: arm64
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ github.event.inputs.tag_name || github.event.release.tag_name }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: '1.22'
+          cache-dependency-path: go-engine/go.sum
+
+      - name: Build endstate-${{ matrix.goos }}-${{ matrix.goarch }}
+        env:
+          TAG: ${{ github.event.inputs.tag_name || github.event.release.tag_name }}
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+          CGO_ENABLED: '0'
+        run: |
+          version="${TAG#v}"
+          schemaVersion="$(tr -d '[:space:]' < SCHEMA_VERSION)"
+          artifact="endstate-${GOOS}-${GOARCH}"
+          cd go-engine
+          go build \
+            -ldflags "-X github.com/Artexis10/endstate/go-engine/internal/config.version=$version -X github.com/Artexis10/endstate/go-engine/internal/config.schemaVersion=$schemaVersion" \
+            -o "../$artifact" \
+            ./cmd/endstate
+
+      - name: Generate SHA256 checksum
+        env:
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          artifact="endstate-${GOOS}-${GOARCH}"
+          sha256sum "$artifact" | cut -d ' ' -f 1 | tr -d '\n' > "$artifact.sha256"
+
+      - name: Upload release assets
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: ${{ github.event.inputs.tag_name || github.event.release.tag_name }}
+          files: |
+            endstate-${{ matrix.goos }}-${{ matrix.goarch }}
+            endstate-${{ matrix.goos }}-${{ matrix.goarch }}.sha256
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify release assets are present
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ github.event.inputs.tag_name || github.event.release.tag_name }}
+          GOOS: ${{ matrix.goos }}
+          GOARCH: ${{ matrix.goarch }}
+        run: |
+          artifact="endstate-${GOOS}-${GOARCH}"
+          names="$(gh release view "$TAG" --json assets --jq '.assets[].name')"
+          missing=()
+          if ! grep -qx "$artifact" <<< "$names"; then missing+=("$artifact"); fi
+          if ! grep -qx "$artifact.sha256" <<< "$names"; then missing+=("$artifact.sha256"); fi
+          if [ "${#missing[@]}" -gt 0 ]; then
+            echo "Missing release assets: ${missing[*]}" >&2
+            exit 1
+          fi
+          echo "Verified: $artifact and $artifact.sha256 are present on release $TAG"

--- a/docs/COMPATIBILITY.md
+++ b/docs/COMPATIBILITY.md
@@ -21,6 +21,13 @@ CI: hermetic Go tests run on windows/macos/ubuntu; real-Nix integration smokes r
 Linux; a real-Homebrew smoke runs on macOS. Deferred platform scope is recorded in
 [the roadmap](roadmap/roadmap.md) §6.
 
+Distribution: GitHub Releases ship `endstate.exe` for Windows plus per-platform Unix binaries
+(`endstate-linux-amd64`, `endstate-linux-arm64`, `endstate-darwin-amd64`, `endstate-darwin-arm64`),
+each with a `.sha256` checksum. `endstate bootstrap` self-installs the running binary on all three
+platforms: on Windows it installs to `%LOCALAPPDATA%\Endstate\bin` with a `.cmd` shim and a PATH
+entry; on Linux/macOS it installs to `${XDG_DATA_HOME:-$HOME/.local/share}/endstate/bin` and creates
+a `$HOME/.local/bin/endstate` symlink (no shell PATH is edited).
+
 ## Engine CLI <-> Schema Version
 
 | CLI Version | Schema Version | Notes |

--- a/go-engine/internal/commands/bootstrap.go
+++ b/go-engine/internal/commands/bootstrap.go
@@ -4,14 +4,8 @@
 package commands
 
 import (
-	"fmt"
 	"io"
 	"os"
-	"os/exec"
-	"path/filepath"
-	"strings"
-
-	"github.com/Artexis10/endstate/go-engine/internal/envelope"
 )
 
 // BootstrapFlags holds the parsed CLI flags for the bootstrap command.
@@ -25,95 +19,20 @@ type BootstrapFlags struct {
 
 // BootstrapData is the data payload returned by the bootstrap command. It
 // reports the paths created and whether the user PATH was modified.
+//
+// On Windows, ShimPath is the path of the generated endstate.cmd shim. On
+// Unix (linux/darwin), ShimPath is the path of the symlink that points at the
+// installed binary, and AddedToPath is always false (the engine never edits
+// shell rc files).
 type BootstrapData struct {
 	InstallPath string `json:"installPath"`
 	ShimPath    string `json:"shimPath"`
 	AddedToPath bool   `json:"addedToPath"`
 }
 
-// shimContent is the endstate.cmd shim that delegates to the Go binary.
-const shimContent = `@echo off
-set "ENDSTATE_ENTRYPOINT=%~f0"
-"%~dp0lib\endstate.exe" %*
-`
-
-// RunBootstrap installs the running binary to the user-local Endstate
-// directory and creates a .cmd shim on the user PATH.
-//
-// Steps:
-//  1. Determine install dir: %LOCALAPPDATA%\Endstate\bin\
-//  2. Create install dir and lib\ subdirectory.
-//  3. Copy running binary to lib\endstate.exe.
-//  4. Write endstate.cmd shim to install dir.
-//  5. Add install dir to user PATH if not already present.
-func RunBootstrap(flags BootstrapFlags) (interface{}, *envelope.Error) {
-	installDir := os.ExpandEnv("${LOCALAPPDATA}\\Endstate\\bin")
-	libDir := filepath.Join(installDir, "lib")
-
-	// Create directories.
-	if err := os.MkdirAll(libDir, 0755); err != nil {
-		return nil, envelope.NewError(
-			envelope.ErrInternalError,
-			fmt.Sprintf("Failed to create install directory: %s", err.Error()),
-		)
-	}
-
-	// Get the path of the currently running binary.
-	exePath, err := os.Executable()
-	if err != nil {
-		return nil, envelope.NewError(
-			envelope.ErrInternalError,
-			fmt.Sprintf("Failed to determine executable path: %s", err.Error()),
-		)
-	}
-
-	// Resolve symlinks to get the real path.
-	exePath, err = filepath.EvalSymlinks(exePath)
-	if err != nil {
-		return nil, envelope.NewError(
-			envelope.ErrInternalError,
-			fmt.Sprintf("Failed to resolve executable path: %s", err.Error()),
-		)
-	}
-
-	// Copy binary to lib\endstate.exe.
-	destBinary := filepath.Join(libDir, "endstate.exe")
-	if err := copyFile(exePath, destBinary); err != nil {
-		return nil, envelope.NewError(
-			envelope.ErrInternalError,
-			fmt.Sprintf("Failed to copy binary: %s", err.Error()),
-		)
-	}
-
-	// Write the .cmd shim.
-	shimPath := filepath.Join(installDir, "endstate.cmd")
-	if err := os.WriteFile(shimPath, []byte(shimContent), 0755); err != nil {
-		return nil, envelope.NewError(
-			envelope.ErrInternalError,
-			fmt.Sprintf("Failed to write shim: %s", err.Error()),
-		)
-	}
-
-	// Check if installDir is already in the user PATH and add it if not.
-	addedToPath := false
-	if !isInUserPath(installDir) {
-		if err := addToUserPath(installDir); err != nil {
-			// PATH modification failure is not fatal; report it but succeed.
-			// The user can add it manually.
-			_ = err
-		} else {
-			addedToPath = true
-		}
-	}
-
-	return &BootstrapData{
-		InstallPath: installDir,
-		ShimPath:    shimPath,
-		AddedToPath: addedToPath,
-	}, nil
-}
-
-// copyFile copies src to dst, overwriting dst if it exists.
+// copyFile copies src to dst, overwriting dst if it exists. The destination is
+// created with the default os.Create mode (0666 before umask); callers that
+// need the destination to be executable adjust its mode after the copy.
 func copyFile(src, dst string) error {
 	in, err := os.Open(src)
 	if err != nil {
@@ -132,29 +51,4 @@ func copyFile(src, dst string) error {
 	}
 
 	return out.Close()
-}
-
-// isInUserPath checks whether dir is present in the current PATH environment
-// variable (case-insensitive on Windows).
-func isInUserPath(dir string) bool {
-	pathEnv := os.Getenv("PATH")
-	normalised := strings.ToLower(filepath.Clean(dir))
-
-	for _, entry := range filepath.SplitList(pathEnv) {
-		if strings.ToLower(filepath.Clean(entry)) == normalised {
-			return true
-		}
-	}
-	return false
-}
-
-// addToUserPath appends dir to the user PATH via setx. This persists the
-// change to the registry (HKCU\Environment\Path) and takes effect in new
-// shell sessions.
-func addToUserPath(dir string) error {
-	currentPath := os.Getenv("PATH")
-	newPath := currentPath + ";" + dir
-
-	cmd := exec.Command("setx", "PATH", newPath)
-	return cmd.Run()
 }

--- a/go-engine/internal/commands/bootstrap_unix.go
+++ b/go-engine/internal/commands/bootstrap_unix.go
@@ -1,0 +1,144 @@
+// Copyright 2025 Substrate Systems OU
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// RunBootstrap installs the running binary to the user-local Endstate
+// directory and creates a symlink on the user PATH (linux/darwin).
+//
+// Steps:
+//  1. Determine install dir: ${XDG_DATA_HOME:-$HOME/.local/share}/endstate/bin
+//  2. Create install dir and lib/ subdirectory.
+//  3. Copy running binary to lib/endstate and chmod it 0755 (executable).
+//  4. Create/re-point a symlink $HOME/.local/bin/endstate -> lib/endstate.
+//  5. Never edit the user PATH or any shell rc file; print a one-line hint if
+//     the symlink directory is not already on PATH.
+func RunBootstrap(flags BootstrapFlags) (interface{}, *envelope.Error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, envelope.NewError(
+			envelope.ErrInternalError,
+			fmt.Sprintf("Failed to determine home directory: %s", err.Error()),
+		)
+	}
+
+	dataHome := os.Getenv("XDG_DATA_HOME")
+	if dataHome == "" {
+		dataHome = filepath.Join(home, ".local", "share")
+	}
+	installDir := filepath.Join(dataHome, "endstate", "bin")
+	libDir := filepath.Join(installDir, "lib")
+
+	// Create directories.
+	if err := os.MkdirAll(libDir, 0755); err != nil {
+		return nil, envelope.NewError(
+			envelope.ErrInternalError,
+			fmt.Sprintf("Failed to create install directory: %s", err.Error()),
+		)
+	}
+
+	// Get the path of the currently running binary.
+	exePath, err := os.Executable()
+	if err != nil {
+		return nil, envelope.NewError(
+			envelope.ErrInternalError,
+			fmt.Sprintf("Failed to determine executable path: %s", err.Error()),
+		)
+	}
+
+	// Resolve symlinks to get the real path.
+	exePath, err = filepath.EvalSymlinks(exePath)
+	if err != nil {
+		return nil, envelope.NewError(
+			envelope.ErrInternalError,
+			fmt.Sprintf("Failed to resolve executable path: %s", err.Error()),
+		)
+	}
+
+	// Copy binary to lib/endstate. If the running binary already resolves to
+	// the install target (a re-bootstrap of the installed copy), skip the copy
+	// rather than truncating the binary we are executing.
+	destBinary := filepath.Join(libDir, "endstate")
+	resolvedDest, derr := filepath.EvalSymlinks(destBinary)
+	selfCopy := derr == nil && resolvedDest == exePath
+	if !selfCopy {
+		if err := copyFile(exePath, destBinary); err != nil {
+			return nil, envelope.NewError(
+				envelope.ErrInternalError,
+				fmt.Sprintf("Failed to copy binary: %s", err.Error()),
+			)
+		}
+	}
+
+	// Ensure the installed binary is executable (copyFile creates it 0666).
+	if err := os.Chmod(destBinary, 0755); err != nil {
+		return nil, envelope.NewError(
+			envelope.ErrInternalError,
+			fmt.Sprintf("Failed to mark binary executable: %s", err.Error()),
+		)
+	}
+
+	// Create/re-point the symlink at $HOME/.local/bin/endstate.
+	binDir := filepath.Join(home, ".local", "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		return nil, envelope.NewError(
+			envelope.ErrInternalError,
+			fmt.Sprintf("Failed to create bin directory: %s", err.Error()),
+		)
+	}
+	shimPath := filepath.Join(binDir, "endstate")
+
+	// Remove any existing symlink/file at the target so the link is re-pointed
+	// idempotently rather than nesting or failing on exists.
+	if _, lerr := os.Lstat(shimPath); lerr == nil {
+		if err := os.Remove(shimPath); err != nil {
+			return nil, envelope.NewError(
+				envelope.ErrInternalError,
+				fmt.Sprintf("Failed to remove existing symlink: %s", err.Error()),
+			)
+		}
+	}
+	if err := os.Symlink(destBinary, shimPath); err != nil {
+		return nil, envelope.NewError(
+			envelope.ErrInternalError,
+			fmt.Sprintf("Failed to create symlink: %s", err.Error()),
+		)
+	}
+
+	// Never edit PATH or shell rc files on Unix. If the symlink directory is
+	// not already on PATH, surface a one-line hint to stderr so the human
+	// message helps without changing the JSON payload shape.
+	if !isInUserPath(binDir) {
+		fmt.Fprintf(os.Stderr, "Hint: add %s to your PATH to run `endstate` directly.\n", binDir)
+	}
+
+	return &BootstrapData{
+		InstallPath: installDir,
+		ShimPath:    shimPath,
+		AddedToPath: false,
+	}, nil
+}
+
+// isInUserPath checks whether dir is present in the current PATH environment
+// variable.
+func isInUserPath(dir string) bool {
+	pathEnv := os.Getenv("PATH")
+	normalised := filepath.Clean(dir)
+
+	for _, entry := range filepath.SplitList(pathEnv) {
+		if filepath.Clean(entry) == normalised {
+			return true
+		}
+	}
+	return false
+}

--- a/go-engine/internal/commands/bootstrap_unix_test.go
+++ b/go-engine/internal/commands/bootstrap_unix_test.go
@@ -1,0 +1,155 @@
+// Copyright 2025 Substrate Systems OU
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build !windows
+
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// setupUnixHome redirects HOME and XDG_DATA_HOME to hermetic temp dirs and
+// returns (home, xdgDataHome).
+func setupUnixHome(t *testing.T) (string, string) {
+	t.Helper()
+	home := t.TempDir()
+	xdg := filepath.Join(t.TempDir(), "share")
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", xdg)
+	// Keep the symlink dir off PATH so the hint path is exercised but harmless.
+	t.Setenv("PATH", "/usr/bin:/bin")
+	return home, xdg
+}
+
+func TestRunBootstrap_UnixInstallsBinaryAndSymlink(t *testing.T) {
+	home, xdg := setupUnixHome(t)
+
+	data, ierr := RunBootstrap(BootstrapFlags{})
+	if ierr != nil {
+		t.Fatalf("RunBootstrap returned error: %v", ierr)
+	}
+
+	bd, ok := data.(*BootstrapData)
+	if !ok {
+		t.Fatalf("expected *BootstrapData, got %T", data)
+	}
+
+	wantInstallDir := filepath.Join(xdg, "endstate", "bin")
+	if bd.InstallPath != wantInstallDir {
+		t.Errorf("InstallPath = %q, want %q", bd.InstallPath, wantInstallDir)
+	}
+
+	wantShim := filepath.Join(home, ".local", "bin", "endstate")
+	if bd.ShimPath != wantShim {
+		t.Errorf("ShimPath = %q, want %q", bd.ShimPath, wantShim)
+	}
+
+	if bd.AddedToPath {
+		t.Error("AddedToPath = true, want false (Unix never edits PATH)")
+	}
+
+	// Binary installed and executable (0755).
+	destBinary := filepath.Join(wantInstallDir, "lib", "endstate")
+	info, err := os.Stat(destBinary)
+	if err != nil {
+		t.Fatalf("installed binary missing: %v", err)
+	}
+	if info.Mode().Perm() != 0755 {
+		t.Errorf("binary mode = %o, want 0755", info.Mode().Perm())
+	}
+
+	// Symlink points at the installed binary.
+	target, err := os.Readlink(wantShim)
+	if err != nil {
+		t.Fatalf("symlink missing or not a symlink: %v", err)
+	}
+	if target != destBinary {
+		t.Errorf("symlink target = %q, want %q", target, destBinary)
+	}
+}
+
+func TestRunBootstrap_UnixDefaultsToLocalShareWhenXDGUnset(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("PATH", "/usr/bin:/bin")
+
+	data, ierr := RunBootstrap(BootstrapFlags{})
+	if ierr != nil {
+		t.Fatalf("RunBootstrap returned error: %v", ierr)
+	}
+	bd := data.(*BootstrapData)
+
+	wantInstallDir := filepath.Join(home, ".local", "share", "endstate", "bin")
+	if bd.InstallPath != wantInstallDir {
+		t.Errorf("InstallPath = %q, want %q", bd.InstallPath, wantInstallDir)
+	}
+}
+
+func TestRunBootstrap_UnixIsIdempotent(t *testing.T) {
+	home, xdg := setupUnixHome(t)
+
+	first, ierr := RunBootstrap(BootstrapFlags{})
+	if ierr != nil {
+		t.Fatalf("first RunBootstrap returned error: %v", ierr)
+	}
+	fb := first.(*BootstrapData)
+
+	// Re-run: must not fail, must not nest, must re-point the symlink.
+	second, ierr := RunBootstrap(BootstrapFlags{})
+	if ierr != nil {
+		t.Fatalf("second RunBootstrap returned error: %v", ierr)
+	}
+	sb := second.(*BootstrapData)
+
+	if fb.InstallPath != sb.InstallPath || fb.ShimPath != sb.ShimPath {
+		t.Errorf("idempotent re-run changed paths: %+v vs %+v", fb, sb)
+	}
+
+	destBinary := filepath.Join(xdg, "endstate", "bin", "lib", "endstate")
+	wantShim := filepath.Join(home, ".local", "bin", "endstate")
+	target, err := os.Readlink(wantShim)
+	if err != nil {
+		t.Fatalf("symlink missing after re-run: %v", err)
+	}
+	if target != destBinary {
+		t.Errorf("symlink target after re-run = %q, want %q", target, destBinary)
+	}
+	info, err := os.Stat(destBinary)
+	if err != nil {
+		t.Fatalf("binary missing after re-run: %v", err)
+	}
+	if info.Mode().Perm() != 0755 {
+		t.Errorf("binary mode after re-run = %o, want 0755", info.Mode().Perm())
+	}
+}
+
+// TestRunBootstrap_UnixRePointsExistingNonSymlink verifies that a pre-existing
+// regular file at the symlink target is replaced (never nested or errored on).
+func TestRunBootstrap_UnixRePointsExistingNonSymlink(t *testing.T) {
+	home, _ := setupUnixHome(t)
+
+	binDir := filepath.Join(home, ".local", "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("setup mkdir: %v", err)
+	}
+	shimPath := filepath.Join(binDir, "endstate")
+	if err := os.WriteFile(shimPath, []byte("stale"), 0644); err != nil {
+		t.Fatalf("setup stale file: %v", err)
+	}
+
+	if _, ierr := RunBootstrap(BootstrapFlags{}); ierr != nil {
+		t.Fatalf("RunBootstrap returned error: %v", ierr)
+	}
+
+	info, err := os.Lstat(shimPath)
+	if err != nil {
+		t.Fatalf("shim missing: %v", err)
+	}
+	if info.Mode()&os.ModeSymlink == 0 {
+		t.Error("expected the stale regular file to be replaced by a symlink")
+	}
+}

--- a/go-engine/internal/commands/bootstrap_windows.go
+++ b/go-engine/internal/commands/bootstrap_windows.go
@@ -1,0 +1,123 @@
+// Copyright 2025 Substrate Systems OU
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package commands
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/Artexis10/endstate/go-engine/internal/envelope"
+)
+
+// shimContent is the endstate.cmd shim that delegates to the Go binary.
+const shimContent = `@echo off
+set "ENDSTATE_ENTRYPOINT=%~f0"
+"%~dp0lib\endstate.exe" %*
+`
+
+// RunBootstrap installs the running binary to the user-local Endstate
+// directory and creates a .cmd shim on the user PATH.
+//
+// Steps:
+//  1. Determine install dir: %LOCALAPPDATA%\Endstate\bin\
+//  2. Create install dir and lib\ subdirectory.
+//  3. Copy running binary to lib\endstate.exe.
+//  4. Write endstate.cmd shim to install dir.
+//  5. Add install dir to user PATH if not already present.
+func RunBootstrap(flags BootstrapFlags) (interface{}, *envelope.Error) {
+	installDir := os.ExpandEnv("${LOCALAPPDATA}\\Endstate\\bin")
+	libDir := filepath.Join(installDir, "lib")
+
+	// Create directories.
+	if err := os.MkdirAll(libDir, 0755); err != nil {
+		return nil, envelope.NewError(
+			envelope.ErrInternalError,
+			fmt.Sprintf("Failed to create install directory: %s", err.Error()),
+		)
+	}
+
+	// Get the path of the currently running binary.
+	exePath, err := os.Executable()
+	if err != nil {
+		return nil, envelope.NewError(
+			envelope.ErrInternalError,
+			fmt.Sprintf("Failed to determine executable path: %s", err.Error()),
+		)
+	}
+
+	// Resolve symlinks to get the real path.
+	exePath, err = filepath.EvalSymlinks(exePath)
+	if err != nil {
+		return nil, envelope.NewError(
+			envelope.ErrInternalError,
+			fmt.Sprintf("Failed to resolve executable path: %s", err.Error()),
+		)
+	}
+
+	// Copy binary to lib\endstate.exe.
+	destBinary := filepath.Join(libDir, "endstate.exe")
+	if err := copyFile(exePath, destBinary); err != nil {
+		return nil, envelope.NewError(
+			envelope.ErrInternalError,
+			fmt.Sprintf("Failed to copy binary: %s", err.Error()),
+		)
+	}
+
+	// Write the .cmd shim.
+	shimPath := filepath.Join(installDir, "endstate.cmd")
+	if err := os.WriteFile(shimPath, []byte(shimContent), 0755); err != nil {
+		return nil, envelope.NewError(
+			envelope.ErrInternalError,
+			fmt.Sprintf("Failed to write shim: %s", err.Error()),
+		)
+	}
+
+	// Check if installDir is already in the user PATH and add it if not.
+	addedToPath := false
+	if !isInUserPath(installDir) {
+		if err := addToUserPath(installDir); err != nil {
+			// PATH modification failure is not fatal; report it but succeed.
+			// The user can add it manually.
+			_ = err
+		} else {
+			addedToPath = true
+		}
+	}
+
+	return &BootstrapData{
+		InstallPath: installDir,
+		ShimPath:    shimPath,
+		AddedToPath: addedToPath,
+	}, nil
+}
+
+// isInUserPath checks whether dir is present in the current PATH environment
+// variable (case-insensitive on Windows).
+func isInUserPath(dir string) bool {
+	pathEnv := os.Getenv("PATH")
+	normalised := strings.ToLower(filepath.Clean(dir))
+
+	for _, entry := range filepath.SplitList(pathEnv) {
+		if strings.ToLower(filepath.Clean(entry)) == normalised {
+			return true
+		}
+	}
+	return false
+}
+
+// addToUserPath appends dir to the user PATH via setx. This persists the
+// change to the registry (HKCU\Environment\Path) and takes effect in new
+// shell sessions.
+func addToUserPath(dir string) error {
+	currentPath := os.Getenv("PATH")
+	newPath := currentPath + ";" + dir
+
+	cmd := exec.Command("setx", "PATH", newPath)
+	return cmd.Run()
+}

--- a/go-engine/internal/commands/bootstrap_windows_test.go
+++ b/go-engine/internal/commands/bootstrap_windows_test.go
@@ -1,0 +1,81 @@
+// Copyright 2025 Substrate Systems OU
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package commands
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestRunBootstrap_WindowsInstallsBinaryAndShim(t *testing.T) {
+	localAppData := t.TempDir()
+	t.Setenv("LOCALAPPDATA", localAppData)
+
+	installDir := filepath.Join(localAppData, "Endstate", "bin")
+	// Put installDir on PATH so the hermetic test never invokes `setx`.
+	t.Setenv("PATH", installDir)
+
+	data, ierr := RunBootstrap(BootstrapFlags{})
+	if ierr != nil {
+		t.Fatalf("RunBootstrap returned error: %v", ierr)
+	}
+	bd, ok := data.(*BootstrapData)
+	if !ok {
+		t.Fatalf("expected *BootstrapData, got %T", data)
+	}
+
+	if bd.InstallPath != installDir {
+		t.Errorf("InstallPath = %q, want %q", bd.InstallPath, installDir)
+	}
+
+	wantShim := filepath.Join(installDir, "endstate.cmd")
+	if bd.ShimPath != wantShim {
+		t.Errorf("ShimPath = %q, want %q", bd.ShimPath, wantShim)
+	}
+
+	// AddedToPath is false because installDir is already on PATH.
+	if bd.AddedToPath {
+		t.Error("AddedToPath = true, want false (already on PATH)")
+	}
+
+	// Binary installed.
+	destBinary := filepath.Join(installDir, "lib", "endstate.exe")
+	if _, err := os.Stat(destBinary); err != nil {
+		t.Fatalf("installed binary missing: %v", err)
+	}
+
+	// Shim written and references lib\endstate.exe.
+	shimBytes, err := os.ReadFile(wantShim)
+	if err != nil {
+		t.Fatalf("shim missing: %v", err)
+	}
+	if !strings.Contains(string(shimBytes), `lib\endstate.exe`) {
+		t.Errorf("shim does not reference lib\\endstate.exe: %q", string(shimBytes))
+	}
+}
+
+func TestRunBootstrap_WindowsIsIdempotent(t *testing.T) {
+	localAppData := t.TempDir()
+	t.Setenv("LOCALAPPDATA", localAppData)
+	installDir := filepath.Join(localAppData, "Endstate", "bin")
+	t.Setenv("PATH", installDir)
+
+	first, ierr := RunBootstrap(BootstrapFlags{})
+	if ierr != nil {
+		t.Fatalf("first RunBootstrap returned error: %v", ierr)
+	}
+	second, ierr := RunBootstrap(BootstrapFlags{})
+	if ierr != nil {
+		t.Fatalf("second RunBootstrap returned error: %v", ierr)
+	}
+	fb := first.(*BootstrapData)
+	sb := second.(*BootstrapData)
+	if fb.InstallPath != sb.InstallPath || fb.ShimPath != sb.ShimPath {
+		t.Errorf("idempotent re-run changed paths: %+v vs %+v", fb, sb)
+	}
+}

--- a/openspec/changes/unix-engine-self-install/.openspec.yaml
+++ b/openspec/changes/unix-engine-self-install/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-06-11

--- a/openspec/changes/unix-engine-self-install/proposal.md
+++ b/openspec/changes/unix-engine-self-install/proposal.md
@@ -1,0 +1,65 @@
+# Proposal: Unix engine self-install + multi-platform release artifacts
+
+## Problem
+
+Endstate's engine already provisions Linux and macOS (the Nix realizer and the macOS Homebrew lane),
+but the distribution and self-install story is still Windows-only:
+
+1. **Releases publish only `endstate.exe`.** The `Release` workflow builds a single Windows binary,
+   so a Linux or macOS user has no published artifact to download — they must build from source.
+2. **`endstate bootstrap` is Windows-only.** The self-install command installs to
+   `%LOCALAPPDATA%\Endstate\bin`, writes a `.cmd` shim, and edits the user PATH via `setx`. On
+   Linux/macOS the same command would attempt a Windows-only layout and PATH mutation, so the
+   "install the running binary onto my PATH" keystone does not exist off Windows.
+
+For the platforms the engine already supports, both gaps make a clean install harder than it should
+be. This change closes them.
+
+## What Changes
+
+- **Split `endstate bootstrap` by platform.** `go-engine/internal/commands/bootstrap.go` becomes a
+  shared file (flags, the `BootstrapData` payload, the `copyFile` helper). The current Windows
+  behavior moves byte-for-byte into `bootstrap_windows.go` (`//go:build windows`). A new
+  `bootstrap_unix.go` (`//go:build !windows`) implements Linux/macOS:
+  - install dir `${XDG_DATA_HOME:-$HOME/.local/share}/endstate/bin`, binary copied to
+    `<installDir>/lib/endstate` and chmod'd `0755` (the copy is created non-executable by default);
+  - a symlink `$HOME/.local/bin/endstate` → `<installDir>/lib/endstate`, re-pointed idempotently
+    (an existing symlink/file at the target is removed first, never nested or errored on);
+  - **no PATH or shell-rc mutation, ever** — `addedToPath` is always `false`; when
+    `$HOME/.local/bin` is not on PATH the human-readable output adds a one-line hint (the JSON
+    payload shape is unchanged);
+  - a self-copy guard: when the running binary already resolves to the install target (a
+    re-bootstrap of the installed copy through its own symlink), the copy is skipped rather than
+    truncating the running binary.
+- **Publish per-platform Unix release artifacts.** The `Release` workflow gains a
+  `publish-unix-artifacts` job on `ubuntu-latest` that cross-compiles with `CGO_ENABLED=0` for
+  `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, producing
+  `endstate-{linux,darwin}-{amd64,arm64}` plus a sibling `.sha256` (lowercase hex), uploaded to the
+  same release with the same version-embedding ldflags as the Windows job. The Windows
+  `publish-artifacts` job is unchanged.
+- **Document distribution** in `docs/COMPATIBILITY.md` (one paragraph): Windows `endstate.exe` plus
+  per-platform Unix binaries on GitHub Releases, and `endstate bootstrap` self-install on all three
+  platforms.
+
+The CI workflow change carries no behavior spec of its own (it is infrastructure), but it is part of
+the same capability story: a Unix user can now both **download** a published binary and **self-install**
+it with `endstate bootstrap`.
+
+## Capabilities
+
+### Modified Capabilities
+- `bootstrap-full-sync`: the bootstrap behavior, previously Windows-only, is now platform-aware. The
+  Windows requirements are restated with explicit Windows scope; new requirements cover the Unix
+  install layout, the symlink, the no-PATH-mutation rule, idempotent re-pointing, and the self-copy
+  guard.
+
+## Impact
+
+- Modified: `go-engine/internal/commands/bootstrap.go` (now shared helpers/types only).
+- Added: `go-engine/internal/commands/bootstrap_windows.go`, `bootstrap_unix.go`,
+  `bootstrap_unix_test.go`, `bootstrap_windows_test.go`.
+- Modified: `.github/workflows/release.yml` (new `publish-unix-artifacts` job; Windows job
+  unchanged). Protected area — maintainer-authorized for this change.
+- Modified: `docs/COMPATIBILITY.md` (distribution paragraph).
+- Backward compatible: the Windows bootstrap behavior and the existing `installPath`/`shimPath`/
+  `addedToPath` payload shape are preserved on every platform.

--- a/openspec/changes/unix-engine-self-install/specs/bootstrap-full-sync/spec.md
+++ b/openspec/changes/unix-engine-self-install/specs/bootstrap-full-sync/spec.md
@@ -1,0 +1,104 @@
+## MODIFIED Requirements
+
+### Requirement: Bootstrap installs Go binary and .cmd shim
+
+On Windows, `endstate bootstrap` SHALL copy the running Go binary to
+`%LOCALAPPDATA%\Endstate\bin\lib\endstate.exe` and write a `.cmd` shim at
+`%LOCALAPPDATA%\Endstate\bin\endstate.cmd` that delegates to it.
+
+#### Scenario: Binary and shim are present after bootstrap
+
+- **WHEN** `endstate bootstrap` is executed on Windows
+- **THEN** `%LOCALAPPDATA%\Endstate\bin\lib\endstate.exe` SHALL exist
+- **AND** `%LOCALAPPDATA%\Endstate\bin\endstate.cmd` SHALL exist and contain a shim that invokes `lib\endstate.exe`
+
+#### Scenario: Install directory added to user PATH
+
+- **WHEN** `endstate bootstrap` is executed on Windows
+- **AND** `%LOCALAPPDATA%\Endstate\bin\` is not already in the user PATH
+- **THEN** the directory SHALL be added to the user PATH via the registry (HKCU\Environment\Path)
+
+### Requirement: Bootstrap always force-overwrites the binary
+
+Bootstrap SHALL unconditionally overwrite the installed binary on every platform. It MUST NOT skip the
+copy based on existence or timestamp. The single exception is the self-install case on Unix described
+in "Bootstrap never truncates the running binary on Unix": when the running binary already resolves to
+the install target, the copy is skipped to avoid truncating the binary currently executing.
+
+#### Scenario: Re-bootstrap overwrites stale binary
+
+- **WHEN** the installed binary has been modified since last bootstrap
+- **AND** `endstate bootstrap` is executed from a different binary than the installed copy
+- **THEN** the modified binary SHALL be replaced with the currently running binary
+
+### Requirement: Bootstrap reports install results
+
+After completing the install, bootstrap SHALL report the install path, shim path, and whether PATH was
+modified. The JSON payload shape is identical on every platform: `installPath`, `shimPath`, and
+`addedToPath`. On Windows `shimPath` is the `.cmd` shim; on Unix `shimPath` is the symlink and
+`addedToPath` is always `false`.
+
+#### Scenario: Successful bootstrap shows install summary
+
+- **WHEN** `endstate bootstrap` completes successfully
+- **THEN** the JSON envelope `data` SHALL include `installPath`, `shimPath`, and `addedToPath` fields
+
+#### Scenario: Copy failure is reported
+
+- **WHEN** the binary copy fails during bootstrap (e.g., permission denied)
+- **THEN** bootstrap SHALL report the failure with an error message in the JSON envelope
+
+## ADDED Requirements
+
+### Requirement: Bootstrap installs Go binary and symlink on Unix
+
+On Linux and macOS, `endstate bootstrap` SHALL copy the running Go binary to
+`${XDG_DATA_HOME:-$HOME/.local/share}/endstate/bin/lib/endstate`, mark it executable (mode `0755`), and
+create a symlink at `$HOME/.local/bin/endstate` that points to the installed binary. The reported
+`installPath` SHALL be `${XDG_DATA_HOME:-$HOME/.local/share}/endstate/bin` and the reported `shimPath`
+SHALL be the symlink path.
+
+#### Scenario: Binary and symlink are present after bootstrap
+
+- **WHEN** `endstate bootstrap` is executed on Linux or macOS
+- **THEN** `${XDG_DATA_HOME:-$HOME/.local/share}/endstate/bin/lib/endstate` SHALL exist with executable mode `0755`
+- **AND** `$HOME/.local/bin/endstate` SHALL be a symlink pointing to that installed binary
+
+#### Scenario: Re-bootstrap re-points the symlink idempotently
+
+- **WHEN** `endstate bootstrap` is executed on Unix and a file or symlink already exists at `$HOME/.local/bin/endstate`
+- **THEN** the existing entry SHALL be removed and re-created as a symlink to the installed binary
+- **AND** the command SHALL NOT nest the link or fail because the target already exists
+
+### Requirement: Bootstrap never edits PATH or shell configuration on Unix
+
+On Linux and macOS, bootstrap MUST NOT modify the user PATH, any shell rc file, or any other shell
+configuration. The reported `addedToPath` SHALL always be `false` on Unix. When `$HOME/.local/bin` is
+not already present on PATH, bootstrap SHALL include a one-line hint in the human-readable output
+without changing the JSON payload shape.
+
+#### Scenario: addedToPath is always false on Unix
+
+- **WHEN** `endstate bootstrap` completes successfully on Linux or macOS
+- **THEN** the JSON envelope `data.addedToPath` SHALL be `false`
+- **AND** no shell rc file SHALL have been modified
+
+#### Scenario: PATH hint shown when symlink dir is off PATH
+
+- **WHEN** `endstate bootstrap` runs on Unix and `$HOME/.local/bin` is not on PATH
+- **THEN** the human-readable output SHALL include a one-line hint to add it to PATH
+- **AND** the JSON payload fields SHALL be unchanged
+
+### Requirement: Bootstrap never truncates the running binary on Unix
+
+Bootstrap on Linux and macOS SHALL skip the binary copy when the currently running binary already
+resolves to the install target (a re-bootstrap of the installed copy invoked through its own symlink),
+rather than truncating the binary it is executing. The installed binary SHALL remain intact and the
+symlink SHALL still point to it.
+
+#### Scenario: Self-bootstrap preserves the installed binary
+
+- **WHEN** the installed `$HOME/.local/bin/endstate` symlink is invoked as `endstate bootstrap`
+- **AND** the running binary resolves to `${XDG_DATA_HOME:-$HOME/.local/share}/endstate/bin/lib/endstate`
+- **THEN** bootstrap SHALL skip copying the binary onto itself
+- **AND** the installed binary SHALL remain a complete, executable file

--- a/openspec/changes/unix-engine-self-install/tasks.md
+++ b/openspec/changes/unix-engine-self-install/tasks.md
@@ -1,0 +1,42 @@
+# Tasks — unix-engine-self-install
+
+> Verification: `cd go-engine && go test ./...` + `go vet ./...` +
+> `GOOS=windows go build ./...` + `GOOS=darwin go build ./...` +
+> `openspec validate --all --strict --no-interactive`.
+
+## Bootstrap platform split
+
+- [x] 1.1 Move shared flags/`BootstrapData`/`copyFile` into `bootstrap.go`; document the
+      platform-dependent `ShimPath`/`AddedToPath` semantics in the type doc.
+- [x] 1.2 `bootstrap_windows.go` (`//go:build windows`): carry the current behavior byte-identically
+      (install to `%LOCALAPPDATA%\Endstate\bin`, `.cmd` shim, `setx` PATH, payload fields).
+- [x] 1.3 `bootstrap_unix.go` (`//go:build !windows`): install to
+      `${XDG_DATA_HOME:-$HOME/.local/share}/endstate/bin`, copy binary to `lib/endstate`, chmod 0755.
+- [x] 1.4 Create/re-point `$HOME/.local/bin/endstate` symlink idempotently (remove existing target
+      first; never nest or fail on exists).
+- [x] 1.5 No PATH/shell-rc mutation on Unix; `addedToPath` always false; print a one-line PATH hint
+      to stderr when `$HOME/.local/bin` is not on PATH (JSON payload shape unchanged).
+- [x] 1.6 Self-copy guard: when the resolved running binary == the install target, skip the copy.
+
+## Tests
+
+- [x] 2.1 `bootstrap_unix_test.go` (`//go:build !windows`): redirect HOME/XDG_DATA_HOME to t.TempDir;
+      assert binary 0755, symlink target, idempotent re-run, payload fields, stale-file re-point.
+- [x] 2.2 `bootstrap_windows_test.go` (`//go:build windows`): redirect LOCALAPPDATA; assert binary +
+      shim present, payload fields, idempotent re-run (hermetic — no real `setx`).
+- [x] 2.3 Real Linux smoke: build, `HOME=<tmp> XDG_DATA_HOME=<tmp>/share endstate bootstrap`, assert
+      layout + symlink + idempotency + installed binary executes + self-copy preserves the binary.
+
+## Release artifacts
+
+- [x] 3.1 `.github/workflows/release.yml`: add `publish-unix-artifacts` (ubuntu-latest) matrix over
+      `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`; `CGO_ENABLED=0`; same ldflags.
+- [x] 3.2 Emit `endstate-<os>-<arch>` + sibling `.sha256` (lowercase hex); upload to the same
+      release; verify the new assets are present. Windows job left byte-identical.
+
+## Docs + spec
+
+- [x] 4.1 `docs/COMPATIBILITY.md`: distribution paragraph (Windows exe + Unix per-platform binaries;
+      bootstrap self-install on all three).
+- [x] 4.2 OpenSpec delta against `bootstrap-full-sync` (MODIFIED Windows requirements + ADDED Unix
+      requirements); `openspec validate --strict` passes.


### PR DESCRIPTION
## Summary

Closes the **distribution gap** surfaced after the platform arc: the engine runs on Linux/macOS, but releases shipped only `endstate.exe` and `endstate bootstrap` was Windows-only.

### `endstate bootstrap` on Linux/macOS
- Platform split: `bootstrap_windows.go` (existing behavior, byte-identical) / `bootstrap_unix.go`
- Unix layout: `${XDG_DATA_HOME:-~/.local/share}/endstate/bin/lib/endstate` (chmod 0755) + symlink `~/.local/bin/endstate`
- **No PATH/shell-rc mutation ever** — `addedToPath: false`, one-line stderr hint when `~/.local/bin` isn't on PATH (precedent: `capture.go` winget-retry warning)
- Self-copy guard (re-bootstrap of the installed copy never clobbers the running binary); idempotent symlink re-point
- JSON payload shape unchanged (`installPath`/`shimPath`/`addedToPath`; `shimPath` = symlink on Unix)

### Release artifacts (protected area — maintainer-authorized)
- New `publish-unix-artifacts` job (ubuntu-latest matrix): `endstate-{linux,darwin}-{amd64,arm64}` + `.sha256`, CGO_ENABLED=0, same ldflags version-embedding and trigger model as the windows job; per-artifact asset verification. Windows job untouched.

### OpenSpec + docs
- Change `unix-engine-self-install`: delta against `bootstrap-full-sync` (Unix layout/symlink/no-PATH-mutation requirements; Windows behavior preserved)
- `docs/COMPATIBILITY.md`: distribution note

## Verification
- `go test ./...` green (hermetic, build-tagged per platform), `go vet`, `GOOS=windows` + `GOOS=darwin` builds green
- `openspec validate --all --strict` 72/72
- **Real WSL smoke**: sandboxed `bootstrap` → XDG layout + 0755 binary + symlink verified, re-run idempotent, installed binary executes via symlink (`capabilities` OK)
- Independent code review: no blockers
- Note: the release workflow itself is exercised on the next tagged release (workflow_dispatch with a tag can dry-run it earlier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)